### PR TITLE
fix(interactive-chart): handle case when rowLegend is null

### DIFF
--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -831,8 +831,13 @@ export class InteractiveChart extends ResponsiveElement {
    * @returns {void}
    */
   protected renderTextLegend (chartType: string, rowLegendElem: RowLegend, value: SeriesDataItem | number | string, priceColor: string, index: number): void {
+    // No need to render if disable legend
+    if (this.disabledLegend) {
+      return;
+    }
+
     if (chartType === 'bar' || chartType === 'candlestick') {
-      if (!this.hasDataPoint && this.isNodeListElement(rowLegendElem)) {
+      if (!this.hasDataPoint && rowLegendElem instanceof NodeList) {
         const spanElem = rowLegendElem[index].querySelectorAll('span.price,span.ohlc');
         spanElem.forEach(span => rowLegendElem[index].removeChild(span));
         const span = document.createElement('span');
@@ -850,24 +855,6 @@ export class InteractiveChart extends ResponsiveElement {
   }
 
   /**
-  * Check `node` inside row legend and case type to HTMLElement
-  * @param rowLegend Legend element
-  * @returns true if not have `node` inside row legend
-  */
-  private isHTMLElement (rowLegend: RowLegend): rowLegend is HTMLElement {
-    return (rowLegend as NodeListOf<Element>).length === undefined;
-  }
-
-  /**
-  * Check `node` inside row legend and case type to NodeListOf<Element>
-  * @param rowLegend Legend element
-  * @returns true if have `node` inside row legend
-  */
-  private isNodeListElement (rowLegend: RowLegend): rowLegend is NodeListOf<Element> {
-    return (rowLegend as NodeListOf<Element>) !== undefined;
-  }
-
-  /**
    * Create span OHLC in row legend used by several series types such as bars or candlesticks
    * @param rowLegend Legend element
    * @param rowData Value of series
@@ -875,7 +862,7 @@ export class InteractiveChart extends ResponsiveElement {
    * @returns {void}
    */
   private createSpanOHLC (rowLegend: RowLegend, rowData: BarData, priceColor: string): void {
-    if (this.isHTMLElement(rowLegend)) {
+    if (rowLegend instanceof HTMLElement) {
       rowLegend.setAttribute('data-color', priceColor);
       this.createSpan(rowLegend, 'O', rowData.open, 'H', rowData.high, 'L', rowData.low, 'C', rowData.close);
     }
@@ -901,11 +888,11 @@ export class InteractiveChart extends ResponsiveElement {
       } as BarData;
     }
     // Create text price after chart has rendered
-    if (this.isHTMLElement(rowLegend)) {
+    if (rowLegend instanceof HTMLElement) {
       this.createSpanOHLC(rowLegend, rowData, priceColor);
     }
     // Handle update text price when mouse crosshairMove in chart
-    else if (this.isNodeListElement(rowLegend)) {
+    else if (rowLegend instanceof NodeList) {
       const rowSpanLength = rowLegend[index].children.length;
       let countElmPrice = 0;
       for (let spanIndex = 0; spanIndex < rowSpanLength; spanIndex++) {
@@ -955,12 +942,12 @@ export class InteractiveChart extends ResponsiveElement {
     const formattedPrice = !!formatter && price !== NO_DATA_POINT ? formatter(price) : price;
 
     // Create text price after chart has rendered
-    if (this.isHTMLElement(rowLegend)) {
+    if (rowLegend instanceof HTMLElement) {
       rowLegend.setAttribute('data-color', priceColor);
       this.createSpan(rowLegend, formattedPrice);
     }
     // Handle update text price when mouse crosshairMove in chart
-    else if (this.isNodeListElement(rowLegend)) {
+    else if (rowLegend instanceof NodeList) {
       const symbolElem = rowLegend[index].children[0];
       const spanIndex = symbolElem.getAttribute('class')?.indexOf('symbol') === 0 ? 1 : 0;
       const rowLegendElem = rowLegend[index];


### PR DESCRIPTION
## Description
As a type `RowLegendInterface`, the rowLegend was possible to have a null value but we did not have any method to check the null value. Therefore, I propose the solution that we can use `instanceof` as a type guard on this issue. Additionally, the legend will not render if `disabledLegend` is set to be true.

Fixes # (issue)
(https://jira.refinitiv.com/browse/ELF-1797) 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings