### PR TITLE
chore: exclude some folders from code coverage calculation

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,7 @@ sonar.projectKey=refinitiv_refinitiv-ui
 sonar.organization=refinitiv
 sonar.exclusions=documents/**, samples/**, packages/*-theme/**, packages/configurations/**, **/__snapshots__/**, **/__demo__/**, **/__test__/**
 sonar.javascript.lcov.reportPaths=**/coverage/lcov.info
+sonar.coverage.exclusions=scripts/**, packages/phrasebook/**, packages/utils/**, packages/polyfills/**, packages/theme-compiler/**
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=dtanp-rft_refinitiv-ui


### PR DESCRIPTION
Exclude some folders from code coverage calculation as they are either not require test or we don't have test yet (e.g. utils).