### PR TITLE
fix(combo-box): import counter instead of pill

### DIFF
--- a/packages/elements/src/combo-box/__test__/combo-box.interaction.test.js
+++ b/packages/elements/src/combo-box/__test__/combo-box.interaction.test.js
@@ -157,7 +157,8 @@ describe('combo-box/Interaction', () => {
       expect(String(el.values)).to.equal('AX,AL', 'Multiple: tapping on the list did not select the values');
       expect(el.query).to.equal('Al', 'Multiple: tapping on the list should clear a query');
       expect(el.opened).to.equal(true, 'Multiple: tapping on the list should not close the popup');
-      expect(el.inputEl.value).to.equal('Al', 'Multiple: tapping on the list did should not clear input value');
+      expect(el.inputEl.value).to.equal('Al', 'Multiple: tapping on the list did not clear input value');
+      expect(el.shadowRoot.querySelector("[part='selection-badge']").value).to.equal('2', 'Multiple: counter on the combo-box did not show correct value');
     });
     it('Enter should select a value in the list', async function () {
       if (skipCITest) {

--- a/packages/elements/src/combo-box/__test__/combo-box.interaction.test.js
+++ b/packages/elements/src/combo-box/__test__/combo-box.interaction.test.js
@@ -157,7 +157,7 @@ describe('combo-box/Interaction', () => {
       expect(String(el.values)).to.equal('AX,AL', 'Multiple: tapping on the list did not select the values');
       expect(el.query).to.equal('Al', 'Multiple: tapping on the list should clear a query');
       expect(el.opened).to.equal(true, 'Multiple: tapping on the list should not close the popup');
-      expect(el.inputEl.value).to.equal('Al', 'Multiple: tapping on the list did not clear input value');
+      expect(el.inputEl.value).to.equal('Al', 'Multiple: tapping on the list should not clear input value');
       expect(el.shadowRoot.querySelector("[part='selection-badge']").value).to.equal('2', 'Multiple: counter on the combo-box did not show correct value');
     });
     it('Enter should select a value in the list', async function () {

--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -29,7 +29,7 @@ import { CustomKeyboardEvent } from './helpers/keyboard-event.js';
 import '../icon/index.js';
 import '../overlay/index.js';
 import '../list/index.js';
-import '../pill/index.js';
+import '../counter/index.js';
 import '../text-field/index.js';
 import { translate, TranslateDirective } from '@refinitiv-ui/translate';
 import '@refinitiv-ui/phrasebook/lib/locale/en/combo-box.js';

--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -34,7 +34,7 @@ import '../text-field/index.js';
 import { translate, TranslateDirective } from '@refinitiv-ui/translate';
 import '@refinitiv-ui/phrasebook/lib/locale/en/combo-box.js';
 
-export { ComboBoxFilter, ComboBoxData };
+export type { ComboBoxFilter, ComboBoxData };
 export { ComboBoxRenderer };
 
 const QUERY_DEBOUNCE_RATE = 0;

--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -34,7 +34,8 @@ import '../text-field/index.js';
 import { translate, TranslateDirective } from '@refinitiv-ui/translate';
 import '@refinitiv-ui/phrasebook/lib/locale/en/combo-box.js';
 
-export type { ComboBoxRenderer, ComboBoxFilter, ComboBoxData };
+export { ComboBoxFilter, ComboBoxData };
+export { ComboBoxRenderer };
 
 const QUERY_DEBOUNCE_RATE = 0;
 


### PR DESCRIPTION
## Description
Found an incorrect import in combo-box. After merging Lit2, it reverted to import pill. It should import counter.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings