### PR TITLE
chore(elements): update homepage on npm

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -7,6 +7,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "homepage": "https://ui.refinitiv.com",
   "repository": {
     "type": "git",
     "url": "git@github.com:Refinitiv/refinitiv-ui.git",


### PR DESCRIPTION
## Description
Changes homepage on npm to point to documentation site instead of GitHub readme

## Type of change
Please delete options that are not relevant.

- [x] This change requires a documentation update