### PR TITLE
Fix/calendar wrong disable color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,10 +54,10 @@
     },
     "documents": {
       "name": "@refinitiv-ui/docs",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@refinitiv-ui/elements": "^5.12.1",
+        "@refinitiv-ui/elements": "^5.12.2",
         "fast-glob": "^3.2.7",
         "fs-extra": "^10.0.0"
       },
@@ -18229,7 +18229,7 @@
     },
     "packages/elements": {
       "name": "@refinitiv-ui/elements",
-      "version": "5.12.1",
+      "version": "5.12.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@refinitiv-ui/browser-sparkline": "1.1.7",
@@ -18238,7 +18238,7 @@
         "@refinitiv-ui/i18n": "^5.2.6",
         "@refinitiv-ui/phrasebook": "^5.4.1",
         "@refinitiv-ui/solar-theme": "^5.7.0",
-        "@refinitiv-ui/translate": "^5.3.2",
+        "@refinitiv-ui/translate": "^5.3.3",
         "@refinitiv-ui/utils": "^5.1.2",
         "@types/chart.js": "^2.9.31",
         "chart.js": "~2.9.4",
@@ -18295,7 +18295,7 @@
     },
     "packages/polyfills": {
       "name": "@refinitiv-ui/polyfills",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@webcomponents/custom-elements": "^1.4.1",
@@ -18842,7 +18842,7 @@
     },
     "packages/translate": {
       "name": "@refinitiv-ui/translate",
-      "version": "5.3.2",
+      "version": "5.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@refinitiv-ui/i18n": "^5.2.6",
@@ -22134,7 +22134,7 @@
     "@refinitiv-ui/docs": {
       "version": "file:documents",
       "requires": {
-        "@refinitiv-ui/elements": "^5.12.1",
+        "@refinitiv-ui/elements": "^5.12.2",
         "chalk": "^4.1.2",
         "concurrently": "^6.4.0",
         "fast-glob": "^3.2.7",
@@ -22170,7 +22170,7 @@
         "@refinitiv-ui/phrasebook": "^5.4.1",
         "@refinitiv-ui/solar-theme": "^5.7.0",
         "@refinitiv-ui/test-helpers": "^5.1.2",
-        "@refinitiv-ui/translate": "^5.3.2",
+        "@refinitiv-ui/translate": "^5.3.3",
         "@refinitiv-ui/utils": "^5.1.2",
         "@types/chart.js": "^2.9.31",
         "@types/d3-interpolate": "^3.0.1",

--- a/packages/halo-theme/src/custom-elements/ef-calendar.less
+++ b/packages/halo-theme/src/custom-elements/ef-calendar.less
@@ -61,7 +61,7 @@
   }
 
   [part~=cell] {
-    &[disabled] [part~="selection"] {
+    &[disabled] {
       opacity: 0.4;
     }
 

--- a/packages/solar-theme/src/custom-elements/ef-calendar.less
+++ b/packages/solar-theme/src/custom-elements/ef-calendar.less
@@ -54,7 +54,7 @@
       box-shadow: 1px 0 0 0 @separator-color;
     }
 
-    &[disabled] [part~="selection"] {
+    &[disabled] {
       opacity: 0.4;
     }
 


### PR DESCRIPTION
## Description
Disabled dates on Calendar (and DateTime Picker) don't apply disabled background colour.

It seems that when implemented Accessibility supports in Calendar, disabled cell has been removed part  `selection` from disabled cell so CSS selectors for disabled cell isn't applied.

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-1836

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings