### PR TITLE
refactor(core): use semantic readonly attribute instead

### DIFF
--- a/packages/core/__test__/elements/ControlElement.test.js
+++ b/packages/core/__test__/elements/ControlElement.test.js
@@ -129,9 +129,6 @@ describe('TestControlElement', () => {
         expect(el.hasAttribute('readonly')).to.equal(true, 'attribute "readonly" should be exists');
         expect(el.getAttribute('readonly')).to.equal('', 'attribute "readonly" should equal ""');
 
-        expect(el.hasAttribute('aria-readonly')).to.equal(true, 'attribute "aria-readonly" should be present');
-        expect(el.getAttribute('aria-readonly')).to.equal('true', '"aria-readonly" should be true');
-
         el.readonly = false;
         await elementUpdated(el);
 
@@ -145,9 +142,6 @@ describe('TestControlElement', () => {
         expect(el.getAttribute('readonly')).to.equal('', 'attribute "readonly" should equal empty string');
         expect(el.hasAttribute('readonly')).to.equal(true, 'attribute "readonly" should be present');
 
-
-        expect(el.hasAttribute('aria-readonly')).to.equal(true, 'attribute "aria-readonly" should be present');
-        expect(el.getAttribute('aria-readonly')).to.equal('true', '"aria-readonly" should be true');
       });
     });
 

--- a/packages/core/src/elements/ControlElement.ts
+++ b/packages/core/src/elements/ControlElement.ts
@@ -87,10 +87,6 @@ export abstract class ControlElement extends BasicElement implements IControlPro
       this.disableChanged(changedProperties);
     }
 
-    if (changedProperties.has('readonly')) {
-      this.readonlyChanged(changedProperties);
-    }
-
     super.update(changedProperties);
   }
 
@@ -107,20 +103,6 @@ export abstract class ControlElement extends BasicElement implements IControlPro
     else if (changedProperties.get('disabled') === true) { /* re-enable only if disabled changed from true to false */
       this.enableFocus();
       this.removeAttribute('aria-disabled');
-    }
-  }
-
-  /**
-   * Update readonly state if detect value changed
-   * @param changedProperties Properties that has changed
-   * @returns {void}
-   */
-  protected readonlyChanged (changedProperties: PropertyValues): void {
-    if (this.readonly) {
-      this.setAttribute('aria-readonly', 'true');
-    }
-    else if (changedProperties.get('readonly') === true) {
-      this.removeAttribute('aria-readonly');
     }
   }
 

--- a/packages/elements/src/time-picker/__snapshots__/TimePicker.md
+++ b/packages/elements/src/time-picker/__snapshots__/TimePicker.md
@@ -7,7 +7,6 @@
 ```html
 <ef-number-field
   aria-label="0 hours"
-  aria-readonly="true"
   id="hours"
   max="23"
   min="0"
@@ -22,7 +21,6 @@
 </span>
 <ef-number-field
   aria-label="0 minutes"
-  aria-readonly="true"
   id="minutes"
   max="59"
   min="0"
@@ -37,7 +35,6 @@
 </span>
 <ef-number-field
   aria-label="0 seconds"
-  aria-readonly="true"
   id="seconds"
   max="59"
   min="0"

--- a/packages/translate/src/translate.ts
+++ b/packages/translate/src/translate.ts
@@ -59,7 +59,7 @@ class AsyncTranslateDirective extends AsyncDirective {
         // the code may fail if polyfills are not available in IE11 or translate syntax is wrong
         /* istanbul ignore next */
         setTimeout(() => {
-          throw new Error(error);
+          throw new Error(error as string);
         });
       });
 
@@ -78,7 +78,7 @@ const translatePromise = (scope: string, locale: string, key: string, options?: 
     // the code may fail if polyfills are not available in IE11 or translate syntax is wrong
     /* istanbul ignore next */
     setTimeout(() => {
-      throw new Error(error);
+      throw new Error(error as string);
     });
     return key;
   });

--- a/packages/translate/src/translate.ts
+++ b/packages/translate/src/translate.ts
@@ -59,7 +59,7 @@ class AsyncTranslateDirective extends AsyncDirective {
         // the code may fail if polyfills are not available in IE11 or translate syntax is wrong
         /* istanbul ignore next */
         setTimeout(() => {
-          throw new Error(error as string);
+          throw error instanceof Error ? error : new Error(String(error));
         });
       });
 
@@ -78,7 +78,7 @@ const translatePromise = (scope: string, locale: string, key: string, options?: 
     // the code may fail if polyfills are not available in IE11 or translate syntax is wrong
     /* istanbul ignore next */
     setTimeout(() => {
-      throw new Error(error as string);
+      throw error instanceof Error ? error : new Error(String(error));
     });
     return key;
   });


### PR DESCRIPTION
## Description
When using semantic HTML form controls, if you set the readonly attribute, you don't need to include aria-readonly="true"

## Type of change
Refactor

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings