### PR TITLE
fix(core): tap event may be fired on wrong target on `space` key

### DIFF
--- a/packages/core/__test__/events/TapEvent.test.js
+++ b/packages/core/__test__/events/TapEvent.test.js
@@ -122,19 +122,19 @@ describe('TestTapEvent', async () => {
 
       await click(element, element);
 
-      expect(tapStartEvent).to.be.exist;
+      expect(tapStartEvent).to.exist;
       expect(tapStartEvent).to.instanceOf(Event);
       expect(tapStartEvent.type).to.equal('tapstart', 'event should be of type `tapstart`');
       expect(tapStartEvent.target).to.equal(element);
       expect(tapStartCount).to.equal(1, 'tapstart event should be fired just once');
 
-      expect(tapEndEvent).to.be.exist;
+      expect(tapEndEvent).to.exist;
       expect(tapEndEvent).to.instanceOf(Event);
       expect(tapEndEvent.type).to.equal('tapend', 'event should be of type `tapend`');
       expect(tapEndEvent.target).to.equal(element);
       expect(tapEndCount).to.equal(1, 'tapend event should be fired just once');
 
-      expect(tapEvent).to.be.exist;
+      expect(tapEvent).to.exist;
       expect(tapEvent).to.instanceOf(Event);
       expect(tapEvent.type).to.equal('tap', 'event should be of type `tap`');
       expect(tapEvent.target).to.equal(element);
@@ -152,19 +152,19 @@ describe('TestTapEvent', async () => {
 
       await click(child, parent);
 
-      expect(tapStartEvent).to.be.exist;
+      expect(tapStartEvent).to.exist;
       expect(tapStartEvent).to.instanceOf(Event);
       expect(tapStartEvent.type).to.equal('tapstart', 'event should be of type `tapstart`');
       expect(tapStartEvent.target).to.equal(child);
       expect(tapStartCount).to.equal(1, 'tapstart event should be fired just once');
 
-      expect(tapEndEvent).to.be.exist;
+      expect(tapEndEvent).to.exist;
       expect(tapEndEvent).to.instanceOf(Event);
       expect(tapEndEvent.type).to.equal('tapend', 'event should be of type `tapend`');
       expect(tapEndEvent.target).to.equal(parent);
       expect(tapEndCount).to.equal(1, 'tapend event should be fired just once');
 
-      expect(tapEvent).to.be.exist;
+      expect(tapEvent).to.exist;
       expect(tapEvent).to.instanceOf(Event);
       expect(tapEvent.type).to.equal('tap', 'event should be of type `tap`');
       expect(tapEvent.target).to.equal(parent);
@@ -182,19 +182,19 @@ describe('TestTapEvent', async () => {
 
       await click(parent, child);
 
-      expect(tapStartEvent).to.be.exist;
+      expect(tapStartEvent).to.exist;
       expect(tapStartEvent).to.instanceOf(Event);
       expect(tapStartEvent.type).to.equal('tapstart', 'event should be of type `tapstart`');
       expect(tapStartEvent.target).to.equal(parent);
       expect(tapStartCount).to.equal(1, 'tapstart event should be fired just once');
 
-      expect(tapEndEvent).to.be.exist;
+      expect(tapEndEvent).to.exist;
       expect(tapEndEvent).to.instanceOf(Event);
       expect(tapEndEvent.type).to.equal('tapend', 'event should be of type `tapend`');
       expect(tapEndEvent.target).to.equal(child);
       expect(tapEndCount).to.equal(1, 'tapend event should be fired just once');
 
-      expect(tapEvent).to.be.exist;
+      expect(tapEvent).to.exist;
       expect(tapEvent).to.instanceOf(Event);
       expect(tapEvent.type).to.equal('tap', 'event should be of type `tap`');
       expect(tapEvent.target).to.equal(parent);
@@ -214,19 +214,19 @@ describe('TestTapEvent', async () => {
 
       await click(child1, child2);
 
-      expect(tapStartEvent).to.be.exist;
+      expect(tapStartEvent).to.exist;
       expect(tapStartEvent).to.instanceOf(Event);
       expect(tapStartEvent.type).to.equal('tapstart', 'event should be of type `tapstart`');
       expect(tapStartEvent.target).to.equal(child1);
       expect(tapStartCount).to.equal(1, 'tapstart event should be fired just once');
 
-      expect(tapEndEvent).to.be.exist;
+      expect(tapEndEvent).to.exist;
       expect(tapEndEvent).to.instanceOf(Event);
       expect(tapEndEvent.type).to.equal('tapend', 'event should be of type `tapend`');
       expect(tapEndEvent.target).to.equal(child2);
       expect(tapEndCount).to.equal(1, 'tapend event should be fired just once');
 
-      expect(tapEvent).to.be.exist;
+      expect(tapEvent).to.exist;
       expect(tapEvent).to.instanceOf(Event);
       expect(tapEvent.type).to.equal('tap', 'event should be of type `tap`');
       expect(tapEvent.target).to.equal(parent);
@@ -239,7 +239,7 @@ describe('TestTapEvent', async () => {
       el.dispatchEvent(keyDownEvent);
       const keyUpEvent = keyboardEvent('keyup', { key: 'Enter' });
       el.dispatchEvent(keyUpEvent);
-      expect(tapEvent).to.be.exist;
+      expect(tapEvent).to.exist;
       expect(tapEvent.target).to.equal(el);
       expect(tapCount).to.equal(1, 'tap event should be fired just once');
     });
@@ -250,7 +250,7 @@ describe('TestTapEvent', async () => {
       el.dispatchEvent(keyDownEvent);
       const keyUpEvent = keyboardEvent('keyup', { key: ' ' });
       el.dispatchEvent(keyUpEvent);
-      expect(tapEvent).to.be.exist;
+      expect(tapEvent).to.exist;
       expect(tapEvent.target).to.equal(el);
       expect(tapCount).to.equal(1, 'tap event should be fired just once');
     });
@@ -268,7 +268,7 @@ describe('TestTapEvent', async () => {
       const keyupEvent = keyboardEvent('keyup', { key: ' ' });
       el.dispatchEvent(keydownEvent);
       el.dispatchEvent(keyupEvent);
-      expect(tapEvent).to.be.exist;
+      expect(tapEvent).to.exist;
       expect(tapEvent.target).to.equal(el);
       expect(tapCount).to.equal(1, 'tap event should be fired just once');
     });
@@ -302,19 +302,19 @@ describe('TestTapEvent', async () => {
 
       await touch(element, element);
 
-      expect(tapStartEvent).to.be.exist;
+      expect(tapStartEvent).to.exist;
       expect(tapStartEvent).to.instanceOf(Event);
       expect(tapStartEvent.type).to.equal('tapstart', 'event should be of type `tapstart`');
       expect(tapStartEvent.target).to.equal(element);
       expect(tapStartCount).to.equal(1, 'tapstart event should be fired just once');
 
-      expect(tapEndEvent).to.be.exist;
+      expect(tapEndEvent).to.exist;
       expect(tapEndEvent).to.instanceOf(Event);
       expect(tapEndEvent.type).to.equal('tapend', 'event should be of type `tapend`');
       expect(tapEndEvent.target).to.equal(element);
       expect(tapEndCount).to.equal(1, 'tapend event should be fired just once');
 
-      expect(tapEvent).to.be.exist;
+      expect(tapEvent).to.exist;
       expect(tapEvent).to.instanceOf(Event);
       expect(tapEvent.type).to.equal('tap', 'event should be of type `tap`');
       expect(tapEvent.target).to.equal(element);
@@ -334,19 +334,19 @@ describe('TestTapEvent', async () => {
       dispatchTouchEvent(element, 'touchend');
       await nextFrame();
 
-      expect(tapStartEvent).to.be.exist;
+      expect(tapStartEvent).to.exist;
       expect(tapStartEvent).to.instanceOf(Event);
       expect(tapStartEvent.type).to.equal('tapstart', 'event should be of type `tapstart`');
       expect(tapStartEvent.target).to.equal(element);
       expect(tapStartCount).to.equal(1, 'tapstart event should be fired just once');
 
-      expect(tapEndEvent).to.be.exist;
+      expect(tapEndEvent).to.exist;
       expect(tapEndEvent).to.instanceOf(Event);
       expect(tapEndEvent.type).to.equal('tapend', 'event should be of type `tapend`');
       expect(tapEndEvent.target).to.equal(element);
       expect(tapEndCount).to.equal(1, 'tapend event should be fired just once');
 
-      expect(tapEvent).to.be.not.exist;
+      expect(tapEvent).to.not.exist;
       expect(tapEvent).to.equal(null);
       expect(tapCount).to.equal(0, 'tap event should not be fired if touch moved');
     });
@@ -365,19 +365,19 @@ describe('TestTapEvent', async () => {
 
       await touch(child, parent);
 
-      expect(tapStartEvent).to.be.exist;
+      expect(tapStartEvent).to.exist;
       expect(tapStartEvent).to.instanceOf(Event);
       expect(tapStartEvent.type).to.equal('tapstart', 'event should be of type `tapstart`');
       expect(tapStartEvent.target).to.equal(child);
       expect(tapStartCount).to.equal(1, 'tapstart event should be fired just once');
 
-      expect(tapEndEvent).to.be.exist;
+      expect(tapEndEvent).to.exist;
       expect(tapEndEvent).to.instanceOf(Event);
       expect(tapEndEvent.type).to.equal('tapend', 'event should be of type `tapend`');
       expect(tapEndEvent.target).to.equal(parent);
       expect(tapEndCount).to.equal(1, 'tapend event should be fired just once');
 
-      expect(tapEvent).to.be.not.exist;
+      expect(tapEvent).to.not.exist;
       expect(tapEvent).to.equal(null);
       expect(tapCount).to.equal(0, 'tap event should not be fired');
     });
@@ -396,19 +396,19 @@ describe('TestTapEvent', async () => {
 
       await touch(parent, child);
 
-      expect(tapStartEvent).to.be.exist;
+      expect(tapStartEvent).to.exist;
       expect(tapStartEvent).to.instanceOf(Event);
       expect(tapStartEvent.type).to.equal('tapstart', 'event should be of type `tapstart`');
       expect(tapStartEvent.target).to.equal(parent);
       expect(tapStartCount).to.equal(1, 'tapstart event should be fired just once');
 
-      expect(tapEndEvent).to.be.exist;
+      expect(tapEndEvent).to.exist;
       expect(tapEndEvent).to.instanceOf(Event);
       expect(tapEndEvent.type).to.equal('tapend', 'event should be of type `tapend`');
       expect(tapEndEvent.target).to.equal(parent);
       expect(tapEndCount).to.equal(1, 'tapend event should be fired just once');
 
-      expect(tapEvent).to.be.not.exist;
+      expect(tapEvent).to.not.exist;
       expect(tapEvent).to.equal(null);
       expect(tapCount).to.equal(0, 'tap event should not be fired');
     });
@@ -429,19 +429,19 @@ describe('TestTapEvent', async () => {
 
       await touch(child1, child2);
 
-      expect(tapStartEvent).to.be.exist;
+      expect(tapStartEvent).to.exist;
       expect(tapStartEvent).to.instanceOf(Event);
       expect(tapStartEvent.type).to.equal('tapstart', 'event should be of type `tapstart`');
       expect(tapStartEvent.target).to.equal(child1);
       expect(tapStartCount).to.equal(1, 'tapstart event should be fired just once');
 
-      expect(tapEndEvent).to.be.exist;
+      expect(tapEndEvent).to.exist;
       expect(tapEndEvent).to.instanceOf(Event);
       expect(tapEndEvent.type).to.equal('tapend', 'event should be of type `tapend`');
       expect(tapEndEvent.target).to.equal(child2);
       expect(tapEndCount).to.equal(1, 'tapend event should be fired just once');
 
-      expect(tapEvent).to.be.not.exist;
+      expect(tapEvent).to.not.exist;
       expect(tapEvent).to.equal(null);
       expect(tapCount).to.equal(0, 'tap event should not be fired');
     });
@@ -457,19 +457,19 @@ describe('TestTapEvent', async () => {
       await touch(element, element);
       await click(element, element);
 
-      expect(tapStartEvent).to.be.exist;
+      expect(tapStartEvent).to.exist;
       expect(tapStartEvent).to.instanceOf(Event);
       expect(tapStartEvent.type).to.equal('tapstart', 'event should be of type `tapstart`');
       expect(tapStartEvent.target).to.equal(element);
       expect(tapStartCount).to.equal(1, 'tapstart event should be fired just once');
 
-      expect(tapEndEvent).to.be.exist;
+      expect(tapEndEvent).to.exist;
       expect(tapEndEvent).to.instanceOf(Event);
       expect(tapEndEvent.type).to.equal('tapend', 'event should be of type `tapend`');
       expect(tapEndEvent.target).to.equal(element);
       expect(tapEndCount).to.equal(1, 'tapend event should be fired just once');
 
-      expect(tapEvent).to.be.exist;
+      expect(tapEvent).to.exist;
       expect(tapEvent).to.instanceOf(Event);
       expect(tapEvent.type).to.equal('tap', 'event should be of type `tap`');
       expect(tapEvent.target).to.equal(element);
@@ -491,7 +491,7 @@ describe('TestTapEvent', async () => {
         detail: 0
       }));
 
-      expect(tapEvent).to.be.exist;
+      expect(tapEvent).to.exist;
       expect(tapEvent).to.instanceOf(Event);
       expect(tapEvent.type).to.equal('tap', 'event should be of type `tap`');
       expect(tapEvent.target).to.equal(element);
@@ -513,7 +513,7 @@ describe('TestTapEvent', async () => {
         detail: 1
       }));
 
-      expect(tapEvent).to.be.not.exist;
+      expect(tapEvent).to.not.exist;
       expect(tapEvent).to.equal(null);
       expect(tapCount).to.equal(0, 'regular click should not generate tap event');
     });
@@ -533,7 +533,7 @@ describe('TestTapEvent', async () => {
         pointerType: null
       }));
 
-      expect(tapEvent).to.be.exist;
+      expect(tapEvent).to.exist;
       expect(tapEvent).to.instanceOf(TapEvent);
       expect(tapEvent.type).to.equal('tap', 'event should be of type `tap`');
       expect(tapEvent.target).to.equal(element);

--- a/packages/core/__test__/events/TapEvent.test.js
+++ b/packages/core/__test__/events/TapEvent.test.js
@@ -262,15 +262,25 @@ describe('TestTapEvent', async () => {
       expect(tapCount).to.equal(0, 'tap event should not be fired');
     });
 
-    it('Should support tap event on role=button when space bar is pressed', async function () {
+    it('Should support tap event on role=button when `space` is pressed', async function () {
       const el = await fixture('<div role="button">Fake Button</div>');
-      const event = keyboardEvent('keyup', {
-        key: ' '
-      });
-      el.dispatchEvent(event);
+      const keydownEvent = keyboardEvent('keydown', { key: ' ' });
+      const keyupEvent = keyboardEvent('keyup', { key: ' ' });
+      el.dispatchEvent(keydownEvent);
+      el.dispatchEvent(keyupEvent);
       expect(tapEvent).to.be.exist;
       expect(tapEvent.target).to.equal(el);
       expect(tapCount).to.equal(1, 'tap event should be fired just once');
+    });
+
+    it('Should not run tap event on role=button when `space` is pressed and target has changed', async function () {
+      const target1 = await fixture('<div role="button">Target 1</div>');
+      const target2 = await fixture('<div role="button">Target 2</div>');
+      const keydownEvent = keyboardEvent('keydown', { key: ' ' });
+      const keyupEvent = keyboardEvent('keyup', { key: ' ' });
+      target1.dispatchEvent(keydownEvent);
+      target2.dispatchEvent(keyupEvent);
+      expect(tapCount).to.equal(0, 'tap event should not be fired on different target');
     });
 
     it('Should not fire tap event when role=button is not set', async function () {

--- a/packages/core/__test__/registries/NativeStyleRegistry.test.js
+++ b/packages/core/__test__/registries/NativeStyleRegistry.test.js
@@ -44,7 +44,7 @@ describe('TestNativeStyleRegistry', () => {
 
     const node = document.querySelector(`[scope=${testName}]`);
 
-    expect(node).to.be.exist;
+    expect(node).to.exist;
   });
 
   it('Test empty css will not be exists in styles', () => {

--- a/packages/core/src/events/TapEvent.ts
+++ b/packages/core/src/events/TapEvent.ts
@@ -160,6 +160,12 @@ const applyEvent = (target: Global): void => {
   let lastTapTarget: EventTarget | null;
 
   /**
+   * The last key down event target on `role=button`.
+   * This is used to ensure that keydown and keyup events run on the same target
+   */
+  let buttonLastKeydownTarget: EventTarget | null;
+
+  /**
    * Stored event path from `mousestart` event.
    * Used to match correct tap target.
    */
@@ -341,10 +347,13 @@ const applyEvent = (target: Global): void => {
   target.addEventListener('keydown', (event: KeyboardEvent) => {
     const target = topPathTarget(event);
     const enterKey = isEnterKey(event);
+    buttonLastKeydownTarget = null;
 
     if (event.defaultPrevented || !(enterKey || isSpaceKey(event)) || !isButtonBehaviour(target)) {
       return;
     }
+
+    buttonLastKeydownTarget = target;
 
     if (enterKey) {
       (target as HTMLElement).click();
@@ -360,11 +369,11 @@ const applyEvent = (target: Global): void => {
   target.addEventListener('keyup', (event: KeyboardEvent) => {
     const target = topPathTarget(event);
 
-    if (event.defaultPrevented || !isSpaceKey(event) || !isButtonBehaviour(target)) {
-      return;
+    if (buttonLastKeydownTarget === target && !event.defaultPrevented && isSpaceKey(event)) {
+      (target as HTMLElement).click();
     }
 
-    (target as HTMLElement).click();
+    buttonLastKeydownTarget = null;
   }, true);
 
   /**


### PR DESCRIPTION
## Description
Tap event may be fired on wrong target on `space` key.

## Type of change
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings