### PR TITLE
fix(checkbox): wrong cursor style when hover the end of checkbox label

### DIFF
--- a/packages/halo-theme/src/shared-styles/checkbox.less
+++ b/packages/halo-theme/src/shared-styles/checkbox.less
@@ -2,12 +2,15 @@
   --check-color: @checkbox-checked-color;
   color: @control-text-color;
 
+  &:not([readonly]) {
+    [part='container'] {  
+      cursor: pointer;
+    }
+  }
+  
   [part='container'] {
     width: 14px;
     height: 14px;
-    &:not([readonly]) {
-      cursor: pointer;
-    }
   }
 
   [part='check'] {

--- a/packages/halo-theme/src/shared-styles/checkbox.less
+++ b/packages/halo-theme/src/shared-styles/checkbox.less
@@ -2,13 +2,12 @@
   --check-color: @checkbox-checked-color;
   color: @control-text-color;
 
-  &:not([readonly]) {
-    cursor: pointer;
-  }
-
   [part='container'] {
     width: 14px;
     height: 14px;
+    &:not([readonly]) {
+      cursor: pointer;
+    }
   }
 
   [part='check'] {
@@ -17,7 +16,7 @@
   }
 
   &:hover {
-    &:not([checked]):not([readonly]) [part='container'] {
+    &:not([checked]):not([indeterminate]):not([readonly]) [part='container'] {
       border-color: @input-hover-border-color;
     }
     &:not([readonly]) {


### PR DESCRIPTION
## Description
When hover at the end of checkbox label, it shows wrong cursor style. Cursor pointer should only use when hover on the tick box. Same problem with radio button.

Fixes # ELF-1648

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings