### PR TITLE
chore: remove modifier and merge attribute column on generated api docs

### DIFF
--- a/scripts/release/api-analyzer.js
+++ b/scripts/release/api-analyzer.js
@@ -145,10 +145,10 @@ const analyze = (file, type) => {
   const data = fs.readFileSync(file, { encoding: 'utf8' });
   const meta = wca.analyzeText(data);
 
-  // Modify meta data of properties/attributes before converted it to markdown files
   meta.results.forEach(result => {
     result.componentDefinitions.forEach(definition => {
       const propCollection = {};
+      // WORKAROUND: Modify meta data of properties/attributes to make it fit with api reference tables of "elf-docs"
       definition.declaration.members.forEach(member => {
         let { propName, attrName, kind } = member;
         // Convert default value of properties to theirs actual type

--- a/scripts/release/api-analyzer.js
+++ b/scripts/release/api-analyzer.js
@@ -150,13 +150,13 @@ const analyze = (file, type) => {
     result.componentDefinitions.forEach(definition => {
       const propCollection = {};
       definition.declaration.members.forEach(member => {
-        const { default: defaultValue, propName, attrName, kind, modifiers } = member;
+        let { propName, attrName, kind } = member;
         // Convert default value of properties to theirs actual type
-        if(defaultValue === 'null') {
-          defaultValue = null;
+        if(member.default === 'null') {
+          member.default = null;
         }
-        else if(defaultValue === '[]') {
-          defaultValue = [];
+        else if(member.default === '[]') {
+          member.default = [];
         }
         // Merge attributes that defined by JSDOC to properties table
         if(propName && !attrName) {
@@ -169,8 +169,8 @@ const analyze = (file, type) => {
           }
         }
         // Remove readonly modifier of properties from meta data
-        if(modifiers === 'readonly') {
-          modifiers = null;
+        if(member.modifiers === 'readonly') {
+          member.modifiers = null;
         }
       })
     })

--- a/scripts/release/api-analyzer.js
+++ b/scripts/release/api-analyzer.js
@@ -111,20 +111,6 @@ const declarationMethodMapCallback = (declarationMethod) => {
 const declarationMethodFilter = (method) => method !== null;
 
 const getMethods = (data, meta) => {
-  /**
-   * it will work if they fix the methods field of data
-   */
-  // const dataMethods = data.methods || [];
-  // const methods = dataMethods.map(dataMethod => ({
-  //   name: dataMethod.name,
-  //   description: dataMethod.description,
-  //   params: dataMethod.arguments || dataMethod.arguments.map(argument => ({
-  //     name: argument.name,
-  //     description: argument.description,
-  //     type: argument.type,
-  //   }))
-  // }));
-
   const declarationMethods = getDeclarationMethods(meta);
   const methods = declarationMethods
     .map(declarationMethodMapCallback)
@@ -158,6 +144,38 @@ const analyze = (file, type) => {
   let output;
   const data = fs.readFileSync(file, { encoding: 'utf8' });
   const meta = wca.analyzeText(data);
+
+  // Modify meta data of properties/attributes before converted it to markdown files
+  meta.results.forEach(result => {
+    result.componentDefinitions.forEach(definition => {
+      const propCollection = {};
+      definition.declaration.members.forEach(member => {
+        const { default: defaultValue, propName, attrName, kind, modifiers } = member;
+        // Convert default value of properties to theirs actual type
+        if(defaultValue === 'null') {
+          defaultValue = null;
+        }
+        else if(defaultValue === '[]') {
+          defaultValue = [];
+        }
+        // Merge attributes that defined by JSDOC to properties table
+        if(propName && !attrName) {
+          propCollection[propName] = member;
+        }
+        if(kind === 'attribute' && !propName && attrName) {
+          const attrCamelCase = attrName.replace(/-./g, attr => attr.length > 0 ? attr[1].toUpperCase() : '');
+          if(propCollection[attrCamelCase]) {
+            propCollection[attrCamelCase].attrName = attrName;
+          }
+        }
+        // Remove readonly modifier of properties from meta data
+        if(modifiers === 'readonly') {
+          modifiers = null;
+        }
+      })
+    })
+  });
+
   if(type === 'json') {
     const rawJson = wca.transformAnalyzerResult('json', meta.results, meta.program);
     const jsonObj = JSON.parse(rawJson);

--- a/scripts/release/api-analyzer.js
+++ b/scripts/release/api-analyzer.js
@@ -147,9 +147,16 @@ const analyze = (file, type) => {
 
   meta.results.forEach(result => {
     result.componentDefinitions.forEach(definition => {
+      const { declaration } = definition;
       const propCollection = {};
+      
+      if(!declaration || declaration && !declaration.members) {
+        error(`Element Analyzer Error: declaration property is missing.`);
+        return;
+      }
+
       // WORKAROUND: Modify meta data of properties/attributes to make it fit with api reference tables of "elf-docs"
-      definition.declaration.members.forEach(member => {
+      declaration.members.forEach(member => {
         let { propName, attrName, kind } = member;
         // Convert default value of properties to theirs actual type
         if(member.default === 'null') {

--- a/scripts/release/api-analyzer.js
+++ b/scripts/release/api-analyzer.js
@@ -169,8 +169,8 @@ const analyze = (file, type) => {
           }
         }
         // Remove readonly modifier of properties from meta data
-        if(member.modifiers === 'readonly') {
-          member.modifiers = null;
+        if(member.modifiers && member.modifiers.has('readonly')) {
+          member.modifiers.delete('readonly');
         }
       })
     })


### PR DESCRIPTION
## Description
Elf-docs use `custom-elements.md` files that generated by `api-analyzer` script and some column in the files are missing some value and have some unnecessary column so we need to modified it. 
- Remove readonly modifier form meta data of properties ( Still keeps static modifier )
- Convert default value of some properties that defined by `@default` syntax
- Merge attributes that defined by JSDOC to properties table
---------
- [ ] Bug fix (non-breaking change which fixes an issue
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Updating build / released scripts

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings