### PR TITLE
chore: update webcomponent-analyzer version to support typescript 4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "sinon": "^9.2.4",
         "typescript": "^4.6.2",
         "watch": "^1.0.2",
-        "web-component-analyzer": "^2.0.0-next.3",
+        "web-component-analyzer": "2.0.0-next.4",
         "yargs": "^17.0.1"
       },
       "engines": {
@@ -18851,14 +18851,14 @@
       }
     },
     "node_modules/web-component-analyzer": {
-      "version": "2.0.0-next.3",
-      "resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.3.tgz",
-      "integrity": "sha512-4EubqKbhaCdtIc1+NQ1Y5oTRfVD7wi31FL5J3PI2VjtiI/G/e3QXvLHc2lLooDWqrqf0V3uNLL0Et9TFXBPY1g==",
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.4.tgz",
+      "integrity": "sha512-XZ4JOibgp+3OKAQ6K9v4gJOoHAurfXztbfX6FwqXIh4cNLTwHz4QcLDOFav+2ddKGpshM4MQrJaPCPXZeCv5+A==",
       "dev": true,
       "dependencies": {
         "fast-glob": "^3.2.2",
         "ts-simple-type": "2.0.0-next.0",
-        "typescript": "~4.3.2",
+        "typescript": "~4.4.3",
         "yargs": "^15.3.1"
       },
       "bin": {
@@ -18944,9 +18944,9 @@
       }
     },
     "node_modules/web-component-analyzer/node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -33522,14 +33522,14 @@
       }
     },
     "web-component-analyzer": {
-      "version": "2.0.0-next.3",
-      "resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.3.tgz",
-      "integrity": "sha512-4EubqKbhaCdtIc1+NQ1Y5oTRfVD7wi31FL5J3PI2VjtiI/G/e3QXvLHc2lLooDWqrqf0V3uNLL0Et9TFXBPY1g==",
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.4.tgz",
+      "integrity": "sha512-XZ4JOibgp+3OKAQ6K9v4gJOoHAurfXztbfX6FwqXIh4cNLTwHz4QcLDOFav+2ddKGpshM4MQrJaPCPXZeCv5+A==",
       "dev": true,
       "requires": {
         "fast-glob": "^3.2.2",
         "ts-simple-type": "2.0.0-next.0",
-        "typescript": "~4.3.2",
+        "typescript": "~4.4.3",
         "yargs": "^15.3.1"
       },
       "dependencies": {
@@ -33583,9 +33583,9 @@
           }
         },
         "typescript": {
-          "version": "4.3.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-          "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+          "version": "4.4.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+          "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
           "dev": true
         },
         "wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "sinon": "^9.2.4",
         "typescript": "^4.6.2",
         "watch": "^1.0.2",
-        "web-component-analyzer": "^1.1.6",
+        "web-component-analyzer": "^2.0.0-next.3",
         "yargs": "^17.0.1"
       },
       "engines": {
@@ -18250,9 +18250,10 @@
       }
     },
     "node_modules/ts-simple-type": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-2.0.0-next.0.tgz",
+      "integrity": "sha512-A+hLX83gS+yH6DtzNAhzZbPfU+D9D8lHlTSd7GeoMRBjOt3GRylDqLTYbdmjA4biWvq2xSfpqfIDj2l0OA/BVg==",
+      "dev": true
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
@@ -18850,13 +18851,14 @@
       }
     },
     "node_modules/web-component-analyzer": {
-      "version": "1.1.6",
+      "version": "2.0.0-next.3",
+      "resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.3.tgz",
+      "integrity": "sha512-4EubqKbhaCdtIc1+NQ1Y5oTRfVD7wi31FL5J3PI2VjtiI/G/e3QXvLHc2lLooDWqrqf0V3uNLL0Et9TFXBPY1g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.2.2",
-        "ts-simple-type": "~1.0.5",
-        "typescript": "^3.8.3",
+        "ts-simple-type": "2.0.0-next.0",
+        "typescript": "~4.3.2",
         "yargs": "^15.3.1"
       },
       "bin": {
@@ -18942,9 +18944,10 @@
       }
     },
     "node_modules/web-component-analyzer/node_modules/typescript": {
-      "version": "3.9.10",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -33099,7 +33102,9 @@
       "dev": true
     },
     "ts-simple-type": {
-      "version": "1.0.7",
+      "version": "2.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/ts-simple-type/-/ts-simple-type-2.0.0-next.0.tgz",
+      "integrity": "sha512-A+hLX83gS+yH6DtzNAhzZbPfU+D9D8lHlTSd7GeoMRBjOt3GRylDqLTYbdmjA4biWvq2xSfpqfIDj2l0OA/BVg==",
       "dev": true
     },
     "tsconfig-paths": {
@@ -33517,12 +33522,14 @@
       }
     },
     "web-component-analyzer": {
-      "version": "1.1.6",
+      "version": "2.0.0-next.3",
+      "resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.3.tgz",
+      "integrity": "sha512-4EubqKbhaCdtIc1+NQ1Y5oTRfVD7wi31FL5J3PI2VjtiI/G/e3QXvLHc2lLooDWqrqf0V3uNLL0Et9TFXBPY1g==",
       "dev": true,
       "requires": {
         "fast-glob": "^3.2.2",
-        "ts-simple-type": "~1.0.5",
-        "typescript": "^3.8.3",
+        "ts-simple-type": "2.0.0-next.0",
+        "typescript": "~4.3.2",
         "yargs": "^15.3.1"
       },
       "dependencies": {
@@ -33576,7 +33583,9 @@
           }
         },
         "typescript": {
-          "version": "3.9.10",
+          "version": "4.3.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+          "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
           "dev": true
         },
         "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "sinon": "^9.2.4",
     "typescript": "^4.6.2",
     "watch": "^1.0.2",
-    "web-component-analyzer": "^2.0.0-next.3",
+    "web-component-analyzer": "2.0.0-next.4",
     "yargs": "^17.0.1",
     "@nrwl/workspace": "latest",
     "@nrwl/cli": "latest",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "sinon": "^9.2.4",
     "typescript": "^4.6.2",
     "watch": "^1.0.2",
-    "web-component-analyzer": "^1.1.6",
+    "web-component-analyzer": "^2.0.0-next.3",
     "yargs": "^17.0.1",
     "@nrwl/workspace": "latest",
     "@nrwl/cli": "latest",


### PR DESCRIPTION
## Description
Previously `web-component-analyzer` treats `protected override` method as a public method because it doesn't know `override` keyword after update typescript version of this package to 4.3 the problem should be solved.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
