### PR TITLE
style: ignore `window` lint error

### DIFF
--- a/packages/elements/src/chart/index.ts
+++ b/packages/elements/src/chart/index.ts
@@ -1,3 +1,6 @@
+/* eslint @typescript-eslint/no-unsafe-call: 0 */
+/* eslint @typescript-eslint/no-unsafe-member-access: 0 */
+
 import {
   BasicElement,
   html,
@@ -43,6 +46,7 @@ window.Chart.pluginService.register(doughnutCenterPlugin);
 
 const CSS_COLOR_PREFIX = '--chart-color-';
 const CHART_TYPE_OPAQUE = ['line', 'bubble', 'radar', 'polarArea'];
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const DEFAULT_CHART_CONFIG = window.Chart.defaults;
 const ELF_CHART_CONFIG = {
   polarArea: {


### PR DESCRIPTION
## Description
Ignore lint error from accessing `window` object which is need by ChartJS.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings