### PR TITLE
fix: fix lit to v2.1.2 as v2.1.3 has issue with SkyPack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,10 +54,10 @@
     },
     "documents": {
       "name": "@refinitiv-ui/docs",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@refinitiv-ui/elements": "^5.11.0",
+        "@refinitiv-ui/elements": "^5.12.0",
         "fast-glob": "^3.2.7",
         "fs-extra": "^10.0.0"
       },
@@ -12074,9 +12074,9 @@
       }
     },
     "node_modules/lit": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.1.1.tgz",
-      "integrity": "sha512-yqDqf36IhXwOxIQSFqCMgpfvDCRdxLCLZl7m/+tO5C9W/OBHUj17qZpiMBT35v97QMVKcKEi1KZ3hZRyTwBNsQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.1.2.tgz",
+      "integrity": "sha512-XacK89dJXF7BJbpiZSMvzT4RxHag7Wt+yNx7tErEVgGVlOFAeN871bj7ivotCMgYeBFWVp/hjKF/PDTk6L7gMA==",
       "dependencies": {
         "@lit/reactive-element": "^1.1.0",
         "lit-element": "^3.1.0",
@@ -18120,7 +18120,7 @@
     },
     "packages/configurations": {
       "name": "@refinitiv-ui/configurations",
-      "version": "5.2.1",
+      "version": "5.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.23.0",
@@ -18134,12 +18134,12 @@
     },
     "packages/core": {
       "name": "@refinitiv-ui/core",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@juggle/resize-observer": "^3.3.1",
-        "@refinitiv-ui/utils": "^5.1.1",
-        "lit": "~2.1.1",
+        "@refinitiv-ui/utils": "^5.1.2",
+        "lit": "2.1.2",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -18148,13 +18148,13 @@
     },
     "packages/demo-block": {
       "name": "@refinitiv-ui/demo-block",
-      "version": "5.1.7",
+      "version": "5.1.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@refinitiv-ui/core": "^5.4.0",
-        "@refinitiv-ui/elemental-theme": "^5.4.2",
-        "@refinitiv-ui/halo-theme": "^5.4.3",
-        "@refinitiv-ui/solar-theme": "^5.6.2",
+        "@refinitiv-ui/core": "^5.4.1",
+        "@refinitiv-ui/elemental-theme": "^5.5.0",
+        "@refinitiv-ui/halo-theme": "^5.5.0",
+        "@refinitiv-ui/solar-theme": "^5.7.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -18163,25 +18163,25 @@
     },
     "packages/elemental-theme": {
       "name": "@refinitiv-ui/elemental-theme",
-      "version": "5.4.2",
+      "version": "5.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@refinitiv-ui/theme-compiler": "^5.0.7"
+        "@refinitiv-ui/theme-compiler": "^5.0.8"
       }
     },
     "packages/elements": {
       "name": "@refinitiv-ui/elements",
-      "version": "5.11.0",
+      "version": "5.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@refinitiv-ui/browser-sparkline": "1.1.7",
-        "@refinitiv-ui/core": "^5.4.0",
-        "@refinitiv-ui/halo-theme": "^5.4.3",
+        "@refinitiv-ui/core": "^5.4.1",
+        "@refinitiv-ui/halo-theme": "^5.5.0",
         "@refinitiv-ui/i18n": "^5.2.6",
         "@refinitiv-ui/phrasebook": "^5.4.1",
-        "@refinitiv-ui/solar-theme": "^5.6.2",
-        "@refinitiv-ui/translate": "^5.3.0",
-        "@refinitiv-ui/utils": "^5.1.1",
+        "@refinitiv-ui/solar-theme": "^5.7.0",
+        "@refinitiv-ui/translate": "^5.3.1",
+        "@refinitiv-ui/utils": "^5.1.2",
         "@types/chart.js": "^2.9.31",
         "chart.js": "~2.9.4",
         "d3-interpolate": "^3.0.1",
@@ -18190,20 +18190,20 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@refinitiv-ui/demo-block": "^5.1.7",
+        "@refinitiv-ui/demo-block": "^5.1.8",
         "@refinitiv-ui/test-helpers": "^5.1.2",
         "@types/d3-interpolate": "^3.0.1"
       }
     },
     "packages/halo-theme": {
       "name": "@refinitiv-ui/halo-theme",
-      "version": "5.4.3",
+      "version": "5.5.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@refinitiv-ui/elemental-theme": "^5.4.2"
+        "@refinitiv-ui/elemental-theme": "^5.5.0"
       },
       "devDependencies": {
-        "@refinitiv-ui/theme-compiler": "^5.0.7"
+        "@refinitiv-ui/theme-compiler": "^5.0.8"
       }
     },
     "packages/i18n": {
@@ -18252,13 +18252,13 @@
     },
     "packages/solar-theme": {
       "name": "@refinitiv-ui/solar-theme",
-      "version": "5.6.2",
+      "version": "5.7.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@refinitiv-ui/elemental-theme": "^5.4.2"
+        "@refinitiv-ui/elemental-theme": "^5.5.0"
       },
       "devDependencies": {
-        "@refinitiv-ui/theme-compiler": "^5.0.7"
+        "@refinitiv-ui/theme-compiler": "^5.0.8"
       }
     },
     "packages/test-helpers": {
@@ -18653,7 +18653,7 @@
     },
     "packages/theme-compiler": {
       "name": "@refinitiv-ui/theme-compiler",
-      "version": "5.0.7",
+      "version": "5.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "autoprefixer": "^10.4.2",
@@ -18776,7 +18776,7 @@
     },
     "packages/translate": {
       "name": "@refinitiv-ui/translate",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@refinitiv-ui/i18n": "^5.2.6",
@@ -18785,13 +18785,13 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@refinitiv-ui/core": "^5.4.0",
+        "@refinitiv-ui/core": "^5.4.1",
         "@refinitiv-ui/test-helpers": "^5.1.2"
       }
     },
     "packages/utils": {
       "name": "@refinitiv-ui/utils",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/d3-color": "^3.0.2",
@@ -22029,18 +22029,18 @@
       "requires": {
         "@juggle/resize-observer": "^3.3.1",
         "@refinitiv-ui/test-helpers": "^5.1.2",
-        "@refinitiv-ui/utils": "^5.1.1",
-        "lit": "~2.1.1",
+        "@refinitiv-ui/utils": "^5.1.2",
+        "lit": "2.1.2",
         "tslib": "^2.3.1"
       }
     },
     "@refinitiv-ui/demo-block": {
       "version": "file:packages/demo-block",
       "requires": {
-        "@refinitiv-ui/core": "^5.4.0",
-        "@refinitiv-ui/elemental-theme": "^5.4.2",
-        "@refinitiv-ui/halo-theme": "^5.4.3",
-        "@refinitiv-ui/solar-theme": "^5.6.2",
+        "@refinitiv-ui/core": "^5.4.1",
+        "@refinitiv-ui/elemental-theme": "^5.5.0",
+        "@refinitiv-ui/halo-theme": "^5.5.0",
+        "@refinitiv-ui/solar-theme": "^5.7.0",
         "@refinitiv-ui/test-helpers": "^5.1.2",
         "tslib": "^2.3.1"
       }
@@ -22048,7 +22048,7 @@
     "@refinitiv-ui/docs": {
       "version": "file:documents",
       "requires": {
-        "@refinitiv-ui/elements": "^5.11.0",
+        "@refinitiv-ui/elements": "^5.12.0",
         "chalk": "^4.1.2",
         "concurrently": "^6.4.0",
         "fast-glob": "^3.2.7",
@@ -22081,22 +22081,22 @@
     "@refinitiv-ui/elemental-theme": {
       "version": "file:packages/elemental-theme",
       "requires": {
-        "@refinitiv-ui/theme-compiler": "^5.0.7"
+        "@refinitiv-ui/theme-compiler": "^5.0.8"
       }
     },
     "@refinitiv-ui/elements": {
       "version": "file:packages/elements",
       "requires": {
         "@refinitiv-ui/browser-sparkline": "1.1.7",
-        "@refinitiv-ui/core": "^5.4.0",
-        "@refinitiv-ui/demo-block": "^5.1.7",
-        "@refinitiv-ui/halo-theme": "^5.4.3",
+        "@refinitiv-ui/core": "^5.4.1",
+        "@refinitiv-ui/demo-block": "^5.1.8",
+        "@refinitiv-ui/halo-theme": "^5.5.0",
         "@refinitiv-ui/i18n": "^5.2.6",
         "@refinitiv-ui/phrasebook": "^5.4.1",
-        "@refinitiv-ui/solar-theme": "^5.6.2",
+        "@refinitiv-ui/solar-theme": "^5.7.0",
         "@refinitiv-ui/test-helpers": "^5.1.2",
-        "@refinitiv-ui/translate": "^5.3.0",
-        "@refinitiv-ui/utils": "^5.1.1",
+        "@refinitiv-ui/translate": "^5.3.1",
+        "@refinitiv-ui/utils": "^5.1.2",
         "@types/chart.js": "^2.9.31",
         "@types/d3-interpolate": "^3.0.1",
         "chart.js": "~2.9.4",
@@ -22109,8 +22109,8 @@
     "@refinitiv-ui/halo-theme": {
       "version": "file:packages/halo-theme",
       "requires": {
-        "@refinitiv-ui/elemental-theme": "^5.4.2",
-        "@refinitiv-ui/theme-compiler": "^5.0.7"
+        "@refinitiv-ui/elemental-theme": "^5.5.0",
+        "@refinitiv-ui/theme-compiler": "^5.0.8"
       }
     },
     "@refinitiv-ui/i18n": {
@@ -22150,8 +22150,8 @@
     "@refinitiv-ui/solar-theme": {
       "version": "file:packages/solar-theme",
       "requires": {
-        "@refinitiv-ui/elemental-theme": "^5.4.2",
-        "@refinitiv-ui/theme-compiler": "^5.0.7"
+        "@refinitiv-ui/elemental-theme": "^5.5.0",
+        "@refinitiv-ui/theme-compiler": "^5.0.8"
       }
     },
     "@refinitiv-ui/test-helpers": {
@@ -22492,7 +22492,7 @@
     "@refinitiv-ui/translate": {
       "version": "file:packages/translate",
       "requires": {
-        "@refinitiv-ui/core": "^5.4.0",
+        "@refinitiv-ui/core": "^5.4.1",
         "@refinitiv-ui/i18n": "^5.2.6",
         "@refinitiv-ui/phrasebook": "^5.4.1",
         "@refinitiv-ui/test-helpers": "^5.1.2",
@@ -28601,9 +28601,9 @@
       }
     },
     "lit": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.1.1.tgz",
-      "integrity": "sha512-yqDqf36IhXwOxIQSFqCMgpfvDCRdxLCLZl7m/+tO5C9W/OBHUj17qZpiMBT35v97QMVKcKEi1KZ3hZRyTwBNsQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.1.2.tgz",
+      "integrity": "sha512-XacK89dJXF7BJbpiZSMvzT4RxHag7Wt+yNx7tErEVgGVlOFAeN871bj7ivotCMgYeBFWVp/hjKF/PDTk6L7gMA==",
       "requires": {
         "@lit/reactive-element": "^1.1.0",
         "lit-element": "^3.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@juggle/resize-observer": "^3.3.1",
     "@refinitiv-ui/utils": "^5.1.2",
-    "lit": "~2.1.1",
+    "lit": "2.1.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Lit v2.1.3 breaks on SkyPack CDN.
ref: https://github.com/skypackjs/skypack-cdn/issues/255

Fix Lit to v2.1.2 for now, otherwise, demo block on Doc won't work.