### PR TITLE
fix(tree-select): composer and _values dont sync after press cancel

### DIFF
--- a/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
@@ -49,6 +49,7 @@ describe('tree-select/Interaction', () => {
       expect(doValuesMatch(expectedSelection, savedValues)).to.equal(true, 'Values do not match');
     });
 
+    // Todo: Should have another test case simulating real user interaction, not by api.
     it('Cancels a selection - flat', async () => {
       const el = await fixture('<ef-tree-select opened lang="en-gb"></ef-tree-select>');
       // ensure events are fired

--- a/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
@@ -90,6 +90,24 @@ describe('tree-select/Interaction', () => {
       expect(savedValues.length).to.equal(savedComposerValues.length, 'Values and ComposerValues should be same');
     });
 
+    it('Cancels a selection - already have selected item', async () => {
+      const el = await fixture('<ef-tree-select opened lang="en-gb"></ef-tree-select>');
+      const data = [{ selected: true, label: '1', value: '1' }, { label: '2', value: '2' }];
+      el.data = data;
+      changeItemSelection(el, data );
+      await aTimeout(200); // make sure all processes are finished
+      el.cancel();
+      await elementUpdated(el);
+      const expectedSelection = data.filter(item => item.selected).map(item => item.value);
+      const savedValues = el.values;
+      expect(savedValues.length).to.equal(expectedSelection.length, 'Saved and Expected are not equal');
+      expect(doValuesMatch(expectedSelection, savedValues)).to.equal(true, 'Values do not match');
+      expect(el.opened).to.equal(false, 'Cancel should close the list');
+      const savedComposerValues = el.composerValues;
+      expect(doValuesMatch(savedValues, savedComposerValues)).to.equal(true, 'Values and ComposerValues should be same');
+      expect(savedValues.length).to.equal(savedComposerValues.length, 'Values and ComposerValues should be same');
+    });
+
     it('Persist a selection, make changes and cancel - flat', async () => {
       const el = await fixture('<ef-tree-select lang="en-gb"></ef-tree-select>');
       // ensure events are fired

--- a/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
@@ -55,6 +55,7 @@ describe('tree-select/Interaction', () => {
       el.data = flatData;
       const expectedSelection = [];
       changeItemSelection(el, flatSelection);
+      await aTimeout(200); // make sure all processes are finished
       checkMemo(el, {
         expandable: 0,
         expanded: 0,
@@ -62,6 +63,7 @@ describe('tree-select/Interaction', () => {
         selected: flatSelection.length
       });
       el.cancel();
+      await elementUpdated(el);
       const savedValues = el.values;
       expect(savedValues.length).to.equal(expectedSelection.length, 'Saved and Expected are not equal');
       expect(doValuesMatch(expectedSelection, savedValues)).to.equal(true, 'Values do not match');
@@ -76,6 +78,7 @@ describe('tree-select/Interaction', () => {
       el.data = nestedData;
       const expectedSelection = [];
       changeItemSelection(el, nestedSelection);
+      await aTimeout(200); // make sure all processes are finished
       el.cancel();
       await elementUpdated(el);
       const savedValues = el.values;

--- a/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
@@ -67,19 +67,25 @@ describe('tree-select/Interaction', () => {
       expect(savedValues.length).to.equal(expectedSelection.length, 'Saved and Expected are not equal');
       expect(doValuesMatch(expectedSelection, savedValues)).to.equal(true, 'Values do not match');
       expect(el.treeManager.visibleItems.length).to.equal(flatData.length, 'Data list should remain the same');
+      const savedComposerValues = el.composerValues;
+      expect(doValuesMatch(savedValues, savedComposerValues)).to.equal(true, 'Values and ComposerValues should be same');
+      expect(savedValues.length).to.equal(savedComposerValues.length, 'Values and ComposerValues should be same');
     });
 
     it('Cancels a selection - nested', async () => {
       const el = await fixture('<ef-tree-select opened lang="en-gb"></ef-tree-select>');
       el.data = nestedData;
       const expectedSelection = [];
-      changeItemSelection(el, flatSelection);
+      changeItemSelection(el, nestedSelection);
       el.cancel();
       await elementUpdated(el);
       const savedValues = el.values;
       expect(savedValues.length).to.equal(expectedSelection.length, 'Saved and Expected are not equal');
       expect(doValuesMatch(expectedSelection, savedValues)).to.equal(true, 'Values do not match');
       expect(el.opened).to.equal(false, 'Cancel should close the list');
+      const savedComposerValues = el.composerValues;
+      expect(doValuesMatch(savedValues, savedComposerValues)).to.equal(true, 'Values and ComposerValues should be same');
+      expect(savedValues.length).to.equal(savedComposerValues.length, 'Values and ComposerValues should be same');
     });
 
     it('Persist a selection, make changes and cancel - flat', async () => {

--- a/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
@@ -49,7 +49,6 @@ describe('tree-select/Interaction', () => {
       expect(doValuesMatch(expectedSelection, savedValues)).to.equal(true, 'Values do not match');
     });
 
-    // Todo: Should have another test case simulating real user interaction, not by api.
     it('Cancels a selection - flat', async () => {
       const el = await fixture('<ef-tree-select opened lang="en-gb"></ef-tree-select>');
       // ensure events are fired

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -402,8 +402,12 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
    * @returns {void}
    */
   protected cancelSelection (): void {
-    // values setter updates the collection composer if required
-    this.values = this._values;
+    const newComparison = this.composerValues.sort().toString();
+    const oldComparison = this.values.sort().toString();
+    if (newComparison !== oldComparison) {
+      // revert selected item by updating the collection composer
+      this.updateComposerValues(this._values);
+    }
   }
 
   /**

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -402,9 +402,13 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
    * @returns {void}
    */
   protected cancelSelection (): void {
-    const newComparison = this.composerValues.sort().toString();
-    const oldComparison = this.values.sort().toString();
-    if (newComparison !== oldComparison) {
+    const oldValues = this.values.slice();
+    const newValues = this.composerValues;
+
+    const oldComparison = oldValues.sort().toString();
+    const newComparison = newValues.sort().toString();
+
+    if (oldComparison !== newComparison) {
       // revert selected item by updating the collection composer
       this.updateComposerValues(this._values);
     }


### PR DESCRIPTION
## Description
After merged https://github.com/Refinitiv/refinitiv-ui/pull/196, we found a new bug that Cancel function of tree-select doesn't worked.

Step to reproduce:
1. Checkout develop branch
2. Try select some item in tree-select
3. Press cancel. Tree-select doesn't revert selected items to the value before step 2.

Jira: no jira
Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings