### PR TITLE
fix(solar-theme): remove border styled of input on readonly state

### DIFF
--- a/packages/solar-theme/src/shared-styles/input.less
+++ b/packages/solar-theme/src/shared-styles/input.less
@@ -52,7 +52,7 @@
   &[readonly] {
     .border(@input-readonly-border-color);
   }
-  &:not([focused]):not(:focus):hover {
+  &:not([focused]):not(:focus):not([disabled]):not([readonly]):hover {
     .border(@input-hover-border-color);
   }
 }


### PR DESCRIPTION
closes: https://jira.refinitiv.com/browse/ELF-609

Expected Result:
Read Only field has no hover. But can be focused.