### PR TITLE
fix(tree-item): slightly increase margin the part checkbox on solar theme

### DIFF
--- a/packages/solar-theme/src/custom-elements/ef-tree-item.less
+++ b/packages/solar-theme/src/custom-elements/ef-tree-item.less
@@ -27,7 +27,7 @@
     margin: 0px 4px 0px 0px;
   }
 
-  [part="checkbox"] {
+  [part=checkbox] {
     margin: 0px 8px 0px 0px;
   }
 }

--- a/packages/solar-theme/src/custom-elements/ef-tree-item.less
+++ b/packages/solar-theme/src/custom-elements/ef-tree-item.less
@@ -26,4 +26,8 @@
   [part=label-icon] {
     margin: 0px 4px 0px 0px;
   }
+
+  [part="checkbox"] {
+    margin: 0px 8px 0px 0px;
+  }
 }


### PR DESCRIPTION
## Description
This fixed was related to this PR [fix(tree-item): reduce space between checkbox and label](https://github.com/Refinitiv/refinitiv-ui/pull/93). I was missed to add some of the margin of part checkbox on the solar theme. 

Fixes # ELF-1678

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings