### PR TITLE
fix: `Enter` should not check/uncheck radio and checkbox

### DIFF
--- a/packages/elements/src/checkbox/__test__/checkbox.test.js
+++ b/packages/elements/src/checkbox/__test__/checkbox.test.js
@@ -239,25 +239,26 @@ describe('checkbox/Checkbox', () => {
   describe('Keypress Enter Event', () => {
     let enterEvent;
     describe('Check / Unchecked State', () => {
-      it('can be checked by pressed Enter on the checkbox', async () => {
+      it('should not be able to check when Enter key is pressed', async () => {
         enterEvent = createEnterKeyboardEvent();
         el = await fixture(unchecked);
+        expect(el.checked).to.equal(false);
+        el.dispatchEvent(enterEvent);
+        await elementUpdated(el);
+        expect(el.checked).to.equal(false);
+      });
+      it('should not be able to uncheck when Enter key is pressed', async () => {
+        enterEvent = createEnterKeyboardEvent();
+        el = await fixture(checked);
+        expect(el.checked).to.equal(true);
         el.dispatchEvent(enterEvent);
         await elementUpdated(el);
         expect(el.checked).to.equal(true);
       });
-      it('should fired an checked-changed event on press Enter and has the correct value', async () => {
-        enterEvent = createEnterKeyboardEvent();
-        el = await fixture(unchecked);
-        const onChecked = () => el.dispatchEvent(enterEvent);
-        setTimeout(onChecked);
-        const e = await oneEvent(el, 'checked-changed');
-        expect(e.target.checked).to.equal(true);
-      });
     });
 
     describe('Disabled State', () => {
-      it('should not be able to press Enter when disabled', async () => {
+      it('should do nothing when Enter key is pressed', async () => {
         enterEvent = createEnterKeyboardEvent();
         el = await fixture(disabled);
         expect(el.disabled).to.equal(true);
@@ -269,7 +270,7 @@ describe('checkbox/Checkbox', () => {
     });
 
     describe('Readonly State', () => {
-      it('should not be able to press Enter when readonly', async () => {
+      it('should do nothing when Enter key is pressed', async () => {
         enterEvent = createEnterKeyboardEvent();
         el = await fixture(readonly);
         expect(el.readonly).to.equal(true);
@@ -280,29 +281,13 @@ describe('checkbox/Checkbox', () => {
       });
     });
     describe('Indeterminate State', () => {
-      it('can be checked by pressed Enter on the checkbox', async () => {
+      it('should not check on Enter key pressed', async () => {
         enterEvent = createEnterKeyboardEvent();
         el = await fixture(indeterminate);
         el.dispatchEvent(enterEvent);
         await elementUpdated(el);
-        expect(el.checked).to.equal(true);
-        expect(el.indeterminate).to.equal(false);
-      });
-      it('should have a correct state when users press Enter as indeterminate => checked => unchecked => checked', async () => {
-        enterEvent = createEnterKeyboardEvent();
-        el = await fixture(indeterminate);
-        el.dispatchEvent(enterEvent);
-        await elementUpdated(el);
-        expect(el.indeterminate).to.equal(false);
-        expect(el.checked).to.equal(true);
-        el.dispatchEvent(enterEvent);
-        await elementUpdated(el);
-        expect(el.indeterminate).to.equal(false);
         expect(el.checked).to.equal(false);
-        el.dispatchEvent(enterEvent);
-        await elementUpdated(el);
-        expect(el.indeterminate).to.equal(false);
-        expect(el.checked).to.equal(true);
+        expect(el.indeterminate).to.equal(true);
       });
     });
   });

--- a/packages/elements/src/checkbox/index.ts
+++ b/packages/elements/src/checkbox/index.ts
@@ -172,7 +172,6 @@ export class Checkbox extends ControlElement {
     }
 
     switch (event.key) {
-      case 'Enter':
       case ' ':
       case 'Spacebar':
         this.handleChangeChecked();

--- a/packages/elements/src/radio-button/__test__/radio-button.test.js
+++ b/packages/elements/src/radio-button/__test__/radio-button.test.js
@@ -71,21 +71,6 @@ describe('radio-button/RadioButton', () => {
       expect(unchecked.checked).to.equal(true, 'property is checked');
       expect(event.detail.value).to.equal(true, 'property is checked');
     });
-    it('Should fire event and changes its state to checked when using Enter key', async () => {
-      const event = createEnterKeyboardEvent();
-
-      window.setTimeout(() => {
-        unchecked.dispatchEvent(event);
-      });
-
-      const { detail } = await oneEvent(unchecked, 'checked-changed');
-      await elementUpdated(unchecked);
-
-      expect(detail.value).to.equal(true, 'checked-changed event is fired');
-
-      expect(unchecked.checked).to.equal(true, 'property is checked');
-      expect(unchecked.hasAttribute('checked')).to.equal(true, 'attribute is checked');
-    });
     it('Should fire event and changes its state to checked when using Space key', async () => {
       const event = createSpacebarKeyboardEvent();
 
@@ -308,6 +293,17 @@ describe('radio-button/RadioButton', () => {
 
       expect(group[0].checked).to.equal(false);
       expect(group[1].checked).to.equal(false);
+    });
+    it('Should not be able to check by Enter key', async () => {
+      const group = [
+        await fixture('<ef-radio-button name="group2">group2</ef-radio-button>'),
+        await fixture('<ef-radio-button name="group2">group2</ef-radio-button>')
+      ];
+      const event = createEnterKeyboardEvent();
+      group[0].dispatchEvent(event);
+      await updateGroup(group);
+
+      expect(group[0].checked).to.equal(false);
     });
     it('Should not be able to uncheck by Enter key', async () => {
       const group = [

--- a/packages/elements/src/radio-button/index.ts
+++ b/packages/elements/src/radio-button/index.ts
@@ -208,7 +208,6 @@ export class RadioButton extends ControlElement {
       return;
     }
     switch (event.key) {
-      case 'Enter':
       case ' ':
       case 'Spacebar':
         if (this.readonly) {


### PR DESCRIPTION
## Description

See, 
 - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox
 - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio

Native checkbox and radio button can only be toggle via `Space` key. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings