### PR TITLE
refactor: remove await from a11y test assertion

### DIFF
--- a/packages/elements/src/button/__test__/button.test.js
+++ b/packages/elements/src/button/__test__/button.test.js
@@ -200,19 +200,19 @@ describe('button/Button', () => {
     it('should not be accessible without label', async () => {
 
       const el = await fixture(`<ef-button></ef-button>`);
-      await expect(el).not.to.be.accessible();
+      expect(el).not.to.be.accessible();
     });
 
     it('should pass a11y testing with aria-label', async () => {
       const el = await fixture(`<ef-button aria-label="Tick Icon" icon="tick"></ef-button>`);
-      await expect(el).to.be.accessible({
+      expect(el).to.be.accessible({
         ignoredRules: ['aria-allowed-attr']
       });
     });
 
     it('should pass a11y testing with slotted label', async () => {
       const el = await fixture(`<ef-button>TEST</ef-button>`);
-      await expect(el).to.be.accessible({
+      expect(el).to.be.accessible({
         ignoredRules: ['aria-allowed-attr', 'color-contrast']
       });
     });
@@ -221,7 +221,7 @@ describe('button/Button', () => {
     describe('should pass a11y testing in toggle mode', () => {
       it('when button is not pressed', async () => {
         const el = await fixture(`<ef-button toggles>Toggle</ef-button>`);
-        await expect(el).to.be.accessible({
+        expect(el).to.be.accessible({
           ignoredRules: ['aria-allowed-attr', 'color-contrast']
         });
         await expect(el.ariaPressed).to.equal('false');
@@ -229,7 +229,7 @@ describe('button/Button', () => {
 
       it('when button is pressed', async () => {
         const el = await fixture(`<ef-button toggles active>Toggle</ef-button>`);
-        await expect(el).to.be.accessible({
+        expect(el).to.be.accessible({
           ignoredRules: ['aria-allowed-attr', 'color-contrast']
         });
         await expect(el.ariaPressed).to.equal('true');
@@ -238,7 +238,7 @@ describe('button/Button', () => {
 
     it('should pass a11y testing when disabled is set', async () => {
       const el = await fixture(`<ef-button disabled>Disabled</ef-button>`);
-      await expect(el).to.be.accessible({
+      expect(el).to.be.accessible({
         ignoredRules: ['aria-allowed-attr', 'color-contrast']
       });
     });

--- a/packages/elements/src/checkbox/__test__/checkbox.test.js
+++ b/packages/elements/src/checkbox/__test__/checkbox.test.js
@@ -29,27 +29,27 @@ describe('checkbox/Checkbox', () => {
   describe('Accessiblity', () => {
     it('should fail without label', async () => {
       const el = await fixture(noLabel);
-      await expect(el).not.to.be.accessible();
+      expect(el).not.to.be.accessible();
     });
     it('should pass a11y test with aria-label', async () => {
       const el = await fixture(`<ef-checkbox aria-label="Checkbox without label"></ef-checkbox>`);
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
     });
     it('should pass a11y test with slotted label', async () => {
       const el = await fixture(unchecked);
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
       await expect(el.ariaChecked).to.equal(String(el.checked));
     });
     it('should pass a11y test when in checked state', async () => {
       const el = await fixture(checked);
 
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
       await expect(el.ariaChecked).to.equal(String(el.checked));
     });
     it('should pass a11y test when in indeterminate state and has aria-checked="mixed"', async () => {
       const el = await fixture(indeterminate);
 
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
       await expect(el.ariaChecked).to.equal('mixed');
     });
     it('should have aria-checked equals to false when indeterminate changes to false', async () => {
@@ -57,7 +57,7 @@ describe('checkbox/Checkbox', () => {
       el.indeterminate = false;
       await elementUpdated(el);
 
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
       await expect(el.checked).to.equal(false);
       await expect(el.ariaChecked).to.equal(String(el.checked));
     });
@@ -66,7 +66,7 @@ describe('checkbox/Checkbox', () => {
       el.checked = true;
       await elementUpdated(el);
 
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
       await expect(el.checked).to.equal(true);
       await expect(el.ariaChecked).to.equal(String(el.checked));
     });
@@ -75,16 +75,16 @@ describe('checkbox/Checkbox', () => {
       el.indeterminate = true;
       await elementUpdated(el);
 
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
       await expect(el.ariaChecked).to.equal('mixed');
     });
     it('should pass a11y test when disabled', async () => {
       const el = await fixture(disabled);
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
     });
     it('should pass a11y test when readonly', async () => {
       const el = await fixture(readonly);
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
     });
   })
 

--- a/packages/elements/src/radio-button/__test__/radio-button.test.js
+++ b/packages/elements/src/radio-button/__test__/radio-button.test.js
@@ -454,7 +454,7 @@ describe('radio-button/RadioButton', () => {
       expect(event.key).to.equal('ArrowLeft');
       expect(option1.checked).to.equal(true);
       expect(option2.checked).to.equal(false);
-      
+
     });
     it('Should uncheck the current button and move to check last button', async () => {
       const option1 = await fixture('<ef-radio-button name="group2" checked>Option 1</ef-radio-button>');
@@ -532,7 +532,7 @@ describe('radio-button/RadioButton', () => {
           await fixture('<ef-radio-button name="group1">2</ef-radio-button>'),
           await fixture('<ef-radio-button name="group1">3</ef-radio-button>')
         ];
-        
+
         group.forEach((el, index) => {
           expect(el.checked).to.equal(false);
           expect(el.getAttribute('tabIndex')).to.equal(index === 0 ? '0' : '-1');
@@ -540,7 +540,7 @@ describe('radio-button/RadioButton', () => {
         // Remove radio from group
         group[0].name = '';
         await updateGroup(group);
-  
+
         group.forEach((el, index) => {
           expect(el.checked).to.equal(false);
           expect(el.getAttribute('tabIndex')).to.equal(index === 2 ? '-1' : '0');
@@ -611,27 +611,27 @@ describe('radio-button/RadioButton', () => {
         await fixture('<ef-radio-button name="group2" checked>1</ef-radio-button>'),
         await fixture('<ef-radio-button name="group2">2</ef-radio-button>')
       ];
-  
+
       group1.forEach((el, index) => {
         expect(el.checked).to.equal(index === 0 ? true : false);
         expect(el.getAttribute('tabIndex')).to.equal(index === 0 ? '0' : '-1');
       });
-  
+
       group2.forEach((el, index) => {
         expect(el.checked).to.equal(index === 0 ? true : false);
         expect(el.getAttribute('tabIndex')).to.equal(index === 0 ? '0' : '-1');
       });
-  
+
       // Move radio to another group
       group2[0].name = 'group1';
       await updateGroup(group1);
       await updateGroup(group2);
-  
+
       group1.forEach((el, index) => {
         expect(el.checked).to.equal(false);
         expect(el.getAttribute('tabIndex')).to.equal('-1');
       });
-  
+
       group2.forEach((el, index) => {
         expect(el.checked).to.equal(index === 0 ? true : false);
         expect(el.getAttribute('tabIndex')).to.equal('0');
@@ -667,29 +667,29 @@ describe('radio-button/RadioButton', () => {
   describe('Accessiblity', () => {
     it('should fail without label', async () => {
       const el = await fixture('<ef-radio-button></ef-radio-button>');
-      await expect(el).not.to.be.accessible();
+      expect(el).not.to.be.accessible();
     });
     it('should pass a11y test with aria-label', async () => {
       const el = await fixture(`<ef-radio-button aria-label="Radio Button"></ef-checkbox>`);
-      await expect(el).to.be.accessible({ignoredRules: ['aria-allowed-attr']});
+      expect(el).to.be.accessible({ignoredRules: ['aria-allowed-attr']});
       expect(el.ariaChecked).to.be.equal(String(el.checked), 'ariaChecked');
       expect(el.getAttribute('aria-checked')).to.be.equal(String(el.checked), 'aria-checked');
     });
     it('should pass a11y test with slotted label', async () => {
       const el = await fixture(`<ef-radio-button>Radio Button</ef-checkbox>`);
-      await expect(el).to.be.accessible({ignoredRules: ['aria-allowed-attr']});
+      expect(el).to.be.accessible({ignoredRules: ['aria-allowed-attr']});
       expect(el.ariaChecked).to.be.equal(String(el.checked), 'ariaChecked');
       expect(el.getAttribute('aria-checked')).to.be.equal(String(el.checked), 'aria-checked');
     });
     it('should pass a11y test when radio button is checked', async () => {
       const el = await fixture(`<ef-radio-button checked>Radio Button</ef-checkbox>`);
-      await expect(el).to.be.accessible({ignoredRules: ['aria-allowed-attr']});
+      expect(el).to.be.accessible({ignoredRules: ['aria-allowed-attr']});
       expect(el.ariaChecked).to.be.equal(String(el.checked), 'ariaChecked');
       expect(el.getAttribute('aria-checked')).to.be.equal(String(el.checked), 'aria-checked');
     });
     it('should pass a11y test when disabled', async () => {
       const el = await fixture(`<ef-radio-button disabled>Radio Button</ef-checkbox>`);
-      await expect(el).to.be.accessible({ignoredRules: ['aria-allowed-attr']});
+      expect(el).to.be.accessible({ignoredRules: ['aria-allowed-attr']});
     });
   });
 });

--- a/packages/elements/src/toggle/__test__/toggle.test.js
+++ b/packages/elements/src/toggle/__test__/toggle.test.js
@@ -28,41 +28,41 @@ describe('toggle/Toggle', () => {
 
     it('Should failed without any visible text', async () => {
       el = await fixture('<ef-toggle></ef-toggle>');
-      await expect(el).not.to.be.accessible();
+      expect(el).not.to.be.accessible();
     });
     it('Should be accessible when custom label is provided', async () => {
       el.label = 'Disable';
       el.checkedLabel = 'Enable';
 
       await elementUpdated(el);
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
     });
     it('Should be accessible when aria-label is provided', async () => {
       el = await fixture('<ef-toggle aria-label="Bluetooth"></ef-toggle>');
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
     });
     it('Should pass a11y test when in unchecked state', async () => {
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
       await expect(el.ariaChecked).to.equal(String(el.checked));
     });
     it('Should pass a11y test when in checked state', async () => {
       el.checked = true;
 
       await elementUpdated(el);
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
       await expect(el.ariaChecked).to.equal(String(el.checked));
     });
     it('Should pass a11y test when disabled', async () => {
       el.disabled = true;
 
       await elementUpdated(el);
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
     });
     it('Should pass a11y test when readonly', async () => {
       el.readonly = true;
 
       await elementUpdated(el);
-      await expect(el).to.be.accessible();
+      expect(el).to.be.accessible();
     });
   })
 


### PR DESCRIPTION
## Description
Removes useless async/await before a11y test assertion.

## Type of change

Code improvement

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings