### PR TITLE
refactor(notification): remove unused condition in `canShow` function

### DIFF
--- a/packages/elements/src/notification/elements/notification-tray.ts
+++ b/packages/elements/src/notification/elements/notification-tray.ts
@@ -48,7 +48,7 @@ export class NotificationTray extends ResponsiveElement {
    * @returns true if tray is ready to show
    */
   private get canShow (): boolean {
-    return this.queue.length >= 0 && this.showing.length < this.max;
+    return this.showing.length < this.max;
   }
 
   /**


### PR DESCRIPTION
## Description

- removes useless condition in `canShow()` as array length is always zero or more. 

reference to SonarCloud recommendation https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&types=BUG&id=refinitiv_refinitiv-ui&open=AX-qmzfGqePuut67JdC2

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings