### PR TITLE
fix(radio-button): add IE11 arrow keys navigation support

### DIFF
--- a/packages/elements/src/radio-button/__test__/radio-button.test.js
+++ b/packages/elements/src/radio-button/__test__/radio-button.test.js
@@ -4,8 +4,8 @@ import '@refinitiv-ui/elemental-theme/light/ef-radio-button';
 
 const createEnterKeyboardEvent = () => keyboardEvent('keydown', { key: 'Enter' });
 const createSpacebarKeyboardEvent = () => keyboardEvent('keydown', { key: isIE() ? 'Spacebar' : ' ' });
-const keyArrowLeft = () => keyboardEvent('keydown', { key: 'ArrowLeft'});
-const keyArrowRight = () => keyboardEvent('keydown', { key: 'ArrowRight'});
+const keyArrowLeft = () => keyboardEvent('keydown', { key: isIE() ? 'Left' : 'ArrowLeft'});
+const keyArrowRight = () => keyboardEvent('keydown', { key: isIE() ? 'Right' : 'ArrowRight'});
 
 const updateGroup = async (group) => {
   for (let i = 0; i < group.length; i += 1) {

--- a/packages/elements/src/radio-button/index.ts
+++ b/packages/elements/src/radio-button/index.ts
@@ -207,6 +207,7 @@ export class RadioButton extends ControlElement {
     if (this.disabled || event.defaultPrevented) {
       return;
     }
+
     switch (event.key) {
       case 'Enter':
       case ' ':
@@ -216,10 +217,14 @@ export class RadioButton extends ControlElement {
         }
         this.handleChangeChecked();
         break;
+      case 'Right':
+      case 'Down':
       case 'ArrowRight':
       case 'ArrowDown':
         this.navigateToSibling('next');
         break;
+      case 'Left':
+      case 'Up':
       case 'ArrowLeft':
       case 'ArrowUp':
         this.navigateToSibling('previous');


### PR DESCRIPTION
## Description

Adds `IE11` arrow keys navigation support. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings