### PR TITLE
test(button): add tapstart tapend test button

### DIFF
--- a/packages/elements/src/button/__test__/button.test.js
+++ b/packages/elements/src/button/__test__/button.test.js
@@ -233,17 +233,17 @@ describe('button/Button', () => {
       expect(el).not.to.be.accessible();
     });
 
-    it('', async () => {
-      const el = await fixture(`<ef-button aria-label="Tick Icon" icon="tick"></ef-button>`);
-      expect(el).to.be.accessible({
-        ignoredRules: ['aria-allowed-attr']
-      });
-    });
-
-    it('', async () => {
+    it('should pass a11y requirement when text content is provided', async () => {
       const el = await fixture(`<ef-button>TEST</ef-button>`);
       expect(el).to.be.accessible({
         ignoredRules: ['aria-allowed-attr', 'color-contrast']
+      });
+    });
+
+    it('should pass a11y requirement when aria-label is provided instead of text content', async () => {
+      const el = await fixture(`<ef-button aria-label="Tick Icon" icon="tick"></ef-button>`);
+      expect(el).to.be.accessible({
+        ignoredRules: ['aria-allowed-attr']
       });
     });
 

--- a/packages/elements/src/button/__test__/button.test.js
+++ b/packages/elements/src/button/__test__/button.test.js
@@ -227,7 +227,7 @@ describe('button/Button', () => {
     });
   });
 
-  describe('Accessiblity', () => {
+  describe('Accessibility', () => {
     it('should not be accessible without label', async () => {
       const el = await fixture(`<ef-button></ef-button>`);
       expect(el).not.to.be.accessible();

--- a/packages/elements/src/button/__test__/button.test.js
+++ b/packages/elements/src/button/__test__/button.test.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 import { expect, fixture, html, elementUpdated, oneEvent } from '@refinitiv-ui/test-helpers';
 
-import '@refinitiv-ui/elements/icon';
 import '@refinitiv-ui/elements/button';
 import '@refinitiv-ui/elemental-theme/light/ef-button';
 
@@ -17,17 +16,17 @@ describe('button/Button', () => {
   });
 
   describe('Transparent Property', () => {
-    it('the transparent property should set to true if the transparent attribute exists', async () => {
+    it('should set to true if the transparent attribute exists', async () => {
       const el = await fixture(html`<ef-button transparent></ef-button>`);
       expect(el.transparent).to.equal(true);
     });
 
-    it('the transparent property should set to false if the transparent attribute doesn\'t exist', async () => {
+    it('should set to false if the transparent attribute doesn\'t exist', async () => {
       const el = await fixture(html`<ef-button></ef-button>`);
       expect(el.transparent).to.equal(false);
     });
 
-    it('the transparent attribute should exist if the transparent property sets to true', async () => {
+    it('should exist if the transparent property sets to true', async () => {
       const el = await fixture(html`<ef-button></ef-button>`);
       el.transparent = true;
       await elementUpdated(el);
@@ -36,17 +35,17 @@ describe('button/Button', () => {
   });
 
   describe('cta(call-to-action) property', () => {
-    it('the cta property should set to true if the cta attribute exists', async () => {
+    it('should set to true if the cta attribute exists', async () => {
       const el = await fixture(html`<ef-button cta></ef-button>`);
       expect(el.cta).to.equal(true);
     });
 
-    it('the cta property should set to false if the cta attribute doesn\'t exist', async () => {
+    it('should set to false if the cta attribute doesn\'t exist', async () => {
       const el = await fixture(html`<ef-button></ef-button>`);
       expect(el.cta).to.equal(false);
     });
 
-    it('the cta attribute should exist if the cta property sets to true', async () => {
+    it('should have cta attribute set to true if the cta property sets to true', async () => {
       const el = await fixture(html`<ef-button></ef-button>`);
       el.cta = true;
       expect(el.hasAttribute('cta')).to.exist;
@@ -54,29 +53,29 @@ describe('button/Button', () => {
   });
 
   describe('Empty Property', () => {
-    it('the empty property should set to true if the empty attribute exists', async () => {
+    it('should set to true if the empty attribute exists', async () => {
       const el = await fixture(html`<ef-button></ef-button>`);
       expect(el.empty).to.equal(true);
     });
 
-    it('the empty property should set to false if the default slot is not empty', async () => {
+    it('should set to false if the default slot is not empty', async () => {
       const el = await fixture(html`<ef-button>Button</ef-button>`);
       expect(el.empty).to.equal(false);
     });
   });
 
   describe('Toggles Property', () => {
-    it('the toggles property should set to true if the toggles attribute exists', async () => {
+    it('should set to true if the toggles attribute exists', async () => {
       const el = await fixture(html`<ef-button toggles></ef-button>`);
       expect(el.toggles).to.equal(true);
     });
 
-    it('the toggles property should set to false if the toggles attribute doesn\'t exist', async () => {
+    it('should set to false if the toggles attribute doesn\'t exist', async () => {
       const el = await fixture(html`<ef-button></ef-button>`);
       expect(el.toggles).to.equal(false);
     });
 
-    it('the toggles attribute should exist if the toggles property sets to true', async () => {
+    it('should have attribute set to true if the toggles property sets to true', async () => {
       const el = await fixture(html`<ef-button></ef-button>`);
       el.toggles = true;
       expect(el.hasAttribute('toggles')).to.exist;
@@ -84,17 +83,17 @@ describe('button/Button', () => {
   });
 
   describe('Active Property', () => {
-    it('the active property should set to true if the the active attribute exists', async () => {
+    it('should set to true if the the active attribute exists', async () => {
       const el = await fixture(html`<ef-button toggles active></ef-button>`);
       expect(el.active).to.equal(true);
     });
 
-    it('the active property should set to false if the active attribute doesn\'t exist', async () => {
+    it('should set to false if the active attribute doesn\'t exist', async () => {
       const el = await fixture(html`<ef-button></ef-button>`);
       expect(el.active).to.equal(false);
     });
 
-    it('the active attribute should exist if the active property sets to true', async () => {
+    it('should have attribute set to true if the active property sets to true', async () => {
       const el = await fixture(html`<ef-button></ef-button>`);
       el.active = true;
       await elementUpdated(el);
@@ -103,31 +102,34 @@ describe('button/Button', () => {
   });
 
   describe('Textpos Property', () => {
-    it('the textpos property should set to "after" the active attribute sets "after"', async () => {
+    it('should have default value to "after"', async () => {
+      const el = await fixture(html`<ef-button></ef-button>`);
+      expect(el.textpos).to.equal('after');
+      expect(el.hasAttribute('textpos')).to.be.exist;
+    });
+
+    it('should set to "after" the active attribute sets "after"', async () => {
       const el = await fixture(html`<ef-button textpos="after"></ef-button>`);
       expect(el.textpos).to.equal('after');
     });
 
-    it('the textpos property should set to "after" the active attribute doesn\'t exist', async () => {
-      const el = await fixture(html`<ef-button></ef-button>`);
-      expect(el.hasAttribute('textpos')).to.be.exist;
-    });
-
-    it('the textpos property desn\'t exist the active attribute sets "after"', async () => {
+    it('should be able to set textpos accordingly', async () => {
       const el = await fixture(html`<ef-button textpos="before"></ef-button>`);
       el.textpos = 'after';
+      await elementUpdated(el);
+
       expect(el.textpos).to.equal('after');
     });
   });
 
   describe('Icon Properties', () => {
-    it('the icon property should have the "tick" icon and set the icon property to ef-icon with icon id', async () => {
+    it('should have the "tick" icon and set the icon property to ef-icon with icon id', async () => {
       const el = await fixture(html`<ef-button icon="tick"></ef-button>`);
       const iconEl = el.shadowRoot.querySelector('#icon');
       expect(iconEl.getAttribute('icon')).to.equal('tick');
     });
 
-    it('the hover-icon property should have the "tick" icon and set the icon property to ef-icon with hover-icon id', async () => {
+    it('should have the "tick" icon and set the icon property to ef-icon with hover-icon id', async () => {
       const el = await fixture(html`<ef-button icon="search" hover-icon="tick"></ef-button>`);
       const iconEl = el.shadowRoot.querySelector('#hover-icon');
       expect(iconEl.getAttribute('icon')).to.equal('tick');
@@ -135,40 +137,41 @@ describe('button/Button', () => {
   });
 
   describe('Default Slot', () => {
-    it('the text content should have the "Button" string in the textContent field if the slot has the "Button" string', async () => {
+    it('should have the "Button" string in the textContent field if the slot has the "Button" string', async () => {
       const el = await fixture(html`<ef-button>Button</ef-button>`);
       expect(el.textContent.trim()).to.equal('Button');
     });
 
-    it('the text content should have the empty string if the slot is empty', async () => {
+    it('should have the empty string if the slot is empty', async () => {
       const el = await fixture(html`<ef-button></ef-button>`);
       expect(el.textContent.trim()).to.equal('');
     });
   });
 
   describe('Toggle Behavior For The Tap Event', () => {
-    it('the element should set the active property to true if the element with toggles attribute is taped', async () => {
+    it('should set the active property to true if the element with toggles attribute is taped', async () => {
       const el = await fixture(html`<ef-button toggles icon="icon.png" hover-icon="hover-icon.png"></ef-button>`);
       setTimeout(() => el.dispatchEvent(new Event('tap')));
       await oneEvent(el, 'tap');
       expect(el.active).to.equal(true);
     });
 
-    it('the element should set the active property to false if the element with toggles and active attributes are taped', async () => {
+    it('should set the active property to false if the element with toggles and active attributes are taped', async () => {
       const el = await fixture(html`<ef-button toggles active icon="icon.png" hover-icon="hover-icon.png"></ef-button>`);
       setTimeout(() => el.dispatchEvent(new Event('tap')));
       await oneEvent(el, 'tap');
       expect(el.active).to.equal(false);
     });
+
     describe('Role=radio', () => {
-      it('the element should set the active property to true if the element with toggles attribute is taped', async () => {
+      it('should set the active property to true if the element with toggles attribute is taped', async () => {
         const el = await fixture(html`<ef-button toggles role="radio" icon="icon.png" hover-icon="hover-icon.png"></ef-button>`);
         setTimeout(() => el.dispatchEvent(new Event('tap')));
         await oneEvent(el, 'tap');
         expect(el.active).to.equal(true);
       });
 
-      it('the element should set the active property to false if the element with toggles and active attributes are taped', async () => {
+      it('should set the active property to false if the element with toggles and active attributes are taped', async () => {
         const el = await fixture(html`<ef-button toggles active role="radio" icon="icon.png" hover-icon="hover-icon.png"></ef-button>`);
         setTimeout(() => el.dispatchEvent(new Event('tap')));
         await oneEvent(el, 'tap');
@@ -190,6 +193,19 @@ describe('button/Button', () => {
       const el = await fixture(html`<ef-button></ef-button>`);
       setTimeout(() => el.dispatchEvent(new Event('tap')));
       await oneEvent(el, 'tap');
+    });
+
+    it('should have `pressed` attribute reflected when `tapstart` and removed when `tapend`', async () => {
+      const el = await fixture(html`<ef-button></ef-button>`);
+      el.dispatchEvent(new Event('tapstart'));
+      await elementUpdated(el);
+
+      expect(el.getAttribute('pressed')).to.equal('');
+
+      el.dispatchEvent(new Event('tapend'));
+      await elementUpdated(el);
+
+      expect(el.getAttribute('pressed')).to.equal(null);
     });
 
     it('should call the keyboard event with space or enter', async () => {
@@ -217,47 +233,37 @@ describe('button/Button', () => {
       expect(el).not.to.be.accessible();
     });
 
-    it('should pass a11y testing with aria-label', async () => {
+    it('', async () => {
       const el = await fixture(`<ef-button aria-label="Tick Icon" icon="tick"></ef-button>`);
       expect(el).to.be.accessible({
         ignoredRules: ['aria-allowed-attr']
       });
     });
 
-    it('should pass a11y testing with slotted label', async () => {
+    it('', async () => {
       const el = await fixture(`<ef-button>TEST</ef-button>`);
       expect(el).to.be.accessible({
         ignoredRules: ['aria-allowed-attr', 'color-contrast']
       });
     });
 
-
-    describe('should pass a11y testing in toggle mode', () => {
-      it('when button is not pressed', async () => {
-        const el = await fixture(`<ef-button toggles>Toggle</ef-button>`);
-        expect(el).to.be.accessible({
-          ignoredRules: ['aria-allowed-attr', 'color-contrast']
-        });
-        await expect(el.getAttribute('aria-pressed')).to.equal('false');
-      });
-
-      it('when button is pressed', async () => {
-        const el = await fixture(`<ef-button toggles active>Toggle</ef-button>`);
-        expect(el).to.be.accessible({
-          ignoredRules: ['aria-allowed-attr', 'color-contrast']
-        });
-        await expect(el.getAttribute('aria-pressed')).to.equal('true');
-      });
-    });
-
-    it('should pass a11y testing when disabled is set', async () => {
-      const el = await fixture(`<ef-button disabled>Disabled</ef-button>`);
+    it('should have aria-pressed="false" when it is not pressed', async () => {
+      const el = await fixture(`<ef-button toggles>Toggle</ef-button>`);
       expect(el).to.be.accessible({
         ignoredRules: ['aria-allowed-attr', 'color-contrast']
       });
+      await expect(el.getAttribute('aria-pressed')).to.equal('false');
     });
 
-    it('aria-pressed should be replaced by aria-checked when button has role=radio', async () => {
+    it('should have aria-pressed="true" when it is pressed', async () => {
+      const el = await fixture(`<ef-button toggles active>Toggle</ef-button>`);
+      expect(el).to.be.accessible({
+        ignoredRules: ['aria-allowed-attr', 'color-contrast']
+      });
+      await expect(el.getAttribute('aria-pressed')).to.equal('true');
+    });
+
+    it('should have aria-pressed instead of aria-checked when button has role="radio"', async () => {
       const el = await fixture(`<ef-button role='radio' toggles></ef-button>`);
       expect(el.hasAttribute('aria-checked')).to.be.true;
       expect(el.hasAttribute('aria-pressed')).to.be.false;


### PR DESCRIPTION
## Description

- Adds `tapstart` and  `tapend` test cases to button in order to increase test coverage. 
- Renames some of the test cases.  
