### PR TITLE
chore: add development mode to dev-server so that developers can see …

### DIFF
--- a/server.config.js
+++ b/server.config.js
@@ -11,7 +11,9 @@ module.exports = {
   rootDir: ROOT,
   open: true,
   watch: false,
-  nodeResolve: true,
+  nodeResolve: {
+    exportConditions: ['development'],
+  },
   preserveSymlinks: true,
   appIndex: '/',
   plugins: [


### PR DESCRIPTION
Add development mode to dev-server so that developers can see warnings from our dependencies.

After this option turned on, we should be able to see a warning from `Lit`,

`
Lit is in dev mode. Not recommended for production! See https://lit.dev/msg/dev-mode for more information.`
