### PR TITLE
Utils A11Y adds the logic to get a text from aria-label

### DIFF
--- a/packages/utils/src/accessibility/helpers.ts
+++ b/packages/utils/src/accessibility/helpers.ts
@@ -15,6 +15,12 @@ const textFromElementIds = (rootNode: Document | DocumentFragment, ids: string):
   for (let i = 0; i < elementIds.length; i += 1) {
     const element = rootNode.getElementById(elementIds[i]);
     if (element) {
+      // Get text from aria-label if available
+      if (element.hasAttribute('aria-label')) {
+        labels.push(element.getAttribute('aria-label') || '');
+        continue;
+      }
+
       labels.push(element.textContent || '');
     }
   }

--- a/packages/utils/src/accessibility/label.ts
+++ b/packages/utils/src/accessibility/label.ts
@@ -27,7 +27,17 @@ const label = (element: HTMLElement): string | null => {
 
   if (element.id) {
     const labelForElement = rootNode.querySelector(`label[for="${element.id}"]`);
-    return labelForElement instanceof HTMLLabelElement ? (labelForElement.textContent || '') : null;
+
+    if (labelForElement instanceof HTMLLabelElement) {
+      // Use text from aria-label fist if available
+      if (labelForElement.hasAttribute('aria-label')) {
+        return labelForElement.getAttribute('aria-label') || '';
+      }
+
+      return labelForElement.textContent || '';
+    }
+
+    return null;
   }
 
   return null;


### PR DESCRIPTION
## Description
Add the logic of getting a text to create a label by picking the text from an `aria-label` attribute before picking a text content.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings