### PR TITLE
feat: remove default aria disabled and aria readonly set by ControlElement

### DIFF
--- a/packages/core/__test__/elements/ControlElement.test.js
+++ b/packages/core/__test__/elements/ControlElement.test.js
@@ -77,9 +77,6 @@ describe('TestControlElement', () => {
         expect(el.getAttribute('disabled')).to.equal(null, 'attribute "disabled" should equal null by default');
         expect(el.hasAttribute('disabled')).to.equal(false, 'attribute "disabled" should not be exists by default');
 
-        expect(el.hasAttribute('aria-disabled')).to.equal(true, 'attribute "aria-disabled" should be present');
-        expect(el.getAttribute('aria-disabled')).to.equal('false', 'by default "aria-disabled" should be false');
-
         el.setAttribute('disabled', '');
         await elementUpdated(el);
 
@@ -88,9 +85,6 @@ describe('TestControlElement', () => {
         expect(el.getAttribute('disabled')).to.equal('', 'attribute "disabled" should equal ""');
 
         expect(el.style.pointerEvents).to.equal('none', 'pointer events should be set to "none"');
-
-        expect(el.hasAttribute('aria-disabled')).to.equal(true, 'attribute "aria-disabled" should be present');
-        expect(el.getAttribute('aria-disabled')).to.equal('true', '"aria-disabled" should be true');
 
         expect(el.tabIndex).to.equal(-1, 'property tabIndex should be changed to -1 if element disabled');
         expect(el.getAttribute('tabindex')).to.equal('-1', 'attribute "tabindex" should be changed to "-1" if element disabled');
@@ -101,9 +95,6 @@ describe('TestControlElement', () => {
         expect(el.disabled).to.equal(false, 'property "disabled" need to be set false');
         expect(el.getAttribute('disabled')).to.equal(null, 'property "disabled" should reflected');
         expect(el.hasAttribute('disabled')).to.equal(false, 'property "disabled" should reflected');
-
-        expect(el.hasAttribute('aria-disabled')).to.equal(true, 'attribute "aria-disabled" should be present');
-        expect(el.getAttribute('aria-disabled')).to.equal('false', '"aria-disabled" should be false');
 
         expect(el.tabIndex).to.equal(0, 'property tabIndex should be changed to 0 (default property value) if element enabled');
         expect(el.getAttribute('tabindex')).to.equal('0', 'attribute "tabindex" should be changed to "0" (default attribute value) if element disabled');
@@ -118,9 +109,6 @@ describe('TestControlElement', () => {
 
         expect(el.style.pointerEvents).to.equal('none', 'pointer events should be set to "none"');
 
-        expect(el.hasAttribute('aria-disabled')).to.equal(true, 'attribute "aria-disabled" should be present');
-        expect(el.getAttribute('aria-disabled')).to.equal('true', '"aria-disabled" should be true');
-
         expect(el.tabIndex).to.equal(-1, 'property tabIndex should be changed to -1 if element disabled');
         expect(el.getAttribute('tabindex')).to.equal('-1', 'attribute "tabindex" should be changed to "-1" if element disabled');
       });
@@ -134,9 +122,6 @@ describe('TestControlElement', () => {
         expect(el.getAttribute('readonly')).to.equal(null, 'attribute "readonly" should equal null by default');
         expect(el.hasAttribute('readonly')).to.equal(false, 'attribute "readonly" should not be exists by default');
 
-        expect(el.hasAttribute('aria-readonly')).to.equal(true, 'attribute "aria-readonly" should be present');
-        expect(el.getAttribute('aria-readonly')).to.equal('false', '"aria-readonly" should be false');
-
         el.setAttribute('readonly', '');
         await elementUpdated(el);
 
@@ -144,20 +129,12 @@ describe('TestControlElement', () => {
         expect(el.hasAttribute('readonly')).to.equal(true, 'attribute "readonly" should be exists');
         expect(el.getAttribute('readonly')).to.equal('', 'attribute "readonly" should equal ""');
 
-        expect(el.hasAttribute('aria-readonly')).to.equal(true, 'attribute "aria-readonly" should be present');
-        expect(el.getAttribute('aria-readonly')).to.equal('true', '"aria-readonly" should be true');
-
         el.readonly = false;
         await elementUpdated(el);
 
         expect(el.readonly).to.equal(false, 'property "readonly" need to be set false');
         expect(el.getAttribute('readonly')).to.equal(null, 'property "readonly" should reflected');
         expect(el.hasAttribute('readonly')).to.equal(false, 'property "readonly" should reflected');
-
-        expect(el.hasAttribute('aria-readonly')).to.equal(true, 'attribute "aria-readonly" should be present');
-        expect(el.getAttribute('aria-readonly')).to.equal('false', '"aria-readonly" should be false');
-
-        expect(el.getAttribute('aria-readonly')).to.equal('false', 'attribute "aria-readonly" should equal "false" by default');
       });
 
       it('Should have correct property and attribute "readonly"', async () => {
@@ -166,10 +143,6 @@ describe('TestControlElement', () => {
         expect(el.readonly).to.equal(true, 'property "readonly" should be setted');
         expect(el.getAttribute('readonly')).to.equal('', 'attribute "readonly" should equal empty string');
         expect(el.hasAttribute('readonly')).to.equal(true, 'attribute "readonly" should be present');
-
-
-        expect(el.hasAttribute('aria-readonly')).to.equal(true, 'attribute "aria-readonly" should be present');
-        expect(el.getAttribute('aria-readonly')).to.equal('true', '"aria-readonly" should be true');
       });
     });
 
@@ -676,7 +649,6 @@ describe('TestControlElement', () => {
         expect(el.hasAttribute('focused')).to.equal(false, 'element attribute focused should be set to false when disabled');
         expect(el.style.pointerEvents).to.equal('none', 'pointer events should be set to none when disabled');
         expect(el.tabIndex).to.equal(-1, 'tabIndex should be set to -1');
-        expect(el.getAttribute('aria-disabled')).to.equal('true', 'attribute aria-disabled should be set to "true" for disabled element');
       });
 
       it('Test element delegate focus', async function () {

--- a/packages/core/src/elements/ControlElement.ts
+++ b/packages/core/src/elements/ControlElement.ts
@@ -86,10 +86,6 @@ export abstract class ControlElement extends BasicElement implements IControlPro
       this.disableChanged(changedProperties);
     }
 
-    if (changedProperties.has('readonly')) {
-      this.readonlyChanged(this.readonly);
-    }
-
     super.update(changedProperties);
   }
 
@@ -99,23 +95,12 @@ export abstract class ControlElement extends BasicElement implements IControlPro
    * @returns {void}
    */
   protected disableChanged (changedProperties: PropertyValues): void {
-    this.setAttribute('aria-disabled', this.disabled ? 'true' : 'false');
-
     if (this.disabled) {
       this.disableFocus();
     }
     else if (changedProperties.get('disabled') === true) { /* re-enable only if disabled changed from true to false */
       this.enableFocus();
     }
-  }
-
-  /**
-   * Update readonly state if detect value changed
-   * @param readonly new value change
-   * @returns {void}
-   */
-  protected readonlyChanged (readonly: boolean): void {
-    this.setAttribute('aria-readonly', readonly ? 'true' : 'false');
   }
 
   /**

--- a/packages/elements/src/autosuggest/__snapshots__/Autosuggest.md
+++ b/packages/elements/src/autosuggest/__snapshots__/Autosuggest.md
@@ -17,8 +17,6 @@
   <slot id="contentSlot">
   </slot>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     id="moreResults"
     part="more-results"
     tabindex="0"

--- a/packages/elements/src/calendar/__snapshots__/Defaults.md
+++ b/packages/elements/src/calendar/__snapshots__/Defaults.md
@@ -7,8 +7,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -17,8 +15,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -27,8 +23,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -450,8 +444,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -460,8 +452,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -470,8 +460,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -831,8 +819,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -841,8 +827,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -851,8 +835,6 @@
     2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1015,8 +997,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1025,8 +1005,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -1035,8 +1013,6 @@
     2000 - 2015
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1197,8 +1173,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1207,8 +1181,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -1217,8 +1189,6 @@
     February 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1570,8 +1540,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1580,8 +1548,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -1590,8 +1556,6 @@
     2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1754,8 +1718,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1764,8 +1726,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -1774,8 +1734,6 @@
     2000 - 2015
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1936,8 +1894,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1946,8 +1902,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -1956,8 +1910,6 @@
     December 2004
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -2321,8 +2273,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -2331,8 +2281,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -2341,8 +2289,6 @@
     2004
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -2505,8 +2451,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -2515,8 +2459,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -2525,8 +2467,6 @@
     2000 - 2015
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -2689,8 +2629,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -2699,8 +2637,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -2709,8 +2645,6 @@
     апрель 2005 г.
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -3070,8 +3004,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -3080,8 +3012,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -3090,8 +3020,6 @@
     เมษายน ค.ศ. 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -3455,8 +3383,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -3465,8 +3391,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -3475,8 +3399,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -3840,8 +3762,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -3850,8 +3770,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -3860,8 +3778,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -4225,8 +4141,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -4235,8 +4149,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -4245,8 +4157,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -4610,8 +4520,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -4620,8 +4528,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -4630,8 +4536,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -4995,8 +4899,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -5005,8 +4907,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -5015,8 +4915,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -5380,8 +5278,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -5390,8 +5286,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -5400,8 +5294,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -5763,8 +5655,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -5773,8 +5663,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -5783,8 +5671,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"

--- a/packages/elements/src/calendar/__snapshots__/Multiple.md
+++ b/packages/elements/src/calendar/__snapshots__/Multiple.md
@@ -7,8 +7,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -17,8 +15,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -27,8 +23,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -390,8 +384,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -400,8 +392,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -410,8 +400,6 @@
     2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -575,8 +563,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -585,8 +571,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -595,8 +579,6 @@
     2000 - 2015
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -759,8 +741,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -769,8 +749,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -779,8 +757,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"

--- a/packages/elements/src/calendar/__snapshots__/Navigation.md
+++ b/packages/elements/src/calendar/__snapshots__/Navigation.md
@@ -7,8 +7,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -17,8 +15,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -27,8 +23,6 @@
     February 2020
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -384,8 +378,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -394,8 +386,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -404,8 +394,6 @@
     January 2020
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -769,8 +757,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -779,8 +765,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -789,8 +773,6 @@
     December 2019
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1156,8 +1138,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1166,8 +1146,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -1176,8 +1154,6 @@
     November 2019
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1537,8 +1513,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1547,8 +1521,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -1557,8 +1529,6 @@
     December 2019
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1922,8 +1892,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1932,8 +1900,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -1942,8 +1908,6 @@
     January 2020
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -2311,8 +2275,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -2321,8 +2283,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -2331,8 +2291,6 @@
     February 1
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -2684,8 +2642,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -2694,8 +2650,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -2704,8 +2658,6 @@
     January 1
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -3069,8 +3021,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -3079,8 +3029,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -3089,8 +3037,6 @@
     December 1 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -3456,8 +3402,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -3466,8 +3410,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -3476,8 +3418,6 @@
     November 2 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -3837,8 +3777,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -3847,8 +3785,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -3857,8 +3793,6 @@
     December 2 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -4222,8 +4156,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -4232,8 +4164,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -4242,8 +4172,6 @@
     January 1 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -4611,8 +4539,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -4621,8 +4547,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -4631,8 +4555,6 @@
     2019
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -4795,8 +4717,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -4805,8 +4725,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -4815,8 +4733,6 @@
     2018
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -4979,8 +4895,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -4989,8 +4903,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -4999,8 +4911,6 @@
     2017
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -5165,8 +5075,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -5175,8 +5083,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -5185,8 +5091,6 @@
     2017
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -5349,8 +5253,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -5359,8 +5261,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -5369,8 +5269,6 @@
     2018
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -5533,8 +5431,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -5543,8 +5439,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -5553,8 +5447,6 @@
     2019
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -5721,8 +5613,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -5731,8 +5621,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -5741,8 +5629,6 @@
     1
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -5905,8 +5791,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -5915,8 +5799,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -5925,8 +5807,6 @@
     1 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -6089,8 +5969,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -6099,8 +5977,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -6109,8 +5985,6 @@
     2 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -6275,8 +6149,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -6285,8 +6157,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -6295,8 +6165,6 @@
     2 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -6459,8 +6327,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -6469,8 +6335,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -6479,8 +6343,6 @@
     1 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -6643,8 +6505,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -6653,8 +6513,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -6663,8 +6521,6 @@
     1
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -6831,8 +6687,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -6841,8 +6695,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -6851,8 +6703,6 @@
     1968 - 1983
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -7011,8 +6861,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -7021,8 +6869,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -7031,8 +6877,6 @@
     1952 - 1967
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -7191,8 +7035,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -7201,8 +7043,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -7211,8 +7051,6 @@
     1936 - 1951
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -7373,8 +7211,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -7383,8 +7219,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -7393,8 +7227,6 @@
     1888 - 1903
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -7553,8 +7385,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -7563,8 +7393,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -7573,8 +7401,6 @@
     1904 - 1919
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -7733,8 +7559,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -7743,8 +7567,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -7753,8 +7575,6 @@
     1920 - 1935
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -7917,8 +7737,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -7927,8 +7745,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -7937,8 +7753,6 @@
     16 - 31
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -8097,8 +7911,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -8107,8 +7919,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -8117,8 +7927,6 @@
     1 BC - 15
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -8277,8 +8085,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -8287,8 +8093,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -8297,8 +8101,6 @@
     17 BC - 2 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -8459,8 +8261,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -8469,8 +8269,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -8479,8 +8277,6 @@
     17 BC - 2 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -8639,8 +8435,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -8649,8 +8443,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -8659,8 +8451,6 @@
     1 BC - 15
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -8819,8 +8609,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -8829,8 +8617,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -8839,8 +8625,6 @@
     16 - 31
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -9003,8 +8787,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -9013,8 +8795,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -9023,8 +8803,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -9384,8 +9162,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -9394,8 +9170,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -9404,8 +9178,6 @@
     2000 - 2015
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -9564,8 +9336,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -9574,8 +9344,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -9584,8 +9352,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -9945,8 +9711,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -9955,8 +9719,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -9965,8 +9727,6 @@
     2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -10129,8 +9889,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -10139,8 +9897,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -10149,8 +9905,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -10514,8 +10268,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -10524,8 +10276,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -10534,8 +10284,6 @@
     2000 - 2015
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -10694,8 +10442,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -10704,8 +10450,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -10714,8 +10458,6 @@
     2001
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -10878,8 +10620,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -10888,8 +10628,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -10898,8 +10636,6 @@
     2001
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -11064,8 +10800,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -11074,8 +10808,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -11084,8 +10816,6 @@
     2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -11250,8 +10980,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -11260,8 +10988,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -11270,8 +10996,6 @@
     2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -11438,8 +11162,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -11448,8 +11170,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -11458,8 +11178,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -11821,8 +11539,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -11831,8 +11547,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -11841,8 +11555,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -12206,8 +11918,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -12216,8 +11926,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -12226,8 +11934,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -12587,8 +12293,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -12597,8 +12301,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -12607,8 +12309,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"

--- a/packages/elements/src/calendar/__snapshots__/Range.md
+++ b/packages/elements/src/calendar/__snapshots__/Range.md
@@ -7,8 +7,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -17,8 +15,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -27,8 +23,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -391,8 +385,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -401,8 +393,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -411,8 +401,6 @@
     2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -578,8 +566,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -588,8 +574,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -598,8 +582,6 @@
     2000 - 2015
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -763,8 +745,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -773,8 +753,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -783,8 +761,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1174,8 +1150,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1184,8 +1158,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -1194,8 +1166,6 @@
     2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1371,8 +1341,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1381,8 +1349,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -1391,8 +1357,6 @@
     2000 - 2015
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1560,8 +1524,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1570,8 +1532,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -1580,8 +1540,6 @@
     April 12 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1961,8 +1919,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1971,8 +1927,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -1981,8 +1935,6 @@
     12 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -2148,8 +2100,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -2158,8 +2108,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -2168,8 +2116,6 @@
     17 BC - 2 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -2335,8 +2281,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -2345,8 +2289,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -2355,8 +2297,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -2717,8 +2657,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -2727,8 +2665,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -2737,8 +2673,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -3105,8 +3039,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -3115,8 +3047,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -3125,8 +3055,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -3487,8 +3415,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -3497,8 +3423,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -3507,8 +3431,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -3869,8 +3791,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -3879,8 +3799,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -3889,8 +3807,6 @@
     May 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"

--- a/packages/elements/src/calendar/__snapshots__/Value.md
+++ b/packages/elements/src/calendar/__snapshots__/Value.md
@@ -7,8 +7,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -17,8 +15,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -27,8 +23,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -389,8 +383,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -399,8 +391,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -409,8 +399,6 @@
     2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -574,8 +562,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -584,8 +570,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -594,8 +578,6 @@
     2000 - 2015
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -757,8 +739,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -767,8 +747,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -777,8 +755,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1141,8 +1117,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1151,8 +1125,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -1161,8 +1133,6 @@
     April 12 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1523,8 +1493,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1533,8 +1501,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -1543,8 +1509,6 @@
     12 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1708,8 +1672,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1718,8 +1680,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="up"
     part="btn-view"
     tabindex="0"
@@ -1728,8 +1688,6 @@
     17 BC - 2 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -1893,8 +1851,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -1903,8 +1859,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -1913,8 +1867,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -2275,8 +2227,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -2285,8 +2235,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -2295,8 +2243,6 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -2659,8 +2605,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -2669,8 +2613,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -2679,8 +2621,6 @@
     April 12 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"
@@ -3041,8 +2981,6 @@
 ```html
 <div part="navigation">
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="left"
     part="btn-prev"
@@ -3051,8 +2989,6 @@
   >
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     icon="down"
     part="btn-view"
     tabindex="0"
@@ -3061,8 +2997,6 @@
     April 12 BC
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="right"
     part="btn-next"

--- a/packages/elements/src/card/__snapshots__/Card.md
+++ b/packages/elements/src/card/__snapshots__/Card.md
@@ -86,8 +86,6 @@
     </slot>
   </div>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     empty=""
     icon="more-vertical"
     part="menu-button"

--- a/packages/elements/src/color-dialog/__snapshots__/ColorDialog.md
+++ b/packages/elements/src/color-dialog/__snapshots__/ColorDialog.md
@@ -41,8 +41,6 @@
       <div>
         R :
         <ef-number-field
-          aria-disabled="false"
-          aria-readonly="false"
           id="redInput"
           max="255"
           min="0"
@@ -54,8 +52,6 @@
       <div>
         G :
         <ef-number-field
-          aria-disabled="false"
-          aria-readonly="false"
           id="greenInput"
           max="255"
           min="0"
@@ -67,8 +63,6 @@
       <div>
         B :
         <ef-number-field
-          aria-disabled="false"
-          aria-readonly="false"
           id="blueInput"
           max="255"
           min="0"
@@ -80,8 +74,6 @@
       <div>
         # :
         <ef-text-field
-          aria-disabled="false"
-          aria-readonly="false"
           icon=""
           id="hexInput"
           maxlength="6"
@@ -95,8 +87,6 @@
 </ef-panel>
 <div part="footer">
   <ef-button
-    aria-disabled="true"
-    aria-readonly="false"
     cta=""
     disabled=""
     id="confirmButton"
@@ -107,8 +97,6 @@
     Apply
   </ef-button>
   <ef-button
-    aria-disabled="false"
-    aria-readonly="false"
     id="closeButton"
     part="button"
     textpos="after"

--- a/packages/elements/src/combo-box/__snapshots__/AsyncFilter.md
+++ b/packages/elements/src/combo-box/__snapshots__/AsyncFilter.md
@@ -7,8 +7,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -38,8 +36,6 @@
   with-shadow=""
 >
   <ef-item
-    aria-disabled="true"
-    aria-readonly="false"
     disabled=""
     tabindex="-1"
   >
@@ -52,8 +48,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -83,36 +77,20 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       tabindex="0"
     >
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
   </ef-list>
 </ef-overlay>

--- a/packages/elements/src/combo-box/__snapshots__/Filter.md
+++ b/packages/elements/src/combo-box/__snapshots__/Filter.md
@@ -7,8 +7,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -38,30 +36,18 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       tabindex="0"
     >
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
   </ef-list>
 </ef-overlay>
@@ -71,8 +57,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -102,21 +86,13 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       tabindex="0"
     >

--- a/packages/elements/src/combo-box/__snapshots__/Selected.md
+++ b/packages/elements/src/combo-box/__snapshots__/Selected.md
@@ -7,8 +7,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -38,37 +36,21 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       selected=""
       tabindex="0"
     >
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
   </ef-list>
 </ef-overlay>
@@ -78,8 +60,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -109,33 +89,17 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
+    </ef-item>
+    <ef-item tabindex="0">
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
-    </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       selected=""
       tabindex="0"
@@ -149,8 +113,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -180,36 +142,20 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       tabindex="0"
     >
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
   </ef-list>
 </ef-overlay>
@@ -221,8 +167,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -258,22 +202,14 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       multiple=""
       selected=""
@@ -281,15 +217,11 @@
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="0"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       selected=""
       tabindex="0"
@@ -303,8 +235,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -334,29 +264,19 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="0"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       multiple=""
       selected=""
@@ -364,8 +284,6 @@
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="0"
     >
@@ -378,8 +296,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -409,37 +325,25 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       multiple=""
       tabindex="0"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="0"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="0"
     >

--- a/packages/elements/src/combo-box/__snapshots__/Template.md
+++ b/packages/elements/src/combo-box/__snapshots__/Template.md
@@ -7,8 +7,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -34,8 +32,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -59,8 +55,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -84,8 +78,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -111,8 +103,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -142,36 +132,20 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       tabindex="0"
     >
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
   </ef-list>
 </ef-overlay>
@@ -181,8 +155,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -208,36 +180,20 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       tabindex="0"
     >
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
   </ef-list>
 </ef-overlay>
@@ -249,8 +205,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -280,36 +234,20 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       tabindex="0"
     >
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
   </ef-list>
 </ef-overlay>
@@ -319,8 +257,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -350,33 +286,17 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       tabindex="0"
     >
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
+    </ef-item>
+    <ef-item tabindex="0">
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
-    </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
@@ -389,8 +309,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -421,8 +339,6 @@
   with-shadow=""
 >
   <ef-item
-    aria-disabled="true"
-    aria-readonly="false"
     disabled=""
     tabindex="-1"
   >

--- a/packages/elements/src/combo-box/__snapshots__/Value.md
+++ b/packages/elements/src/combo-box/__snapshots__/Value.md
@@ -7,8 +7,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -38,37 +36,21 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       selected=""
       tabindex="0"
     >
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
   </ef-list>
 </ef-overlay>
@@ -78,8 +60,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -109,34 +89,20 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       tabindex="0"
     >
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       selected=""
       tabindex="0"
     >
@@ -149,8 +115,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -180,36 +144,20 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       tabindex="0"
     >
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
   </ef-list>
 </ef-overlay>
@@ -221,8 +169,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -252,37 +198,21 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       selected=""
       tabindex="0"
     >
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
-    <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
-      tabindex="0"
-    >
+    <ef-item tabindex="0">
     </ef-item>
   </ef-list>
 </ef-overlay>
@@ -294,8 +224,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -331,22 +259,14 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       multiple=""
       selected=""
@@ -354,15 +274,11 @@
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="0"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       selected=""
       tabindex="0"
@@ -376,8 +292,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -407,38 +321,26 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       multiple=""
       tabindex="0"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       selected=""
       tabindex="0"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="0"
     >
@@ -451,8 +353,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"
@@ -482,37 +382,25 @@
   tabindex="-1"
   with-shadow=""
 >
-  <ef-list
-    aria-disabled="false"
-    aria-readonly="false"
-    id="internal-list"
-  >
+  <ef-list id="internal-list">
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="-1"
       type="header"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       highlighted=""
       multiple=""
       tabindex="0"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="0"
     >
     </ef-item>
     <ef-item
-      aria-disabled="false"
-      aria-readonly="false"
       multiple=""
       tabindex="0"
     >

--- a/packages/elements/src/datetime-picker/__snapshots__/DOMStructure.md
+++ b/packages/elements/src/datetime-picker/__snapshots__/DOMStructure.md
@@ -7,8 +7,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     id="input"
     part="input"
@@ -30,8 +28,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     id="input"
     part="input"
@@ -68,8 +64,6 @@
     <div part="selectors-wrapper">
       <div part="calendar-wrapper">
         <ef-calendar
-          aria-disabled="false"
-          aria-readonly="false"
           id="calendar"
           part="calendar"
           tabindex="0"
@@ -95,8 +89,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     id="input"
     part="input"
@@ -107,8 +99,6 @@
   <div part="input-separator">
   </div>
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     id="input-to"
     part="input"
@@ -145,8 +135,6 @@
     <div part="selectors-wrapper">
       <div part="calendar-wrapper">
         <ef-calendar
-          aria-disabled="false"
-          aria-readonly="false"
           id="calendar"
           part="calendar"
           range=""
@@ -173,8 +161,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     id="input"
     part="input"
@@ -211,16 +197,12 @@
     <div part="selectors-wrapper">
       <div part="calendar-wrapper">
         <ef-calendar
-          aria-disabled="false"
-          aria-readonly="false"
           id="calendar"
           part="calendar"
           tabindex="0"
         >
         </ef-calendar>
         <ef-calendar
-          aria-disabled="false"
-          aria-readonly="false"
           id="calendar-to"
           part="calendar"
           tabindex="0"
@@ -246,8 +228,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     id="input"
     part="input"
@@ -284,8 +264,6 @@
     <div part="selectors-wrapper">
       <div part="calendar-wrapper">
         <ef-calendar
-          aria-disabled="false"
-          aria-readonly="false"
           id="calendar"
           part="calendar"
           tabindex="0"
@@ -294,8 +272,6 @@
       </div>
       <div part="timepicker-wrapper">
         <ef-time-picker
-          aria-disabled="false"
-          aria-readonly="false"
           id="timepicker"
           part="time-picker"
           tabindex="0"
@@ -321,8 +297,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     id="input"
     part="input"
@@ -359,8 +333,6 @@
     <div part="selectors-wrapper">
       <div part="calendar-wrapper">
         <ef-calendar
-          aria-disabled="false"
-          aria-readonly="false"
           id="calendar"
           part="calendar"
           tabindex="0"
@@ -369,8 +341,6 @@
       </div>
       <div part="timepicker-wrapper">
         <ef-time-picker
-          aria-disabled="false"
-          aria-readonly="false"
           id="timepicker"
           part="time-picker"
           tabindex="0"
@@ -396,8 +366,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     id="input"
     part="input"
@@ -408,8 +376,6 @@
   <div part="input-separator">
   </div>
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     id="input-to"
     part="input"
@@ -446,8 +412,6 @@
     <div part="selectors-wrapper">
       <div part="calendar-wrapper">
         <ef-calendar
-          aria-disabled="false"
-          aria-readonly="false"
           id="calendar"
           part="calendar"
           range=""
@@ -457,8 +421,6 @@
       </div>
       <div part="timepicker-wrapper">
         <ef-time-picker
-          aria-disabled="false"
-          aria-readonly="false"
           id="timepicker"
           part="time-picker"
           tabindex="0"
@@ -467,8 +429,6 @@
         <div part="input-separator">
         </div>
         <ef-time-picker
-          aria-disabled="false"
-          aria-readonly="false"
           id="timepicker-to"
           part="time-picker"
           tabindex="0"

--- a/packages/elements/src/dialog/__snapshots__/Dialog.md
+++ b/packages/elements/src/dialog/__snapshots__/Dialog.md
@@ -28,8 +28,6 @@
   <slot name="footer">
     <div part="default-buttons">
       <ef-button
-        aria-disabled="false"
-        aria-readonly="false"
         cta=""
         part="default-button"
         textpos="after"
@@ -37,8 +35,6 @@
         OK
       </ef-button>
       <ef-button
-        aria-disabled="false"
-        aria-readonly="false"
         part="default-button"
         textpos="after"
       >

--- a/packages/elements/src/item/__snapshots__/Item.md
+++ b/packages/elements/src/item/__snapshots__/Item.md
@@ -246,8 +246,6 @@
 ```html
 <div part="left">
   <ef-checkbox
-    aria-disabled="false"
-    aria-readonly="false"
     part="checkbox"
     tabindex="-1"
   >
@@ -272,8 +270,6 @@
 ```html
 <div part="left">
   <ef-checkbox
-    aria-disabled="false"
-    aria-readonly="false"
     checked=""
     part="checkbox"
     tabindex="-1"

--- a/packages/elements/src/list/__snapshots__/List.md
+++ b/packages/elements/src/list/__snapshots__/List.md
@@ -3,10 +3,7 @@
 #### `Label and DOM structure is correct`
 
 ```html
-<ef-list
-  aria-disabled="false"
-  aria-readonly="false"
->
+<ef-list>
 </ef-list>
 
 ```
@@ -20,10 +17,7 @@
 #### `Supports setting a data array`
 
 ```html
-<ef-list
-  aria-disabled="false"
-  aria-readonly="false"
->
+<ef-list>
 </ef-list>
 
 ```
@@ -37,10 +31,7 @@
 #### `Supports setting a data composer`
 
 ```html
-<ef-list
-  aria-disabled="false"
-  aria-readonly="false"
->
+<ef-list>
 </ef-list>
 
 ```
@@ -54,10 +45,7 @@
 #### `Supports setting null data`
 
 ```html
-<ef-list
-  aria-disabled="false"
-  aria-readonly="false"
->
+<ef-list>
 </ef-list>
 
 ```

--- a/packages/elements/src/multi-input/__snapshots__/MultiInput.md
+++ b/packages/elements/src/multi-input/__snapshots__/MultiInput.md
@@ -8,8 +8,6 @@
   part="list"
 >
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     part="search"
     tabindex="1"
     transparent=""

--- a/packages/elements/src/pagination/__snapshots__/Pagination.md
+++ b/packages/elements/src/pagination/__snapshots__/Pagination.md
@@ -18,8 +18,6 @@
   </div>
   <ef-button-bar part="buttons">
     <ef-button
-      aria-disabled="true"
-      aria-readonly="false"
       disabled=""
       empty=""
       icon="skip-to-start"
@@ -30,8 +28,6 @@
     >
     </ef-button>
     <ef-button
-      aria-disabled="true"
-      aria-readonly="false"
       disabled=""
       empty=""
       icon="left"
@@ -43,8 +39,6 @@
     </ef-button>
   </ef-button-bar>
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     id="input"
     no-spinner=""
@@ -54,8 +48,6 @@
   </ef-text-field>
   <ef-button-bar part="buttons">
     <ef-button
-      aria-disabled="true"
-      aria-readonly="false"
       disabled=""
       empty=""
       icon="right"
@@ -66,8 +58,6 @@
     >
     </ef-button>
     <ef-button
-      aria-disabled="true"
-      aria-readonly="false"
       disabled=""
       empty=""
       icon="skip-to-end"

--- a/packages/elements/src/select/__snapshots__/Selection.md
+++ b/packages/elements/src/select/__snapshots__/Selection.md
@@ -133,16 +133,12 @@
   with-shadow=""
 >
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="header"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     highlighted=""
     part="item"
     selected=""
@@ -150,23 +146,17 @@
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="divider"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
@@ -203,39 +193,29 @@
   with-shadow=""
 >
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="header"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     highlighted=""
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="divider"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     selected=""
     tabindex="0"
@@ -273,39 +253,29 @@
   with-shadow=""
 >
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="header"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     highlighted=""
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="divider"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     selected=""
     tabindex="0"

--- a/packages/elements/src/select/__snapshots__/Template.md
+++ b/packages/elements/src/select/__snapshots__/Template.md
@@ -225,38 +225,28 @@
   with-shadow=""
 >
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="header"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="divider"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
@@ -288,38 +278,28 @@
   with-shadow=""
 >
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="header"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="divider"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
@@ -357,38 +337,28 @@
   with-shadow=""
 >
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="header"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="divider"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
@@ -424,37 +394,27 @@
   with-shadow=""
 >
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="divider"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="header"
@@ -491,37 +451,27 @@
   with-shadow=""
 >
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="divider"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="header"

--- a/packages/elements/src/select/__snapshots__/Value.md
+++ b/packages/elements/src/select/__snapshots__/Value.md
@@ -166,16 +166,12 @@
   with-shadow=""
 >
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="header"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     highlighted=""
     part="item"
     selected=""
@@ -183,23 +179,17 @@
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="divider"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
@@ -236,39 +226,29 @@
   with-shadow=""
 >
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="header"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     highlighted=""
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="divider"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     selected=""
     tabindex="0"
@@ -306,39 +286,29 @@
   with-shadow=""
 >
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="header"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     highlighted=""
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="-1"
     type="divider"
   >
   </ef-item>
   <ef-item
-    aria-disabled="false"
-    aria-readonly="false"
     part="item"
     tabindex="0"
   >

--- a/packages/elements/src/tab-bar/__snapshots__/TabBar.md
+++ b/packages/elements/src/tab-bar/__snapshots__/TabBar.md
@@ -4,8 +4,6 @@
 
 ```html
 <ef-button
-  aria-disabled="false"
-  aria-readonly="false"
   empty=""
   icon="left"
   part="left-btn"
@@ -18,8 +16,6 @@
   </slot>
 </div>
 <ef-button
-  aria-disabled="false"
-  aria-readonly="false"
   empty=""
   icon="right"
   part="right-btn"

--- a/packages/elements/src/time-picker/__snapshots__/TimePicker.md
+++ b/packages/elements/src/time-picker/__snapshots__/TimePicker.md
@@ -6,8 +6,6 @@
 
 ```html
 <ef-number-field
-  aria-disabled="false"
-  aria-readonly="true"
   id="hours"
   max="23"
   min="0"
@@ -22,8 +20,6 @@
 <span part="divider">
 </span>
 <ef-number-field
-  aria-disabled="false"
-  aria-readonly="true"
   id="minutes"
   max="59"
   min="0"
@@ -38,8 +34,6 @@
 <span part="divider">
 </span>
 <ef-number-field
-  aria-disabled="false"
-  aria-readonly="true"
   id="seconds"
   max="59"
   min="0"
@@ -58,8 +52,6 @@
 
 ```html
 <ef-number-field
-  aria-disabled="true"
-  aria-readonly="false"
   disabled=""
   id="hours"
   max="23"
@@ -75,8 +67,6 @@
 <span part="divider">
 </span>
 <ef-number-field
-  aria-disabled="true"
-  aria-readonly="false"
   disabled=""
   id="minutes"
   max="59"
@@ -92,8 +82,6 @@
 <span part="divider">
 </span>
 <ef-number-field
-  aria-disabled="true"
-  aria-readonly="false"
   disabled=""
   id="seconds"
   max="59"
@@ -113,8 +101,6 @@
 
 ```html
 <ef-number-field
-  aria-disabled="false"
-  aria-readonly="false"
   id="hours"
   max="23"
   min="0"
@@ -128,8 +114,6 @@
 <span part="divider">
 </span>
 <ef-number-field
-  aria-disabled="false"
-  aria-readonly="false"
   id="minutes"
   max="59"
   min="0"
@@ -147,8 +131,6 @@
 
 ```html
 <ef-number-field
-  aria-disabled="false"
-  aria-readonly="false"
   id="hours"
   max="23"
   min="0"
@@ -162,8 +144,6 @@
 <span part="divider">
 </span>
 <ef-number-field
-  aria-disabled="false"
-  aria-readonly="false"
   id="minutes"
   max="59"
   min="0"
@@ -177,8 +157,6 @@
 <span part="divider">
 </span>
 <ef-number-field
-  aria-disabled="false"
-  aria-readonly="false"
   id="seconds"
   max="59"
   min="0"
@@ -196,8 +174,6 @@
 
 ```html
 <ef-number-field
-  aria-disabled="false"
-  aria-readonly="false"
   id="hours"
   max="12"
   min="1"
@@ -211,8 +187,6 @@
 <span part="divider">
 </span>
 <ef-number-field
-  aria-disabled="false"
-  aria-readonly="false"
   id="minutes"
   max="59"
   min="0"

--- a/packages/elements/src/tree-select/__snapshots__/TreeSelect.md
+++ b/packages/elements/src/tree-select/__snapshots__/TreeSelect.md
@@ -7,8 +7,6 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    aria-disabled="false"
-    aria-readonly="false"
     icon=""
     part="input"
     tabindex="0"

--- a/packages/elements/src/tree/__snapshots__/Tree.md
+++ b/packages/elements/src/tree/__snapshots__/Tree.md
@@ -5,10 +5,7 @@
 ####   `Label and DOM structure is correct`
 
 ```html
-<ef-tree
-  aria-disabled="false"
-  aria-readonly="false"
->
+<ef-tree>
 </ef-tree>
 
 ```


### PR DESCRIPTION
According to [w3](https://www.w3.org/TR/html-aria/#docconformance-attr)

- `aria-disabled` does not have any use when element is also `disabled`
- Screen reader should be able to know disabled state with just `disabled` attribute, the same applies to `readonly`.
- It could serve a different purpose from `disabled`. For example, https://a11y-101.com/development/aria-disabled which is up to users to decide.