### PR TITLE
docs(): remove additional type definition section

### DIFF
--- a/documents/src/pages/build-app/framework-integration/angular.md
+++ b/documents/src/pages/build-app/framework-integration/angular.md
@@ -278,16 +278,4 @@ export class NumberFieldValueAccessor implements ControlValueAccessor {
   }
 ```
 
-## Additional type definition
-
-Some EF elements supports i18N features. It uses [FormatJS](https://formatjs.io/) library and some of thier modules are using features that available in new Javascript version. If you see any errors related to @formatjs during project compilation, you may need to add `esnext.intl` into `lib` section in `tsconfig.json` file.
-
-```diff
-"lib": [
-  "es2018",
-+ "esnext.intl"
-  "dom"
-]
-```
-
 ::footer::


### PR DESCRIPTION
## Description
Remove type definition section from build app of Angular page.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings