### PR TITLE
ci: add sync to develop job for the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,3 +41,10 @@ jobs:
         run: lerna publish from-git --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Sync to develop branch
+        run: |
+          git checkout develop
+          git merge main --no-edit --no-ff
+          git push
+          git status

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Sync to develop branch
+      - name: Sync published changes to develop branch
         run: |
           git checkout develop
           git merge main --no-edit --no-ff


### PR DESCRIPTION
## Description
 Add the new job in the last step of release workflow to synchronize from `main` to `develop` branch automatically, for updating the changelogs and package version. We must have this feature to reduce human error by doing it manually.

## Type of change

- [x] CI Improvement

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings