### PR TITLE
fix(tree-select): selected button should support disabled item

### DIFF
--- a/packages/elements/src/tree-select/__test__/tree-select.filter.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.filter.test.js
@@ -268,5 +268,13 @@ describe('tree-select/Filter', () => {
       expect(el.treeManager.visibleItems.length).to.equal(selectableCount + 2, 'All items are visible');
     });
 
+    it('Should selection filter on disabled selected items when press Selected button', async () => {
+      const el = await fixture('<ef-tree-select lang="en-gb"></ef-tree-select>');
+      const data = [{ selected: true, label: '1', value: '1', disabled: true }, { selected: true, label: '2', value: '2', readonly: true }, { label: '3', value: '3' }];
+      el.data = data;
+      el.selectedClickHandler();
+      const selectedData = data.filter(item => item.selected === true);
+      expect(el.treeManager.visibleItems.length).to.equal(selectedData.length, 'Show all selected items including disabled and readonly');
+    });
   });
 });

--- a/packages/elements/src/tree-select/__test__/tree-select.filter.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.filter.test.js
@@ -268,13 +268,22 @@ describe('tree-select/Filter', () => {
       expect(el.treeManager.visibleItems.length).to.equal(selectableCount + 2, 'All items are visible');
     });
 
-    it('Should selection filter on disabled selected items when press Selected button', async () => {
+    it('Should allow selected filter button when there is only selected but disabled item in tree', async () => {
       const el = await fixture('<ef-tree-select lang="en-gb"></ef-tree-select>');
-      const data = [{ selected: true, label: '1', value: '1', disabled: true }, { selected: true, label: '2', value: '2', readonly: true }, { label: '3', value: '3' }];
+      const data = [{ selected: true, label: '1', value: '1', disabled: true }, { label: '2', value: '2' }];
       el.data = data;
       el.selectedClickHandler();
       const selectedData = data.filter(item => item.selected === true);
-      expect(el.treeManager.visibleItems.length).to.equal(selectedData.length, 'Show all selected items including disabled and readonly');
+      expect(el.treeManager.visibleItems.length).to.equal(selectedData.length, 'Show all selected items including disabled');
+    });
+
+    it('Should allow selected filter button when there is only selected but readonly item in tree', async () => {
+      const el = await fixture('<ef-tree-select lang="en-gb"></ef-tree-select>');
+      const data = [{ selected: true, label: '1', value: '1', readonly: true }, { label: '2', value: '2' }];
+      el.data = data;
+      el.selectedClickHandler();
+      const selectedData = data.filter(item => item.selected === true);
+      expect(el.treeManager.visibleItems.length).to.equal(selectedData.length, 'Show all selected items including readonly');
     });
   });
 });

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -428,7 +428,7 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
           this.memo.expanded += 1;
         }
       }
-      else if (this.treeManager.isItemCheckable(item)) {
+      else if (!this.composer.isItemLocked(item)) {
         this.memo.selectable += 1;
         if (this.getItemPropertyValue(item, 'selected') === true) {
           this.memo.selected += 1;


### PR DESCRIPTION
## Description
'Selected' button is not working if all Multi Select selection are disabled

Fixes # (ELF-1713) **jira**: https://jira.refinitiv.com/browse/ELF-1713

**Step to reproduce**: try to press selected button when all selected items are disabled
1. el.data = [{ selected: true, label: '1', value: '1', disabled: true }, { selected: true, label: '2', value: '2', readonly: true }, { label: '3', value: '3' }]
2. try to press Selected button at top right of tree-select

**Expected**: Should be able to press Selected button to filter

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings