### PR TITLE
test(heatmap): fix incorrect test

### DIFF
--- a/packages/elements/src/heatmap/__test__/heatmap.test.js
+++ b/packages/elements/src/heatmap/__test__/heatmap.test.js
@@ -117,22 +117,16 @@ describe('heatmap/Heatmap', () => {
     });
 
     it('Should not render any axes', async () => {
-      el.confg = { data: [[{ value: 1, header: 'ABC' }, { value: 0.5, header: 'DEF' }]] };
-
+      el.config = { data: [[{ value: 1, header: 'ABC' }, { value: 0.5, header: 'DEF' }]] };
       await elementUpdated(el);
 
       const crossBox = el.shadowRoot.querySelector('[part=cross-box]');
-      const crossBoxHeight = window.getComputedStyle(crossBox).height.replace(removeUnit, '');
-
       const xAxis = el.shadowRoot.querySelector('[part=x-axis]');
-      const xAxisHeight = window.getComputedStyle(xAxis).height.replace(removeUnit, '');
-
       const yAxis = el.shadowRoot.querySelector('[part=y-axis]');
-      const yAxisHeight = window.getComputedStyle(yAxis).height.replace(removeUnit, '');
 
-      expect(xAxisHeight).to.equal('0');
-      expect(yAxisHeight).to.equal('0');
-      expect(crossBoxHeight).to.equal('0');
+      expect(crossBox).to.equal(null);
+      expect(xAxis).to.equal(null);
+      expect(yAxis).to.equal(null);
     });
 
     it('Should render x-axis', async () => {


### PR DESCRIPTION
## Description
When not passing x-axis and y-axis object in the config object, [part=x-axis] [part=y-axis] [part=cross-box] shouldn't be created in DOM. The old test case expected that those parts are created without size which wasn't the case.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings