### PR TITLE
refactor(text-field): extract shouldSyncInputValue and syncInputValue

### DIFF
--- a/packages/elements/src/text-field/index.ts
+++ b/packages/elements/src/text-field/index.ts
@@ -143,13 +143,34 @@ export class TextField extends FormFieldElement {
   protected updated (changedProperties: PropertyValues): void {
     super.updated(changedProperties);
 
-    if (this.inputValue !== this.value) {
-      this.inputValue = this.value;
+    if (this.shouldSyncInputValue(changedProperties)) {
+      this.syncInputValue(changedProperties);
     }
 
     if (this.shouldValidateInput(changedProperties)) {
       this.validateInput();
     }
+  }
+
+  /**
+   * Check if input value should be synchronised with component value
+   * @param changedProperties Properties that has changed
+   * @returns True if input should be synchronised
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected shouldSyncInputValue (changedProperties: PropertyValues): boolean {
+    return this.inputValue !== this.value;
+  }
+
+  /**
+   * Synchronise input value with value.
+   * Override the method if value and input value are not the same
+   * @param changedProperties Properties that has changed
+   * @returns {void}
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected syncInputValue (changedProperties: PropertyValues): void {
+    this.inputValue = this.value;
   }
 
   /**


### PR DESCRIPTION
## Description
It should be possible to override `shouldSyncInputValue` and `syncInputValue` if `value` and `inputValue` are not the same and parsing/formatting stage is required.

## Type of change
Please delete options that are not relevant.

- [X] Refactoring

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings