### PR TITLE
docs(readme): point to ui.refinitiv.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Element Framework is Refinitiv design system components that provides components and tooling with Refinitiv's design system to help product teams work faster and more efficiently.
 
 # Documentation
-Getting started and usage guide are available from this [documentation](https://cdn.ppe.refinitiv.com/public/apps/elf-docs/book/en/index.html).
+Getting started and usage guide are available from this [documentation](https://ui.refinitiv.com).
 
 # Packages
 | Package                       | Version                                                                                                                               | Change Log                                                                                                                                                                 |


### PR DESCRIPTION
## Description
Updates readme to point to ui.refinitiv.com instead of PPE CDN

## Type of change
Please delete options that are not relevant.

- [x] This change requires a documentation update