### PR TITLE
refactor(core): remove aria-hidden and role from FormField element

### DIFF
--- a/packages/core/__snapshots__/elements/FormFieldElement/AriaDescriptionTest.md
+++ b/packages/core/__snapshots__/elements/FormFieldElement/AriaDescriptionTest.md
@@ -5,17 +5,13 @@
 ```html
 <input
   aria-description="Description"
-  aria-hidden="true"
   autocomplete="off"
 >
 
 ```
 
 ```html
-<input
-  aria-hidden="true"
-  autocomplete="off"
->
+<input autocomplete="off">
 
 ```
 
@@ -24,7 +20,6 @@
 ```html
 <input
   aria-description="Described By"
-  aria-hidden="true"
   autocomplete="off"
 >
 
@@ -35,7 +30,6 @@
 ```html
 <input
   aria-description="!ERROR! Described By"
-  aria-hidden="true"
   aria-invalid="true"
   autocomplete="off"
 >

--- a/packages/core/__snapshots__/elements/FormFieldElement/AriaLabelTest.md
+++ b/packages/core/__snapshots__/elements/FormFieldElement/AriaLabelTest.md
@@ -4,7 +4,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   aria-label="Label"
   autocomplete="off"
 >
@@ -12,10 +11,7 @@
 ```
 
 ```html
-<input
-  aria-hidden="true"
-  autocomplete="off"
->
+<input autocomplete="off">
 
 ```
 
@@ -23,7 +19,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   aria-label="Labelled By"
   autocomplete="off"
 >
@@ -34,7 +29,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   aria-label="Label For"
   autocomplete="off"
 >

--- a/packages/core/__snapshots__/elements/FormFieldElement/DefaultsTest.md
+++ b/packages/core/__snapshots__/elements/FormFieldElement/DefaultsTest.md
@@ -3,10 +3,7 @@
 #### `Default properties`
 
 ```html
-<input
-  aria-hidden="true"
-  autocomplete="off"
->
+<input autocomplete="off">
 
 ```
 

--- a/packages/core/__snapshots__/elements/FormFieldElement/DisabledTest.md
+++ b/packages/core/__snapshots__/elements/FormFieldElement/DisabledTest.md
@@ -4,7 +4,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   autocomplete="off"
   disabled=""
 >
@@ -12,10 +11,7 @@
 ```
 
 ```html
-<input
-  aria-hidden="true"
-  autocomplete="off"
->
+<input autocomplete="off">
 
 ```
 

--- a/packages/core/__snapshots__/elements/FormFieldElement/ErrorTest.md
+++ b/packages/core/__snapshots__/elements/FormFieldElement/ErrorTest.md
@@ -4,7 +4,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   aria-invalid="true"
   autocomplete="off"
 >
@@ -12,10 +11,7 @@
 ```
 
 ```html
-<input
-  aria-hidden="true"
-  autocomplete="off"
->
+<input autocomplete="off">
 
 ```
 

--- a/packages/core/__snapshots__/elements/FormFieldElement/PlaceholderTest.md
+++ b/packages/core/__snapshots__/elements/FormFieldElement/PlaceholderTest.md
@@ -4,7 +4,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   autocomplete="off"
   placeholder="Placeholder"
 >
@@ -12,10 +11,7 @@
 ```
 
 ```html
-<input
-  aria-hidden="true"
-  autocomplete="off"
->
+<input autocomplete="off">
 
 ```
 

--- a/packages/core/__snapshots__/elements/FormFieldElement/ReadonlyTest.md
+++ b/packages/core/__snapshots__/elements/FormFieldElement/ReadonlyTest.md
@@ -4,7 +4,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   autocomplete="off"
   readonly=""
 >
@@ -12,10 +11,7 @@
 ```
 
 ```html
-<input
-  aria-hidden="true"
-  autocomplete="off"
->
+<input autocomplete="off">
 
 ```
 

--- a/packages/core/__snapshots__/elements/FormFieldElement/RequiredTest.md
+++ b/packages/core/__snapshots__/elements/FormFieldElement/RequiredTest.md
@@ -4,7 +4,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   aria-required="true"
   autocomplete="off"
 >
@@ -12,10 +11,7 @@
 ```
 
 ```html
-<input
-  aria-hidden="true"
-  autocomplete="off"
->
+<input autocomplete="off">
 
 ```
 

--- a/packages/core/src/elements/FormFieldElement.ts
+++ b/packages/core/src/elements/FormFieldElement.ts
@@ -47,8 +47,6 @@ export abstract class FormFieldElement extends ControlElement {
     ]));
   }
 
-  protected readonly defaultRole: string | null = 'textbox';
-
   /**
    * Set state to error
    */
@@ -238,7 +236,6 @@ export abstract class FormFieldElement extends ControlElement {
 
   /**
    * Decorate `<input>` element with common properties:
-   * aria-hidden="true" - always true. Required for onLoad screen read. this is always true for Chrome. Other browsers may need to tweak
    * aria-label - calculated from `aria-label`, `aria-labelledby` and `label[for="<element.id>"]`
    * aria-description - calculated from `aria-description` or `aria-describedby`
    * aria-invalid="true|null" - calculated on based on `error` state
@@ -253,7 +250,6 @@ export abstract class FormFieldElement extends ControlElement {
    */
   protected get decorateInputMap (): TemplateMap {
     return {
-      'aria-hidden': 'true',
       'aria-label': this.inputAriaLabel,
       'aria-description': this.inputAriaDescription,
       'aria-invalid': this.error ? 'true' : null,

--- a/packages/elements/src/color-dialog/__snapshots__/ColorDialog.md
+++ b/packages/elements/src/color-dialog/__snapshots__/ColorDialog.md
@@ -46,7 +46,6 @@
           min="0"
           no-spinner=""
           part="color-input"
-          role="textbox"
         >
         </ef-number-field>
       </div>
@@ -58,7 +57,6 @@
           min="0"
           no-spinner=""
           part="color-input"
-          role="textbox"
         >
         </ef-number-field>
       </div>
@@ -70,7 +68,6 @@
           min="0"
           no-spinner=""
           part="color-input"
-          role="textbox"
         >
         </ef-number-field>
       </div>
@@ -81,7 +78,6 @@
           maxlength="6"
           part="color-input"
           pattern="^([0-9a-fA-F]{3}){1,2}$"
-          role="textbox"
         >
         </ef-text-field>
       </div>

--- a/packages/elements/src/combo-box/__snapshots__/AsyncFilter.md
+++ b/packages/elements/src/combo-box/__snapshots__/AsyncFilter.md
@@ -8,7 +8,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -51,7 +50,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >

--- a/packages/elements/src/combo-box/__snapshots__/Filter.md
+++ b/packages/elements/src/combo-box/__snapshots__/Filter.md
@@ -8,7 +8,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -70,7 +69,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >

--- a/packages/elements/src/combo-box/__snapshots__/Selected.md
+++ b/packages/elements/src/combo-box/__snapshots__/Selected.md
@@ -8,7 +8,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -77,7 +76,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -146,7 +144,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -216,7 +213,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -296,7 +292,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -369,7 +364,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >

--- a/packages/elements/src/combo-box/__snapshots__/Template.md
+++ b/packages/elements/src/combo-box/__snapshots__/Template.md
@@ -8,7 +8,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -33,7 +32,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -56,7 +54,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -79,7 +76,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -104,7 +100,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -172,7 +167,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -238,7 +232,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -306,7 +299,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -374,7 +366,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >

--- a/packages/elements/src/combo-box/__snapshots__/Value.md
+++ b/packages/elements/src/combo-box/__snapshots__/Value.md
@@ -8,7 +8,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -77,7 +76,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -146,7 +144,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -216,7 +213,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -287,7 +283,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -367,7 +362,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -440,7 +434,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >

--- a/packages/elements/src/datetime-picker/__snapshots__/DOMStructure.md
+++ b/packages/elements/src/datetime-picker/__snapshots__/DOMStructure.md
@@ -9,7 +9,6 @@
   <ef-text-field
     id="input"
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -30,7 +29,6 @@
   <ef-text-field
     id="input"
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -92,7 +90,6 @@
   <ef-text-field
     id="input"
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -102,7 +99,6 @@
   <ef-text-field
     id="input-to"
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -165,7 +161,6 @@
   <ef-text-field
     id="input"
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -234,7 +229,6 @@
   <ef-text-field
     id="input"
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -304,7 +298,6 @@
   <ef-text-field
     id="input"
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -374,7 +367,6 @@
   <ef-text-field
     id="input"
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >
@@ -384,7 +376,6 @@
   <ef-text-field
     id="input-to"
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >

--- a/packages/elements/src/email-field/__snapshots__/EmailField.md
+++ b/packages/elements/src/email-field/__snapshots__/EmailField.md
@@ -4,7 +4,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   autocomplete="off"
   inputmode="email"
   part="input"
@@ -17,7 +16,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   autocomplete="off"
   inputmode="email"
   multiple=""

--- a/packages/elements/src/multi-input/__snapshots__/MultiInput.md
+++ b/packages/elements/src/multi-input/__snapshots__/MultiInput.md
@@ -9,7 +9,6 @@
 >
   <ef-text-field
     part="search"
-    role="textbox"
     tabindex="1"
     transparent=""
   >

--- a/packages/elements/src/number-field/__snapshots__/NumberField.md
+++ b/packages/elements/src/number-field/__snapshots__/NumberField.md
@@ -6,7 +6,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   aria-valuenow="0"
   autocomplete="off"
   inputmode="decimal"
@@ -34,7 +33,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   aria-valuenow="0"
   autocomplete="off"
   inputmode="decimal"

--- a/packages/elements/src/pagination/__snapshots__/Pagination.md
+++ b/packages/elements/src/pagination/__snapshots__/Pagination.md
@@ -46,7 +46,6 @@
     id="input"
     no-spinner=""
     part="input"
-    role="textbox"
     tabindex="0"
   >
   </ef-text-field>

--- a/packages/elements/src/password-field/__snapshots__/PasswordField.md
+++ b/packages/elements/src/password-field/__snapshots__/PasswordField.md
@@ -4,7 +4,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   autocomplete="off"
   part="input"
   type="password"
@@ -24,7 +23,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   autocomplete="off"
   part="input"
   type="text"
@@ -42,7 +40,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   autocomplete="off"
   part="input"
   type="password"

--- a/packages/elements/src/search-field/__snapshots__/SearchField.md
+++ b/packages/elements/src/search-field/__snapshots__/SearchField.md
@@ -4,7 +4,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   autocomplete="off"
   inputmode="search"
   part="input"

--- a/packages/elements/src/text-field/__snapshots__/TextField.md
+++ b/packages/elements/src/text-field/__snapshots__/TextField.md
@@ -4,7 +4,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   autocomplete="off"
   part="input"
   type="text"
@@ -16,7 +15,6 @@
 
 ```html
 <input
-  aria-hidden="true"
   aria-invalid="true"
   autocomplete="off"
   maxlength="10"

--- a/packages/elements/src/time-picker/__snapshots__/TimePicker.md
+++ b/packages/elements/src/time-picker/__snapshots__/TimePicker.md
@@ -14,7 +14,6 @@
   part="input"
   placeholder="00"
   readonly=""
-  role="textbox"
   tabindex="0"
   transparent=""
 >
@@ -30,7 +29,6 @@
   part="input"
   placeholder="00"
   readonly=""
-  role="textbox"
   tabindex="0"
   transparent=""
 >
@@ -46,7 +44,6 @@
   part="input"
   placeholder="00"
   readonly=""
-  role="textbox"
   tabindex="0"
   transparent=""
 >
@@ -66,7 +63,6 @@
   no-spinner=""
   part="input"
   placeholder="00"
-  role="textbox"
   style="pointer-events: none;"
   tabindex="-1"
   transparent=""
@@ -83,7 +79,6 @@
   no-spinner=""
   part="input"
   placeholder="00"
-  role="textbox"
   style="pointer-events: none;"
   tabindex="-1"
   transparent=""
@@ -100,7 +95,6 @@
   no-spinner=""
   part="input"
   placeholder="00"
-  role="textbox"
   style="pointer-events: none;"
   tabindex="-1"
   transparent=""
@@ -119,7 +113,6 @@
   no-spinner=""
   part="input"
   placeholder="08"
-  role="textbox"
   tabindex="0"
   transparent=""
 >
@@ -133,7 +126,6 @@
   no-spinner=""
   part="input"
   placeholder="16"
-  role="textbox"
   tabindex="0"
   transparent=""
 >
@@ -151,7 +143,6 @@
   no-spinner=""
   part="input"
   placeholder="08"
-  role="textbox"
   tabindex="0"
   transparent=""
 >
@@ -165,7 +156,6 @@
   no-spinner=""
   part="input"
   placeholder="16"
-  role="textbox"
   tabindex="0"
   transparent=""
 >
@@ -179,7 +169,6 @@
   no-spinner=""
   part="input"
   placeholder="32"
-  role="textbox"
   tabindex="0"
   transparent=""
 >
@@ -197,7 +186,6 @@
   no-spinner=""
   part="input"
   placeholder="01"
-  role="textbox"
   tabindex="0"
   transparent=""
 >
@@ -211,7 +199,6 @@
   no-spinner=""
   part="input"
   placeholder="30"
-  role="textbox"
   tabindex="0"
   transparent=""
 >

--- a/packages/elements/src/tree-select/__snapshots__/TreeSelect.md
+++ b/packages/elements/src/tree-select/__snapshots__/TreeSelect.md
@@ -8,7 +8,6 @@
 <div part="input-wrapper">
   <ef-text-field
     part="input"
-    role="textbox"
     tabindex="0"
     transparent=""
   >


### PR DESCRIPTION
## Description
It is wrong to have `aria-hidden` for focusable elements

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings