### PR TITLE
fix(radio-button): radio name should be unique within its own scope

### DIFF
--- a/packages/elements/src/radio-button/__test__/radio-button.test.js
+++ b/packages/elements/src/radio-button/__test__/radio-button.test.js
@@ -447,6 +447,21 @@ describe('radio-button/RadioButton', () => {
       const checkedRadio = group.find(element => element.checked);
       expect(checkedRadio.id).to.equal('btn2');
     });
+    it('Should separate scope between shadow dom and light dom', async () => {
+      const radio = await fixture('<ef-radio-button name="group" id="btn1" checked>1</ef-radio-button>');
+      const container = await fixture('<div></div>');
+      container.attachShadow({ mode: 'open' });
+      const radio2 = document.createElement('ef-radio-button');
+      radio2.setAttribute('name', 'group');
+      radio2.setAttribute('id', 'btn2');
+      radio2.checked = true;
+      container.shadowRoot.appendChild(radio2);
+      await elementUpdated(radio);
+      await elementUpdated(radio2);
+
+      expect(radio.checked).to.equal(true);
+      expect(radio2.checked).to.equal(true);
+    });
   });
 
   describe('Group navigation', () => {

--- a/packages/elements/src/radio-button/__test__/radio-button.test.js
+++ b/packages/elements/src/radio-button/__test__/radio-button.test.js
@@ -448,7 +448,7 @@ describe('radio-button/RadioButton', () => {
       const checkedRadio = group.find(element => element.checked);
       expect(checkedRadio.id).to.equal('btn2');
     });
-    it('Should separate scope between shadow dom and light dom', async () => {
+    it('Should separate scope between shadow DOM and light DOM', async () => {
       const radio1 = await fixture('<ef-radio-button name="group" id="btn1" checked>1</ef-radio-button>');
       const radio2 = await fixture('<ef-radio-button name="group" id="btn2">2</ef-radio-button>');
       const radioWrapper = await fixture('<radio-wrapper></radio-wrapper>');
@@ -466,7 +466,7 @@ describe('radio-button/RadioButton', () => {
       expect(radioInShadow1.checked).to.equal(true);
       expect(radioInShadow2.checked).to.equal(false);
     });
-    it('Should separate shadow dom scope in each element that contain radio-button', async () => {
+    it('Should separate shadow DOM scope in each element that contain radio-button', async () => {
       const radioWrapper1 = await fixture('<radio-wrapper></radio-wrapper>');
       const radioWrapper2 = await fixture('<radio-wrapper></radio-wrapper>');
       const radio1InGroup1 = radioWrapper1.shadowRoot.querySelector('#btn1');

--- a/packages/elements/src/radio-button/__test__/radio-button.test.js
+++ b/packages/elements/src/radio-button/__test__/radio-button.test.js
@@ -461,19 +461,16 @@ describe('radio-button/RadioButton', () => {
 
       radio2.checked = true;
       await elementUpdated(radio1);
-      await elementUpdated(radio2);
-      await elementUpdated(radioInShadow1);
-      await elementUpdated(radioInShadow2);
       expect(radio1.checked).to.equal(false);
       expect(radio2.checked).to.equal(true);
       expect(radioInShadow1.checked).to.equal(true);
       expect(radioInShadow2.checked).to.equal(false);
     });
-    it('Should separate shadow dom against their wrapper elements', async () => {
-      const radioWrapper = await fixture('<radio-wrapper></radio-wrapper>');
+    it('Should separate shadow dom scope in each element that contain radio-button', async () => {
+      const radioWrapper1 = await fixture('<radio-wrapper></radio-wrapper>');
       const radioWrapper2 = await fixture('<radio-wrapper></radio-wrapper>');
-      const radio1InGroup1 = radioWrapper.shadowRoot.querySelector('#btn1');
-      const radio2InGroup1 = radioWrapper.shadowRoot.querySelector('#btn2');
+      const radio1InGroup1 = radioWrapper1.shadowRoot.querySelector('#btn1');
+      const radio2InGroup1 = radioWrapper1.shadowRoot.querySelector('#btn2');
       const radio1InGroup2 = radioWrapper2.shadowRoot.querySelector('#btn1');
       const radio2InGroup2 = radioWrapper2.shadowRoot.querySelector('#btn2');
       expect(radio1InGroup1.checked).to.equal(true);
@@ -483,9 +480,6 @@ describe('radio-button/RadioButton', () => {
 
       radio2InGroup1.checked = true;
       await elementUpdated(radio1InGroup1);
-      await elementUpdated(radio2InGroup1);
-      await elementUpdated(radio1InGroup2);
-      await elementUpdated(radio2InGroup2);
       expect(radio1InGroup1.checked).to.equal(false);
       expect(radio2InGroup1.checked).to.equal(true);
       expect(radio1InGroup2.checked).to.equal(true);

--- a/packages/elements/src/radio-button/__test__/radio-button.test.js
+++ b/packages/elements/src/radio-button/__test__/radio-button.test.js
@@ -1,6 +1,7 @@
 import { fixture, expect, elementUpdated, oneEvent, keyboardEvent, isIE } from '@refinitiv-ui/test-helpers';
 import '@refinitiv-ui/elements/radio-button';
 import '@refinitiv-ui/elemental-theme/light/ef-radio-button';
+import './radio-wrapper-mockup.js';
 
 const createEnterKeyboardEvent = () => keyboardEvent('keydown', { key: 'Enter' });
 const createSpacebarKeyboardEvent = () => keyboardEvent('keydown', { key: isIE() ? 'Spacebar' : ' ' });
@@ -448,19 +449,47 @@ describe('radio-button/RadioButton', () => {
       expect(checkedRadio.id).to.equal('btn2');
     });
     it('Should separate scope between shadow dom and light dom', async () => {
-      const radio = await fixture('<ef-radio-button name="group" id="btn1" checked>1</ef-radio-button>');
-      const container = await fixture('<div></div>');
-      container.attachShadow({ mode: 'open' });
-      const radio2 = document.createElement('ef-radio-button');
-      radio2.setAttribute('name', 'group');
-      radio2.setAttribute('id', 'btn2');
-      radio2.checked = true;
-      container.shadowRoot.appendChild(radio2);
-      await elementUpdated(radio);
-      await elementUpdated(radio2);
+      const radio1 = await fixture('<ef-radio-button name="group" id="btn1" checked>1</ef-radio-button>');
+      const radio2 = await fixture('<ef-radio-button name="group" id="btn2">2</ef-radio-button>');
+      const radioWrapper = await fixture('<radio-wrapper></radio-wrapper>');
+      const radioInShadow1 = radioWrapper.shadowRoot.querySelector('#btn1');
+      const radioInShadow2 = radioWrapper.shadowRoot.querySelector('#btn2');
+      expect(radio1.checked).to.equal(true);
+      expect(radio2.checked).to.equal(false);
+      expect(radioInShadow1.checked).to.equal(true);
+      expect(radioInShadow2.checked).to.equal(false);
 
-      expect(radio.checked).to.equal(true);
+      radio2.checked = true;
+      await elementUpdated(radio1);
+      await elementUpdated(radio2);
+      await elementUpdated(radioInShadow1);
+      await elementUpdated(radioInShadow2);
+      expect(radio1.checked).to.equal(false);
       expect(radio2.checked).to.equal(true);
+      expect(radioInShadow1.checked).to.equal(true);
+      expect(radioInShadow2.checked).to.equal(false);
+    });
+    it('Should separate shadow dom against their wrapper elements', async () => {
+      const radioWrapper = await fixture('<radio-wrapper></radio-wrapper>');
+      const radioWrapper2 = await fixture('<radio-wrapper></radio-wrapper>');
+      const radio1InGroup1 = radioWrapper.shadowRoot.querySelector('#btn1');
+      const radio2InGroup1 = radioWrapper.shadowRoot.querySelector('#btn2');
+      const radio1InGroup2 = radioWrapper2.shadowRoot.querySelector('#btn1');
+      const radio2InGroup2 = radioWrapper2.shadowRoot.querySelector('#btn2');
+      expect(radio1InGroup1.checked).to.equal(true);
+      expect(radio2InGroup1.checked).to.equal(false);
+      expect(radio1InGroup2.checked).to.equal(true);
+      expect(radio2InGroup2.checked).to.equal(false);
+
+      radio2InGroup1.checked = true;
+      await elementUpdated(radio1InGroup1);
+      await elementUpdated(radio2InGroup1);
+      await elementUpdated(radio1InGroup2);
+      await elementUpdated(radio2InGroup2);
+      expect(radio1InGroup1.checked).to.equal(false);
+      expect(radio2InGroup1.checked).to.equal(true);
+      expect(radio1InGroup2.checked).to.equal(true);
+      expect(radio2InGroup2.checked).to.equal(false);
     });
   });
 

--- a/packages/elements/src/radio-button/__test__/radio-wrapper-mockup.js
+++ b/packages/elements/src/radio-button/__test__/radio-wrapper-mockup.js
@@ -1,0 +1,16 @@
+
+import { BasicElement, html } from '@refinitiv-ui/core';
+import { customElement } from '@refinitiv-ui/core/lib/decorators/custom-element.js';
+
+import '@refinitiv-ui/elements/radio-button';
+import '@refinitiv-ui/elemental-theme/light/ef-radio-button';
+
+export class RadioWrapper extends BasicElement {
+  render () {
+    return html`<div>
+    <ef-radio-button name="group" id="btn1" checked>1</ef-radio-button>
+    <ef-radio-button name="group" id="btn2">2</ef-radio-button>
+    </div>`;
+  }
+}
+customElement('radio-wrapper', { theme: false })(RadioWrapper);

--- a/packages/elements/src/radio-button/radio-button-registry.ts
+++ b/packages/elements/src/radio-button/radio-button-registry.ts
@@ -1,5 +1,6 @@
 // Keeps registration records of radio button group per its name
 import type { RadioButton } from './index';
+import { getElementScope } from '@refinitiv-ui/utils/lib/element.js';
 
 const registry: RadioButton[] = [];
 
@@ -103,7 +104,8 @@ const getRadioGroup = (radio: RadioButton): RadioButton[] => {
   }
 
   const groupName = radio.name;
-  return registry.filter(radio => radio.name === groupName);
+  const rootNode = getElementScope(radio);
+  return registry.filter(radio => ((rootNode === getElementScope(radio)) && (radio.name === groupName)));
 };
 
 export {

--- a/packages/elements/src/radio-button/radio-button-registry.ts
+++ b/packages/elements/src/radio-button/radio-button-registry.ts
@@ -94,7 +94,7 @@ const restoreTabIndex = (radioGroup: RadioButton[]): void => {
 };
 
 /**
- * Get the group of same name radio buttons
+ * Get the group of radio buttons that same name and scope
  * @param radio A radio to get a group for
  * @returns collection of radio buttons
  */
@@ -105,7 +105,7 @@ const getRadioGroup = (radio: RadioButton): RadioButton[] => {
 
   const groupName = radio.name;
   const rootNode = getElementScope(radio);
-  return registry.filter(radio => ((rootNode === getElementScope(radio)) && (radio.name === groupName)));
+  return registry.filter(radio => rootNode === getElementScope(radio) && radio.name === groupName);
 };
 
 export {

--- a/packages/elements/src/radio-button/radio-button-registry.ts
+++ b/packages/elements/src/radio-button/radio-button-registry.ts
@@ -94,7 +94,7 @@ const restoreTabIndex = (radioGroup: RadioButton[]): void => {
 };
 
 /**
- * Get the group of radio buttons that same name and scope
+ * Get a group of radio buttons that has the same name and scope
  * @param radio A radio to get a group for
  * @returns collection of radio buttons
  */


### PR DESCRIPTION
## Description
[radio-button] radio group name should be unique within its own scope
If radio group is in document level, the name should be unique at document level.
If radio group is in shadow root level, the name should be unique at shadow root level.
jira: https://jira.refinitiv.com/browse/ELF-1754

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings