### PR TITLE
fix(tree-select): remove unnecessary x-scrollbar on default styles

### DIFF
--- a/packages/halo-theme/src/custom-elements/ef-tree-select.less
+++ b/packages/halo-theme/src/custom-elements/ef-tree-select.less
@@ -3,7 +3,7 @@
 
 :host {
   @list-max-height: var(--list-max-height, 400px);
-  @panel-width: var(--panel-width, unit((@input-width * 2), px));
+  @panel-width: var(--panel-width, 320px);
   width: unit((@input-width * 1.5), px);
   
   [part~=filter-control], [part~=tree-control] {


### PR DESCRIPTION
## Description
Default width of inner panel in Tree Select is too small so x-scrollbar. 

Fixes # ELF-1305

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings