### PR TITLE
fix(halo-theme): fix import native-element path

### DIFF
--- a/packages/halo-theme/package.json
+++ b/packages/halo-theme/package.json
@@ -5,26 +5,6 @@
   "author": "Refinitiv",
   "license": "SEE LICENSE IN LICENSE",
   "main": "index.less",
-  "exports": {
-    "./dark/all-elements.js": {
-      "default": "./dark/imports/all-elements.js"
-    },
-    "./dark/custom-elements.js": {
-      "default": "./dark/imports/custom-elements.js"
-    },
-    "./dark/native-elements.js": {
-      "default": "./dark/imports/native-elements.js"
-    },
-    "./light/all-elements.js": {
-      "default": "./light/imports/all-elements.js"
-    },
-    "./light/custom-elements.js": {
-      "default": "./light/imports/custom-elements.js"
-    },
-    "./light/native-elements.js": {
-      "default": "./light/imports/native-elements.js"
-    }
-  },
   "repository": {
     "type": "git",
     "url": "git@github.com:Refinitiv/refinitiv-ui.git",


### PR DESCRIPTION
## Description
`import '@refinitiv-ui/halo-theme/dark/imports/native-elements';` does not work anymore because we don't export this path in package.json.

Error message is
```
Error: Module not found: Error: Package path ./dark/import/native-elements is not exported from package C:\Users\UC255417\w\angular13\node_modules\@refinitiv-ui\halo-theme (see exports field in C:\Users\UC255417\w\angular13\node_modules\@refinitiv-ui\halo-theme\package.json)
```

We should ensure that existing app who use import '@refinitiv-ui/halo-theme/dark/imports/native-elements'; won't break after upgrading to EF5.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings