### PR TITLE
docs(datetime-picker): fix typo jsdoc for slot content

### DIFF
--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -94,10 +94,10 @@ const INPUT_FORMAT = {
  * @attr {boolean} disabled - Set disabled state
  * @prop {boolean} [disabled=false] - Set disabled state
  *
- * @slots header - Header slot
- * @slots right - Right slot
- * @slots footer - Footer slot
- * @slots left - Left slot
+ * @slot header - Slot to add custom contents at the top of popup
+ * @slot right - Slot to add custom contents at the right of popup
+ * @slot footer - Slot to add custom contents at the bottom of popup
+ * @slot left - Slot to add custom contents at the left of popup
  */
 @customElement('ef-datetime-picker', {
   alias: 'emerald-datetime-picker'


### PR DESCRIPTION
## Description
Fix typo in jsdoc for slot so it doesn't generate slot in API section

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings