### PR TITLE
fix: release script should not be publish to NPM

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -43,3 +43,6 @@ tsconfig.json
 
 # map files
 /lib/**/*.map
+
+# scriptes
+/scripts/**/*


### PR DESCRIPTION
Ignore release scripts when publish to NPM 

You can test this by running `npm publish --dry-run` scripts should not be on filelist. 