### PR TITLE
fix(tree-item): reduce space between checkbox and label

### DIFF
--- a/packages/elemental-theme/src/custom-elements/ef-tree-item.less
+++ b/packages/elemental-theme/src/custom-elements/ef-tree-item.less
@@ -52,7 +52,11 @@
   }
 
   [part=label] {
-    padding: 4px extract(@input-padding, 2);
+    padding: 4px 0px;
     word-break: break-word;
+  }
+
+  [part=label-icon] {
+    margin: 0px 4px 0px 0px;
   }
 }

--- a/packages/elemental-theme/src/custom-elements/ef-tree-item.less
+++ b/packages/elemental-theme/src/custom-elements/ef-tree-item.less
@@ -52,11 +52,7 @@
   }
 
   [part=label] {
-    padding: 4px 0px;
+    padding: 4px extract(@input-padding, 2);
     word-break: break-word;
-  }
-
-  [part=label-icon] {
-    margin: 0px 4px 0px 0px;
   }
 }

--- a/packages/halo-theme/src/custom-elements/ef-tree-item.less
+++ b/packages/halo-theme/src/custom-elements/ef-tree-item.less
@@ -26,6 +26,11 @@
   }
 
   [part=label] {
+    padding: 4px 6px 4px 0px;
     line-height: 1.2;
+  }
+
+  [part=label-icon] {
+    margin: 0px 4px 0px 0px;
   }
 }

--- a/packages/solar-theme/src/custom-elements/ef-tree-item.less
+++ b/packages/solar-theme/src/custom-elements/ef-tree-item.less
@@ -18,4 +18,12 @@
   &:last-of-type {
     border-color: transparent;
   }
+
+  [part=label] {
+    padding: 4px 6px 4px 0px;
+  }
+
+  [part=label-icon] {
+    margin: 0px 4px 0px 0px;
+  }
 }


### PR DESCRIPTION
## Description
I managed to reduce the horizontal padding to 0px and let the margin of the checkbox manage the space between the checkbox and label.  When there is an icon on items, I need to add space between icon and label. This fixed effect on tree-select and tree.

Fixes # (issue)
ELF-1678 the space between checkbox and label is too large
## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings