### PR TITLE
feat(collapse): add accessibility

### DIFF
--- a/packages/elemental-theme/src/custom-elements/ef-collapse.less
+++ b/packages/elemental-theme/src/custom-elements/ef-collapse.less
@@ -1,22 +1,41 @@
 @import 'element:ef-panel';
-@import 'element:ef-header';
 @import 'element:ef-icon';
 @import '../responsive';
+@import '../shared-styles/header';
 
 :host {
-  [focused="visible"] {
+  &[focused="visible"] [part~=header-toggle]:focus [part~=header-label] {
     outline: 1px solid @color-scheme-primary;
   }
 
+  [part~=header-wrapper] {
+    .header-defaults;
+    padding: 0;
+    align-items: stretch;
+  }
+
+  [part="spacer"] {
+    flex: none;
+    width: extract(@header-padding, 2);
+  }
+
   [part="header-toggle"] {
-    flex: 1 1 auto;
+    cursor: pointer;
+    .touch-action();
+    align-items: center;
+    outline: none;
+  }
+
+  [part="header-label"] {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   [part="toggle"] {
     transition: @global-transition-duration @global-transition-easing;
     opacity: .5;
     margin-right: 0.5em;
-    margin-left: 0.8em;
     flex-shrink: 0;
   }
 
@@ -24,10 +43,10 @@
     transform: rotate(90deg);
   }
 
-  [part="header"] {
-    display: flex;
-    align-items: center;
-    .touch-action();
+  [part="header-wrapper"] ::slotted(*) {
+    margin-top: 0;
+    margin-bottom: 0;
+    vertical-align: middle;
   }
 
   @keyframes expand {
@@ -53,6 +72,10 @@
   [part="content"] {
     animation-duration: @global-transition-duration;
     animation-timing-function: @global-transition-easing;
+  }
+
+  [part~=content-data] {
+    overflow: auto;
   }
 
   &:not([expanded]) {

--- a/packages/elemental-theme/src/custom-elements/ef-collapse.less
+++ b/packages/elemental-theme/src/custom-elements/ef-collapse.less
@@ -14,14 +14,10 @@
     align-items: stretch;
   }
 
-  [part="spacer"] {
-    flex: none;
-    width: extract(@header-padding, 2);
-  }
-
   [part="header-toggle"] {
-    cursor: pointer;
     .touch-action();
+    cursor: pointer;
+    padding: 0 extract(@header-padding, 2);
     align-items: center;
     outline: none;
   }

--- a/packages/elements/src/collapse/__demo__/index.html
+++ b/packages/elements/src/collapse/__demo__/index.html
@@ -11,7 +11,7 @@
       }
       .badge {
         border-radius: 100%;
-        height: 19;
+        height: 19px;
         width: 19px;
         font-size: 12px;
         line-height: 18px;
@@ -19,6 +19,15 @@
         box-sizing: border-box;
         display: flex;
         justify-content: center;
+        margin: auto 0;
+      }
+      .status {
+        display: inline-flex;
+        width: 3px;
+        background-color: #2a9d54;
+      }
+      .status.red {
+        background-color: #e31414;
       }
       .overflow {
         background: red;
@@ -29,8 +38,11 @@
         height: 200%;
       }
       .checkbox {
-        margin: 5px;
-        margin-right: 0px;
+        margin: auto 5px;
+      }
+      .menu {
+        color: currentColor;
+        margin: auto 0;
       }
     </style>
   </head>
@@ -43,7 +55,7 @@
     </script>
 
     <demo-block header="Default" layout="normal">
-      <ef-collapse header="Collapsible">
+      <ef-collapse header="Collapsible Collapsible Collapsible Collapsible Collapsible Collapsible Collapsible">
         <div class="content">Content inside a div with a fixed 100px height</div>
       </ef-collapse>
     </demo-block>
@@ -83,41 +95,26 @@
 
     <demo-block header="Use Slot" layout="normal" tags="slot">
       <ef-collapse header="Close above 14D SMA">
-        <div style="
-            display: inline-flex;
-            width: 3px;
-            height: 27px;
-            background-color: #2a9d54;
-        " slot="header-left"></div>
+        <div class="status" slot="header-left"></div>
         <ef-checkbox slot="header-left" class="checkbox"></ef-checkbox>
         <div slot="header-right" class="badge">8</div>
-        <ef-button slot="header-right" icon="menu" transparent></ef-button>
+        <ef-button slot="header-right" icon="menu" class="menu" transparent></ef-button>
         <div class="content">Content inside a div with a fixed 100px height</div>
       </ef-collapse>
       <ef-collapse header="Close below 14D SMA">
-        <div style="
-            display: inline-flex;
-            width: 3px;
-            height: 27px;
-            background-color: #e31414;
-        " slot="header-left"></div>
+        <div class="status red" slot="header-left"></div>
         <ef-checkbox slot="header-left" class="checkbox"></ef-checkbox>
         <div slot="header-right" class="badge">8</div>
-        <ef-button slot="header-right" icon="menu" transparent></ef-button>
+        <ef-button slot="header-right" icon="menu" class="menu" transparent></ef-button>
         <div class="content">Content inside a div with a fixed 100px height</div>
       </ef-collapse>
       <ef-collapse header="New 52 week high">
-        <div style="
-            display: inline-flex;
-            width: 3px;
-            height: 27px;
-            background-color: #2a9d54;
-        " slot="header-left"></div>
+        <div class="status" slot="header-left"></div>
         <ef-checkbox slot="header-left" class="checkbox"></ef-checkbox>
         <div slot="header-right" class="badge">8</div>
-        <ef-button slot="header-right" icon="menu" transparent></ef-button>
+        <ef-button slot="header-right" icon="menu" class="menu" transparent></ef-button>
         <div class="content">Content inside a div with a fixed 100px height</div>
-      </ef-collapse>            
+      </ef-collapse>
     </demo-block>
 
     <demo-block header="Prevent Expanding" layout="normal" tags="cancel event">

--- a/packages/elements/src/collapse/index.ts
+++ b/packages/elements/src/collapse/index.ts
@@ -116,7 +116,6 @@ export class Collapse extends BasicElement {
   @state()
   private headingLevel: string | null = null;
 
-
   public attributeChangedCallback (name: string, oldValue: string | null, newValue: string | null): void {
     super.attributeChangedCallback(name, oldValue, newValue);
     if (name === 'aria-level') {

--- a/packages/elements/src/collapse/index.ts
+++ b/packages/elements/src/collapse/index.ts
@@ -191,9 +191,7 @@ export class Collapse extends BasicElement {
   protected render (): TemplateResult {
     return html`
       <div part="header-wrapper" level="${this.level}">
-        <slot name="header-left">
-          <div part="spacer"></div>
-        </slot>
+        <slot name="header-left"></slot>
         <div part="header"
              role="heading"
              aria-level="${ifDefined(this.headingLevel || undefined)}">
@@ -207,9 +205,7 @@ export class Collapse extends BasicElement {
             <span part="header-label">${this.header}</span>
           </div>
         </div>
-        <slot name="header-right">
-          <div part="spacer"></div>
-        </slot>
+        <slot name="header-right"></slot>
       </div>
       <div id="content" part="content" role="region" aria-labelledby="header-toggle">
         <ef-panel part="content-data" ?spacing="${this.spacing}" transparent>

--- a/packages/elements/src/collapse/index.ts
+++ b/packages/elements/src/collapse/index.ts
@@ -54,9 +54,6 @@ export class Collapse extends BasicElement {
         flex: 1 1 auto;
         min-width: 0;
       }
-      [part="toggle"] {
-        flex: none;
-      }
       [part="content"]  {
         overflow: hidden;
         box-sizing: border-box;

--- a/packages/elements/src/collapse/index.ts
+++ b/packages/elements/src/collapse/index.ts
@@ -194,7 +194,8 @@ export class Collapse extends BasicElement {
         <div part="header"
              role="heading"
              aria-level="${ifDefined(this.headingLevel || undefined)}">
-          <div part="header-toggle"
+          <div id="header-toggle"
+               part="header-toggle"
                role="button"
                tabindex="0"
                aria-expanded="${this.expanded}"


### PR DESCRIPTION
I have made a draft of what I think it should be. It works fine apart of these things:
1) I cannot use ef-header because it would not overflow text correctly in this scenario
2) I cannot use spacers to correctly pad slots (as in that case clickable area would not include these spacers). Do not think this is a big issue anyway. If really required this can be calculated programmatically.

... and I have not tested that with screen readers, hope it works :)

re: @TremayneChrist