### PR TITLE
fix(calendar, time-picker): add missing role to aria-live part

### DIFF
--- a/packages/elements/src/calendar/__snapshots__/Defaults.md
+++ b/packages/elements/src/calendar/__snapshots__/Defaults.md
@@ -9,6 +9,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -771,6 +772,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -1435,6 +1437,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -1738,6 +1741,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -2039,6 +2043,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -2689,6 +2694,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -2992,6 +2998,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -3293,6 +3300,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -3964,6 +3972,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -4267,6 +4276,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -4570,6 +4580,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -5234,6 +5245,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -5902,6 +5914,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -6570,6 +6583,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -7196,6 +7210,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -7846,6 +7861,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -8506,6 +8522,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -9164,6 +9181,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -9800,6 +9818,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">

--- a/packages/elements/src/calendar/__snapshots__/KeyboardNavigation.md
+++ b/packages/elements/src/calendar/__snapshots__/KeyboardNavigation.md
@@ -9,6 +9,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -680,6 +681,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -1348,6 +1350,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -1651,6 +1654,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -1958,6 +1962,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -2257,6 +2262,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">

--- a/packages/elements/src/calendar/__snapshots__/Multiple.md
+++ b/packages/elements/src/calendar/__snapshots__/Multiple.md
@@ -9,6 +9,7 @@
   aria-label="Selected 3 dates, Thursday, 21 April 2005 and others"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -675,6 +676,7 @@
   aria-label="Selected 3 dates, Thursday, 21 April 2005 and others"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -979,6 +981,7 @@
   aria-label="Selected 3 dates, Thursday, 21 April 2005 and others"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -1282,6 +1285,7 @@
   aria-label="Selected none. Choose dates"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">

--- a/packages/elements/src/calendar/__snapshots__/Navigation.md
+++ b/packages/elements/src/calendar/__snapshots__/Navigation.md
@@ -9,6 +9,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -666,6 +667,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -1337,6 +1339,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -2010,6 +2013,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -2674,6 +2678,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -3345,6 +3350,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -4020,6 +4026,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -4670,6 +4677,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -5341,6 +5349,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -6014,6 +6023,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -6678,6 +6688,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -7349,6 +7360,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -8024,6 +8036,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -8327,6 +8340,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -8630,6 +8644,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -8935,6 +8950,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -9238,6 +9254,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -9541,6 +9558,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -9848,6 +9866,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -10151,6 +10170,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -10454,6 +10474,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -10759,6 +10780,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -11062,6 +11084,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -11365,6 +11388,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -11672,6 +11696,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -11971,6 +11996,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -12270,6 +12296,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -12571,6 +12598,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -12870,6 +12898,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -13169,6 +13198,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -13472,6 +13502,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -13771,6 +13802,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -14070,6 +14102,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -14371,6 +14404,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -14670,6 +14704,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -14969,6 +15004,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -15272,6 +15308,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -15936,6 +15973,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -16235,6 +16273,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -16899,6 +16938,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -17202,6 +17242,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -17870,6 +17911,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -18169,6 +18211,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -18472,6 +18515,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -18777,6 +18821,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -19082,6 +19127,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -19389,6 +19435,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -20055,6 +20102,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -20723,6 +20771,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -21387,6 +21436,7 @@
   aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">

--- a/packages/elements/src/calendar/__snapshots__/Range.md
+++ b/packages/elements/src/calendar/__snapshots__/Range.md
@@ -9,6 +9,7 @@
   aria-label="Selected range is from Friday, 1 April 2005 to Friday, 1 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -676,6 +677,7 @@
   aria-label="Selected range is from Friday, 1 April 2005 to Friday, 1 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -982,6 +984,7 @@
   aria-label="Selected range is from Friday, 1 April 2005 to Friday, 1 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -1286,6 +1289,7 @@
   aria-label="Selected range is from Tuesday, 1 March 2005 to Wednesday, 1 April 2009"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -1980,6 +1984,7 @@
   aria-label="Selected range is from Tuesday, 1 March 2005 to Wednesday, 1 April 2009"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -2296,6 +2301,7 @@
   aria-label="Selected range is from Tuesday, 1 March 2005 to Wednesday, 1 April 2009"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -2604,6 +2610,7 @@
   aria-label="Selected range is from Tuesday, 4 April 12 to Friday, 21 April 12"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -3288,6 +3295,7 @@
   aria-label="Selected range is from Tuesday, 4 April 12 to Friday, 21 April 12"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -3594,6 +3602,7 @@
   aria-label="Selected range is from Tuesday, 4 April 12 to Friday, 21 April 12"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -3900,6 +3909,7 @@
   aria-label="Selected range is from Wednesday, 6 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -4565,6 +4575,7 @@
   aria-label="Selected range is from Wednesday, 6 April 2005 to Sunday, 10 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -5236,6 +5247,7 @@
   aria-label="Selected range is from Wednesday, 13 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -5901,6 +5913,7 @@
   aria-label="Selected range is from Tuesday, 12 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -6566,6 +6579,7 @@
   aria-label="Selected range is from Tuesday, 12 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">

--- a/packages/elements/src/calendar/__snapshots__/Value.md
+++ b/packages/elements/src/calendar/__snapshots__/Value.md
@@ -9,6 +9,7 @@
   aria-label="Selected date is Thursday, 21 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -674,6 +675,7 @@
   aria-label="Selected date is Thursday, 21 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -978,6 +980,7 @@
   aria-label="Selected date is Thursday, 21 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -1280,6 +1283,7 @@
   aria-label="Selected date is Thursday, 21 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -1947,6 +1951,7 @@
   aria-label="Selected date is Friday, 21 April 12"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -2612,6 +2617,7 @@
   aria-label="Selected date is Friday, 21 April 12"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -2916,6 +2922,7 @@
   aria-label="Selected date is Friday, 21 April 12"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -3220,6 +3227,7 @@
   aria-label="Selected date is Friday, 1 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -3885,6 +3893,7 @@
   aria-label="Selected date is Saturday, 30 April 2005"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -4552,6 +4561,7 @@
   aria-label="Selected date is Saturday, 1 April 12"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">
@@ -5217,6 +5227,7 @@
   aria-label="Selected date is Sunday, 30 April 12"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
 <div part="navigation">

--- a/packages/elements/src/calendar/index.ts
+++ b/packages/elements/src/calendar/index.ts
@@ -1454,6 +1454,7 @@ export class Calendar extends ControlElement implements MultiValue {
     }
     return html`<div
       part="aria-selection"
+      role="status"
       aria-live="polite"
       aria-label="${this.value
         ? this.range

--- a/packages/elements/src/time-picker/__snapshots__/TimePicker.md
+++ b/packages/elements/src/time-picker/__snapshots__/TimePicker.md
@@ -49,8 +49,10 @@
   aria-label="Selected time is: 00:00:00"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
+
 ```
 
 ####   `DOM structure: disabled`
@@ -106,8 +108,10 @@
   aria-label="Selected time is: 00:00:00"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
+
 ```
 
 ####   `DOM structure: value, no seconds`
@@ -141,8 +145,10 @@
   aria-label="Selected time is: 08:16"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
+
 ```
 
 ####   `DOM structure: value, with seconds`
@@ -189,8 +195,10 @@
   aria-label="Selected time is: 08:16:32"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
+
 ```
 
 ####   `DOM structure: value, am/pm no seconds`
@@ -250,8 +258,10 @@
   aria-label="Selected time is: 1:30 PM"
   aria-live="polite"
   part="aria-selection"
+  role="status"
 >
 </div>
+
 ```
 
 ####   `DOM structure: role=none`

--- a/packages/elements/src/time-picker/index.ts
+++ b/packages/elements/src/time-picker/index.ts
@@ -974,6 +974,7 @@ export class TimePicker extends ControlElement {
 
     return html`<div
       part="aria-selection"
+      role="status"
       aria-live="polite"
       aria-label="${this.t('SELECTED', {
         value: value ? parse(value) : null,


### PR DESCRIPTION
## Description
`role=status` is missing from [part=aria-selection] in Calendar and Time Picker. Google Lighthouse reports this the issue.

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings