### PR TITLE
fix(clock): slightly increase font size of digital part inside analog clock

### DIFF
--- a/packages/elemental-theme/src/custom-elements/ef-clock.less
+++ b/packages/elemental-theme/src/custom-elements/ef-clock.less
@@ -96,7 +96,7 @@
       left: 0;
       right: 0;
       justify-content: center;
-      font-size: 0.3em;
+      font-size: 0.34em;
       [part~='am-pm'] {
         font-size: 100%;
         line-height: 1;


### PR DESCRIPTION
## Description
Make digital part inside analog clock to use font close to UX spec (from 9px -> ~10px).

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings