### PR TITLE
fix(core): check if ShadyCSS is defined before calling the statement

### DIFF
--- a/packages/core/src/registries/NativeStyleRegistry.ts
+++ b/packages/core/src/registries/NativeStyleRegistry.ts
@@ -30,9 +30,12 @@ export abstract class NativeStyleRegistry {
     style.setAttribute('scope', name);
     style.textContent = css;
     childRef ? head.insertBefore(style, childRef) : head.appendChild(style);
-    // Register style tag with ShadyCSS
-    // to support CSS variables in legacy browsers
-    ShadyCSS?.CustomStyleInterface?.addCustomStyle(style);
+
+    if (ShadyCSS) {
+      // Register style tag with ShadyCSS
+      // to support CSS variables in legacy browsers
+      ShadyCSS?.CustomStyleInterface?.addCustomStyle(style);
+    }
   }
   /**
    * Gets any native style that has already been defined.

--- a/packages/core/src/registries/NativeStyleRegistry.ts
+++ b/packages/core/src/registries/NativeStyleRegistry.ts
@@ -34,7 +34,7 @@ export abstract class NativeStyleRegistry {
     if (ShadyCSS) {
       // Register style tag with ShadyCSS
       // to support CSS variables in legacy browsers
-      ShadyCSS?.CustomStyleInterface?.addCustomStyle(style);
+      ShadyCSS.CustomStyleInterface.addCustomStyle(style);
     }
   }
   /**


### PR DESCRIPTION
## Description 

Fixes core crashing when ShadyCSS is undefined.