### PR TITLE
fix(phrasebook): change ICU syntax on japanese language

### DIFF
--- a/packages/phrasebook/src/locale/ja/tree-select.ts
+++ b/packages/phrasebook/src/locale/ja/tree-select.ts
@@ -9,8 +9,8 @@ const translations = {
   // used as a toggle control
   FULL_LIST: 'すべて',
   SELECTED: '選択項目のみ',
-  EXPAND_COLLAPSE: '{expansion, select, false {すべてを展開} true {すべてを折りたたむ}}',
-  SELECT_CONTROL: '{selected, select, false {すべて選択} true {選択をすべて解除}}',
+  EXPAND_COLLAPSE: '{expansion, select, false {すべてを展開} other {すべてを折りたたむ}}',
+  SELECT_CONTROL: '{selected, select, false {すべて選択} other {選択をすべて解除}}',
   // button control
   DONE: '完了',
   // selection/filter feedback


### PR DESCRIPTION
## Description
The change is related to the syntax of the ICU message that requires `other` argument.

Fixes # (issue)
ELF-1680  Japanese translation (ja) in tree-select does not work

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings