### PR TITLE
fix(tree): render wrong state when data is invalid

### DIFF
--- a/packages/elements/src/tree/__test__/mock_data/multi-level.js
+++ b/packages/elements/src/tree/__test__/mock_data/multi-level.js
@@ -81,17 +81,17 @@ export const multiLevelInvalidData = [
     'items': [{
       'value': 'l23',
       'label': 'Level 2-3',
-      'selected': false,
+      'selected': true,
       'expanded': true,
       'items': [{
         'value': 'l34',
         'label': 'Level 3-4',
-        'selected': true,
+        'selected': false,
         'expanded': true,
       },{
         'value': 'l35',
         'label': 'Level 3-5',
-        'selected': true,
+        'selected': false,
         'expanded': true,
       }]
     },{

--- a/packages/elements/src/tree/__test__/mock_data/multi-level.js
+++ b/packages/elements/src/tree/__test__/mock_data/multi-level.js
@@ -42,3 +42,63 @@ export const multiLevelData = [
     }]
   }
 ];
+
+export const multiLevelInvalidData = [
+  {
+    'value': 'l11',
+    'selected': true,
+    'label': 'Level 1-1',
+    'items': [{
+      'value': 'l21',
+      'label': 'Level 2-1',
+      'selected': false,
+      'expanded': true,
+      'items': [{
+        'value': 'l31',
+        'label': 'Level 3-1',
+        'selected': true,
+      },{
+        'value': 'l32',
+        'label': 'Level 3-2',
+        'selected': true,
+      }]
+    },{
+      'value': 'l22',
+      'label': 'Level 2-2',
+      'selected': false,
+      'expanded': true,
+      'items': [{
+        'value': 'l33',
+        'label': 'Level 3-3',
+        'selected': true,
+      }]
+    }]
+  }, {
+    'value': 'l12',
+    'label': 'Level 1-2',
+    'expanded': true,
+    'selected': true,
+    'items': [{
+      'value': 'l23',
+      'label': 'Level 2-3',
+      'selected': false,
+      'expanded': true,
+      'items': [{
+        'value': 'l34',
+        'label': 'Level 3-4',
+        'selected': true,
+        'expanded': true,
+      },{
+        'value': 'l35',
+        'label': 'Level 3-5',
+        'selected': true,
+        'expanded': true,
+      }]
+    },{
+      'value': 'l24',
+      'label': 'Level 2-4',
+      'selected': true,
+      'expanded': true,
+    }]
+  }
+];

--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -398,15 +398,26 @@ describe('tree/Tree', () => {
       expect(el.values).to.deep.equal(['1.1', '1.2']);
     });
 
+    it('Render correct un-checked states when data is invalid', async () => {
+      const el = await fixture('<ef-tree multiple></ef-tree>');
+      el.data = multiLevelInvalidData;
+      await elementUpdated(el);
+      expect(el.querySelectorAll('[selected]').length).to.equal(3);
+      el.uncheckAll();
+      await elementUpdated(el);
+      await nextFrame();
+      expect(el.querySelectorAll('[selected]').length).to.equal(0, 'All item is unchecked');
+    });
+    
     it('Render correct checked states when data is invalid', async () => {
       const el = await fixture('<ef-tree multiple></ef-tree>');
       el.data = multiLevelInvalidData;
       await elementUpdated(el);
-      expect(el.querySelectorAll('[selected]').length).to.equal(6);
-      el.uncheckAll();
+      expect(el.querySelectorAll('[selected]').length).to.equal(3);
+      el.checkAll();
       await elementUpdated(el);
       await nextFrame();
-      expect(el.querySelectorAll('[selected]').length).to.equal(0);
+      expect(el.querySelectorAll('[selected]').length).to.equal(6, 'All item is checked');
     });
   });
 

--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -11,7 +11,7 @@ import {
 // import element and theme
 import '@refinitiv-ui/elements/tree';
 import '@refinitiv-ui/elemental-theme/light/ef-tree';
-import { multiLevelData } from './mock_data/multi-level';
+import { multiLevelData, multiLevelInvalidData } from './mock_data/multi-level';
 
 const keyArrowUp = keyboardEvent('keydown', { key: 'Up' });
 const keyArrowDown = keyboardEvent('keydown', { key: 'Down' });
@@ -396,6 +396,17 @@ describe('tree/Tree', () => {
       await elementUpdated(el);
       expect(el.value).to.equal('1.1');
       expect(el.values).to.deep.equal(['1.1', '1.2']);
+    });
+
+    it('Render correct checked states when data is invalid', async () => {
+      const el = await fixture('<ef-tree multiple></ef-tree>');
+      el.data = multiLevelInvalidData;
+      await elementUpdated(el);
+      expect(el.querySelectorAll('[selected]').length).to.equal(6);
+      el.uncheckAll();
+      await elementUpdated(el);
+      await nextFrame();
+      expect(el.querySelectorAll('[selected]').length).to.equal(0);
     });
   });
 

--- a/packages/elements/src/tree/managers/tree-manager.ts
+++ b/packages/elements/src/tree/managers/tree-manager.ts
@@ -388,7 +388,7 @@ export class TreeManager<T extends TreeDataItem> {
       this.composer.setItemPropertyValue(item, 'selected', true);
       if (manageRelationships) {
         this.forceUpdateOnPath(item);
-        this.getItemDescendants(item).forEach(descendant => this._checkItem(descendant, false));
+        this.getItemDescendants(item).forEach(descendant => this._checkItem(descendant, this.isItemParent(descendant)));
       }
       return true;
     }

--- a/packages/elements/src/tree/managers/tree-manager.ts
+++ b/packages/elements/src/tree/managers/tree-manager.ts
@@ -408,7 +408,7 @@ export class TreeManager<T extends TreeDataItem> {
       this.composer.setItemPropertyValue(item, 'selected', false);
       if (manageRelationships) {
         this.forceUpdateOnPath(item);
-        this.getItemDescendants(item).forEach(descendant => this._uncheckItem(descendant, false));
+        this.getItemDescendants(item).forEach(descendant => this._uncheckItem(descendant, this.isItemParent(descendant)));
       }
       return true;
     }


### PR DESCRIPTION
## Description
In this case is fixed about tree element render wrong checked/unchecked state when data is invalid. 

It seems that tree-manager recursive logic checkItem/uncheckItem when call item descendants is always sent false to `manageRelationships` parameter and not work perfectly when item level 1 called item level 2 with descendants.

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-1835

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings