### PR TITLE
fix(text-field): error doesn't display when first render

### DIFF
--- a/packages/elements/src/text-field/index.ts
+++ b/packages/elements/src/text-field/index.ts
@@ -199,7 +199,7 @@ export class TextField extends FormFieldElement {
    * @returns {void}
    */
   protected validateInput (): void {
-    let error = !this.inputElement?.checkValidity();
+    let error = this.error || !this.inputElement?.checkValidity();
     /* istanbul ignore next */
     if (this.shouldValidateForMinLength(error)) {
       error = !!this.minLength && (this.minLength > this.value.length);


### PR DESCRIPTION
## Description
Found error attribute doesn't display when first render.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings