### PR TITLE
Fix/pagination handle input number with string

### DIFF
--- a/packages/elements/src/pagination/index.ts
+++ b/packages/elements/src/pagination/index.ts
@@ -369,7 +369,7 @@ export class Pagination extends BasicElement {
   }
 
   /**
-   * Validate integer value
+   * Validate page value which returns true when value is valid
    * @param value value
    * @param warning show warning message when value is invalid
    * @param propName property name to show in warning message
@@ -449,7 +449,8 @@ export class Pagination extends BasicElement {
       }
       this.value = newValue.toString();
     }
-    else if (!isNaN(newValue)) {
+    // When input value is invalid in case less than support range (value<1), then reset value = '1'.
+    else if (!isNaN(newValue) && newValue < 1) {
       this.value = '1';
     }
 

--- a/packages/elements/src/pagination/index.ts
+++ b/packages/elements/src/pagination/index.ts
@@ -444,10 +444,7 @@ export class Pagination extends BasicElement {
 
     // Reset input and boundary value into supported range.
     if (this.validatePage(this.input.value)) {
-      if (newValue <= 0) {
-        newValue = 1;
-      }
-      else if (newValue > this.internalMax) {
+      if (newValue > this.internalMax) {
         newValue = this.internalMax;
       }
       this.value = newValue.toString();


### PR DESCRIPTION
## Description
Refer to https://github.com/Refinitiv/refinitiv-ui/pull/77#pullrequestreview-836280840
Trem found a bug that value will to be '1' when user input '8.t' (any number with string). 

### Step to reproduce: 
1. Log to know the current value
2. Set as user input by '8.t' or any number with string.
3. Value will be '1' that expected result should be ignore changing.

### Expected Results:
The value should be ignore changing.

### Actual Results:
The value set to be '1'. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings