### PR TITLE
Incorrect focus management with Shift+Tab and delegatesFocus

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,8 @@ export {
   html,
   svg,
   css,
-  unsafeCSS
+  unsafeCSS,
+  render
 } from 'lit';
 
 export type {
@@ -56,6 +57,7 @@ export type { StyleInfo } from './interfaces/StyleInfo';
  */
 export { FocusableHelper } from './utils/focusableHelper.js';
 export { matches } from './utils/matches.js';
+export { isBasicElement } from './utils/helpers.js';
 
 /**
  * Export focused key.

--- a/packages/elements/src/overlay/managers/focus-manager.ts
+++ b/packages/elements/src/overlay/managers/focus-manager.ts
@@ -1,7 +1,7 @@
 import type { Overlay } from '../elements/overlay';
 import { AnimationTaskRunner } from '@refinitiv-ui/utils/async.js';
 import { getOverlays } from './zindex-manager.js';
-import { FocusableHelper } from '@refinitiv-ui/core';
+import { isBasicElement, FocusableHelper } from '@refinitiv-ui/core';
 
 type ActiveTabbableNodes = {
   nodes: HTMLElement[];
@@ -103,7 +103,15 @@ export class FocusManager {
   }
 
   private getReTargetFocusNode (nodes: HTMLElement[]): HTMLElement | null {
-    const activeElement = this.getActiveElement();
+    let activeElement = this.getActiveElement();
+
+    // This code fixes a bug when focus is going outside the overlay
+    // when Shift+Tab is used and element delegates focus.
+    // Once native delegatesFocus is implemented this code can be safely removed
+    if (isBasicElement(activeElement) && activeElement.delegatesFocus) {
+      activeElement = activeElement.tabbableElements[0] || activeElement;
+    }
+
     if (!activeElement || activeElement === nodes[nodes.length - 1] || !this.isFocusBoundaryDescendant(activeElement)) {
       return nodes[0];
     }


### PR DESCRIPTION
## Description
When using Shift + Tab it is possible to navigate outside the dialog scope.
Add missing exports to core.

Fixes #ELF-1828

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings