### PR TITLE
chore: add incremental to TypeScript compiler option for faster subsequent builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17965,7 +17965,7 @@
     },
     "packages/core": {
       "name": "@refinitiv-ui/core",
-      "version": "5.3.3",
+      "version": "5.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@juggle/resize-observer": "^3.3.1",
@@ -17979,13 +17979,13 @@
     },
     "packages/demo-block": {
       "name": "@refinitiv-ui/demo-block",
-      "version": "5.1.3",
+      "version": "5.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@refinitiv-ui/core": "^5.3.3",
-        "@refinitiv-ui/elemental-theme": "^5.3.1",
-        "@refinitiv-ui/halo-theme": "^5.3.1",
-        "@refinitiv-ui/solar-theme": "^5.5.1",
+        "@refinitiv-ui/core": "^5.3.4",
+        "@refinitiv-ui/elemental-theme": "^5.4.1",
+        "@refinitiv-ui/halo-theme": "^5.4.1",
+        "@refinitiv-ui/solar-theme": "^5.6.1",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -17994,7 +17994,7 @@
     },
     "packages/elemental-theme": {
       "name": "@refinitiv-ui/elemental-theme",
-      "version": "5.3.1",
+      "version": "5.4.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@refinitiv-ui/theme-compiler": "^5.0.6"
@@ -18002,16 +18002,16 @@
     },
     "packages/elements": {
       "name": "@refinitiv-ui/elements",
-      "version": "5.8.1",
+      "version": "5.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@refinitiv-ui/browser-sparkline": "1.1.7",
-        "@refinitiv-ui/core": "^5.3.3",
-        "@refinitiv-ui/halo-theme": "^5.3.1",
-        "@refinitiv-ui/i18n": "^5.2.3",
-        "@refinitiv-ui/phrasebook": "^5.2.1",
-        "@refinitiv-ui/solar-theme": "^5.5.1",
-        "@refinitiv-ui/translate": "^5.2.3",
+        "@refinitiv-ui/core": "^5.3.4",
+        "@refinitiv-ui/halo-theme": "^5.4.1",
+        "@refinitiv-ui/i18n": "^5.2.5",
+        "@refinitiv-ui/phrasebook": "^5.4.0",
+        "@refinitiv-ui/solar-theme": "^5.6.1",
+        "@refinitiv-ui/translate": "^5.2.5",
         "@refinitiv-ui/utils": "^5.1.1",
         "@types/chart.js": "^2.9.31",
         "chart.js": "~2.9.4",
@@ -18021,17 +18021,17 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@refinitiv-ui/demo-block": "^5.1.3",
+        "@refinitiv-ui/demo-block": "^5.1.5",
         "@refinitiv-ui/test-helpers": "^5.1.1",
         "@types/d3-interpolate": "^3.0.1"
       }
     },
     "packages/halo-theme": {
       "name": "@refinitiv-ui/halo-theme",
-      "version": "5.3.1",
+      "version": "5.4.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@refinitiv-ui/elemental-theme": "^5.3.1"
+        "@refinitiv-ui/elemental-theme": "^5.4.1"
       },
       "devDependencies": {
         "@refinitiv-ui/theme-compiler": "^5.0.6"
@@ -18039,12 +18039,12 @@
     },
     "packages/i18n": {
       "name": "@refinitiv-ui/i18n",
-      "version": "5.2.3",
+      "version": "5.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@formatjs/icu-messageformat-parser": "^2.0.15",
         "@formatjs/intl-utils": "^3.8.4",
-        "@refinitiv-ui/phrasebook": "^5.2.1",
+        "@refinitiv-ui/phrasebook": "^5.4.0",
         "intl-format-cache": "^4.3.1",
         "intl-messageformat": "^9.10.0",
         "tslib": "^2.3.1"
@@ -18055,7 +18055,7 @@
     },
     "packages/phrasebook": {
       "name": "@refinitiv-ui/phrasebook",
-      "version": "5.2.1",
+      "version": "5.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -18083,10 +18083,10 @@
     },
     "packages/solar-theme": {
       "name": "@refinitiv-ui/solar-theme",
-      "version": "5.5.1",
+      "version": "5.6.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@refinitiv-ui/elemental-theme": "^5.3.1"
+        "@refinitiv-ui/elemental-theme": "^5.4.1"
       },
       "devDependencies": {
         "@refinitiv-ui/theme-compiler": "^5.0.6"
@@ -18560,16 +18560,16 @@
     },
     "packages/translate": {
       "name": "@refinitiv-ui/translate",
-      "version": "5.2.3",
+      "version": "5.2.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@refinitiv-ui/i18n": "^5.2.3",
-        "@refinitiv-ui/phrasebook": "^5.2.1",
+        "@refinitiv-ui/i18n": "^5.2.5",
+        "@refinitiv-ui/phrasebook": "^5.4.0",
         "lit": "^2.0.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@refinitiv-ui/core": "^5.3.3",
+        "@refinitiv-ui/core": "^5.3.4",
         "@refinitiv-ui/test-helpers": "^5.1.1"
       }
     },
@@ -22220,10 +22220,10 @@
     "@refinitiv-ui/demo-block": {
       "version": "file:packages/demo-block",
       "requires": {
-        "@refinitiv-ui/core": "^5.3.3",
-        "@refinitiv-ui/elemental-theme": "^5.3.1",
-        "@refinitiv-ui/halo-theme": "^5.3.1",
-        "@refinitiv-ui/solar-theme": "^5.5.1",
+        "@refinitiv-ui/core": "^5.3.4",
+        "@refinitiv-ui/elemental-theme": "^5.4.1",
+        "@refinitiv-ui/halo-theme": "^5.4.1",
+        "@refinitiv-ui/solar-theme": "^5.6.1",
         "@refinitiv-ui/test-helpers": "^5.1.1",
         "tslib": "^2.3.1"
       }
@@ -22238,14 +22238,14 @@
       "version": "file:packages/elements",
       "requires": {
         "@refinitiv-ui/browser-sparkline": "1.1.7",
-        "@refinitiv-ui/core": "^5.3.3",
-        "@refinitiv-ui/demo-block": "^5.1.3",
-        "@refinitiv-ui/halo-theme": "^5.3.1",
-        "@refinitiv-ui/i18n": "^5.2.3",
-        "@refinitiv-ui/phrasebook": "^5.2.1",
-        "@refinitiv-ui/solar-theme": "^5.5.1",
+        "@refinitiv-ui/core": "^5.3.4",
+        "@refinitiv-ui/demo-block": "^5.1.5",
+        "@refinitiv-ui/halo-theme": "^5.4.1",
+        "@refinitiv-ui/i18n": "^5.2.5",
+        "@refinitiv-ui/phrasebook": "^5.4.0",
+        "@refinitiv-ui/solar-theme": "^5.6.1",
         "@refinitiv-ui/test-helpers": "^5.1.1",
-        "@refinitiv-ui/translate": "^5.2.3",
+        "@refinitiv-ui/translate": "^5.2.5",
         "@refinitiv-ui/utils": "^5.1.1",
         "@types/chart.js": "^2.9.31",
         "@types/d3-interpolate": "^3.0.1",
@@ -22259,7 +22259,7 @@
     "@refinitiv-ui/halo-theme": {
       "version": "file:packages/halo-theme",
       "requires": {
-        "@refinitiv-ui/elemental-theme": "^5.3.1",
+        "@refinitiv-ui/elemental-theme": "^5.4.1",
         "@refinitiv-ui/theme-compiler": "^5.0.6"
       }
     },
@@ -22268,7 +22268,7 @@
       "requires": {
         "@formatjs/icu-messageformat-parser": "^2.0.15",
         "@formatjs/intl-utils": "^3.8.4",
-        "@refinitiv-ui/phrasebook": "^5.2.1",
+        "@refinitiv-ui/phrasebook": "^5.4.0",
         "@refinitiv-ui/test-helpers": "^5.1.1",
         "intl-format-cache": "^4.3.1",
         "intl-messageformat": "^9.10.0",
@@ -22300,7 +22300,7 @@
     "@refinitiv-ui/solar-theme": {
       "version": "file:packages/solar-theme",
       "requires": {
-        "@refinitiv-ui/elemental-theme": "^5.3.1",
+        "@refinitiv-ui/elemental-theme": "^5.4.1",
         "@refinitiv-ui/theme-compiler": "^5.0.6"
       }
     },
@@ -22660,9 +22660,9 @@
     "@refinitiv-ui/translate": {
       "version": "file:packages/translate",
       "requires": {
-        "@refinitiv-ui/core": "^5.3.3",
-        "@refinitiv-ui/i18n": "^5.2.3",
-        "@refinitiv-ui/phrasebook": "^5.2.1",
+        "@refinitiv-ui/core": "^5.3.4",
+        "@refinitiv-ui/i18n": "^5.2.5",
+        "@refinitiv-ui/phrasebook": "^5.4.0",
         "@refinitiv-ui/test-helpers": "^5.1.1",
         "lit": "^2.0.0",
         "tslib": "^2.3.1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@refinitiv-ui/configurations/tsconfig.json"
+  "extends": "@refinitiv-ui/configurations/tsconfig.json",
+  "compilerOptions": {
+    "incremental": true
+  }
 }


### PR DESCRIPTION
`incremental` compiler option was introduced in [TS3.4](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#faster-subsequent-builds-with-the---incremental-flag). 

- This can reduces over 50% of build time on subsequent builds by using build information from `.tsbuildinfo`
- `.tsbuildinfo` should not be committed