### PR TITLE
fix(clock): a11y, tick, show-seconds should not pronounce all the time

### DIFF
--- a/packages/elements/src/clock/__test__/clock.interactive.test.js
+++ b/packages/elements/src/clock/__test__/clock.interactive.test.js
@@ -147,7 +147,7 @@ describe('clock/Interactive', () => {
     });
     
     describe('Accessibility', () => {
-      it('Should have role="spinbutton" and focusable', async () => {
+      it('Should have role="spinbutton", be focusable, and aria attributes', async () => {
         expect(el.getAttribute('role')).to.be.equal('spinbutton');
         expect(el.getAttribute('tabindex')).to.be.equal('0');
         expect(el.getAttribute('aria-valuenow')).to.be.equal(`${el.displayTime}`);

--- a/packages/elements/src/clock/__test__/clock.interactive.test.js
+++ b/packages/elements/src/clock/__test__/clock.interactive.test.js
@@ -150,6 +150,16 @@ describe('clock/Interactive', () => {
       it('Should have role="spinbutton" and focusable', async () => {
         expect(el.getAttribute('role')).to.be.equal('spinbutton');
         expect(el.getAttribute('tabindex')).to.be.equal('0');
+        expect(el.getAttribute('aria-valuenow')).to.be.equal(`${el.displayTime}`);
+        expect(el.getAttribute('aria-valuetext')).to.be.equal('Time: 00:00');
+      });
+      it('Should remove attributes when interactive attribute has been change', async () => {
+        el.interactive = false;
+        await elementUpdated(el);
+        expect(el.getAttribute('role')).to.be.equal(null);
+        expect(el.getAttribute('tabindex')).to.be.equal(null);
+        expect(el.getAttribute('aria-valuenow')).to.be.equal(null);
+        expect(el.getAttribute('aria-valuetext')).to.be.equal(null);
       });
       it('Should increase hour value and update aria-valuetext when Arrow Up is pressed on hour segment', async () => {
         await onTapstart(hoursSegment, el);

--- a/packages/elements/src/clock/index.ts
+++ b/packages/elements/src/clock/index.ts
@@ -728,7 +728,7 @@ export class Clock extends ResponsiveElement {
       void this.updateAriaValue(true);
     }
 
-    if (changedProperties.has('sessionTicks')) {
+    if (this.interactive && changedProperties.has('sessionTicks')) {
       // Avoid announce every second that could interrupt the screen reader when the user takes an action.
       if (this.isDisplayMinutesChange) {
         void this.updateAriaValue(true);

--- a/packages/elements/src/clock/index.ts
+++ b/packages/elements/src/clock/index.ts
@@ -728,8 +728,8 @@ export class Clock extends ResponsiveElement {
       void this.updateAriaValue();
     }
 
+    // Avoid announce every second that could interrupt the screen reader when the user takes an action.
     if (this.interactive && changedProperties.has('sessionTicks')) {
-      // Avoid announce every second that could interrupt the screen reader when the user takes an action.
       void this.updateAriaValue(this.isDisplayMinutesChange);
     }
   }

--- a/packages/elements/src/clock/index.ts
+++ b/packages/elements/src/clock/index.ts
@@ -411,6 +411,14 @@ export class Clock extends ResponsiveElement {
   }
 
   /**
+   * Returns `true` if display minutes has changed
+   * @returns Result
+   */
+  private get isDisplayMinutesChange (): boolean {
+    return this.displayTime % SECONDS_IN_MINUTE === 0;
+  }
+
+  /**
    * Configures the tick manager to either start or stop ticking,
    * depending on the state of the element.
    * @param [forceTick=false] forces a tick update
@@ -579,17 +587,20 @@ export class Clock extends ResponsiveElement {
 
   /**
   * Set aria-valuenow to display value and aria-valuetext to translated format
+  * @param updateAriaValueText condition to update aria-valueText
   * @returns {void}
   */
-  private async updateAriaValue () {
-    const value = await this.tPromise('TIME', {
-      value: parse(this.displayValue),
-      amPm: this.amPm,
-      // Avoid every second announcement that could interrupt the screen reader when the user takes an action.
-      showSeconds: (this.interactive && this.tick) ? false : this.showSeconds
-    });
+  private async updateAriaValue (updateAriaValueText: boolean) {
     this.setAttribute('aria-valuenow', `${this.displayTime}`);
-    this.setAttribute('aria-valuetext', value);
+    
+    if (updateAriaValueText) {
+      const value = await this.tPromise('TIME', {
+        value: parse(this.displayValue),
+        amPm: this.amPm,
+        showSeconds: this.showSeconds
+      });
+      this.setAttribute('aria-valuetext', value);
+    }
   }
 
   /**
@@ -709,13 +720,22 @@ export class Clock extends ResponsiveElement {
     super.willUpdate(changedProperties);
 
     if (this.interactive && (!this.hasUpdated
-      || changedProperties.has('sessionTicks')
       || changedProperties.has('offset')
       || changedProperties.has('value')
       || changedProperties.has('showSeconds')
       || changedProperties.has('amPm')
       || changedProperties.has(TranslatePropertyKey))) {
-      void this.updateAriaValue();
+      void this.updateAriaValue(true);
+    }
+
+    if (changedProperties.has('sessionTicks')) {
+      // Avoid announce every second that could interrupt the screen reader when the user takes an action.
+      if (this.isDisplayMinutesChange) {
+        void this.updateAriaValue(true);
+      }
+      else {
+        void this.updateAriaValue(false);
+      }
     }
   }
 

--- a/packages/elements/src/clock/index.ts
+++ b/packages/elements/src/clock/index.ts
@@ -695,8 +695,9 @@ export class Clock extends ResponsiveElement {
    */
   private interactiveChanged (): void {
     if (this.interactive) {
+      const tabIndex = (this.tabIndex >= 0) ? this.tabIndex.toString() : '0';
       this.setAttribute('role', 'spinbutton');
-      this.setAttribute('tabindex', this.getAttribute('tabindex') || '0');
+      this.setAttribute('tabindex', tabIndex);
       void this.updateAriaValue();
     }
     else {

--- a/packages/elements/src/clock/index.ts
+++ b/packages/elements/src/clock/index.ts
@@ -696,7 +696,7 @@ export class Clock extends ResponsiveElement {
   private interactiveChanged (): void {
     if (this.interactive) {
       this.setAttribute('role', 'spinbutton');
-      this.setAttribute('tabindex', '0');
+      this.setAttribute('tabindex', this.getAttribute('tabindex') || '0');
       void this.updateAriaValue();
     }
     else {

--- a/packages/elements/src/clock/index.ts
+++ b/packages/elements/src/clock/index.ts
@@ -690,9 +690,7 @@ export class Clock extends ResponsiveElement {
   }
 
   /**
-   * Handles interactive by changing role, tabindex, and aria attribute changes
-   * When interactive mode, clock will be focusable, role=spinbutton, and update aria attributes.
-   * When non interactive mode, clock is unable to focus, no role, and remove related aria attributes.
+   * Handles interactive by update role, tabindex, and aria attribute
    * @returns {void}
    */
   private interactiveChanged (): void {

--- a/packages/elements/src/clock/index.ts
+++ b/packages/elements/src/clock/index.ts
@@ -590,7 +590,7 @@ export class Clock extends ResponsiveElement {
   * @param updateAriaValueText condition to update aria-valueText
   * @returns {void}
   */
-  private async updateAriaValue (updateAriaValueText: boolean) {
+  private async updateAriaValue (updateAriaValueText = true) {
     this.setAttribute('aria-valuenow', `${this.displayTime}`);
     
     if (updateAriaValueText) {
@@ -725,17 +725,12 @@ export class Clock extends ResponsiveElement {
       || changedProperties.has('showSeconds')
       || changedProperties.has('amPm')
       || changedProperties.has(TranslatePropertyKey))) {
-      void this.updateAriaValue(true);
+      void this.updateAriaValue();
     }
 
     if (this.interactive && changedProperties.has('sessionTicks')) {
       // Avoid announce every second that could interrupt the screen reader when the user takes an action.
-      if (this.isDisplayMinutesChange) {
-        void this.updateAriaValue(true);
-      }
-      else {
-        void this.updateAriaValue(false);
-      }
+      void this.updateAriaValue(this.isDisplayMinutesChange);
     }
   }
 

--- a/packages/elements/src/clock/index.ts
+++ b/packages/elements/src/clock/index.ts
@@ -585,7 +585,8 @@ export class Clock extends ResponsiveElement {
     const value = await this.tPromise('TIME', {
       value: parse(this.displayValue),
       amPm: this.amPm,
-      showSeconds: this.showSeconds
+      // Avoid every second announcement that could interrupt the screen reader when the user takes an action.
+      showSeconds: (this.interactive && this.tick) ? false : this.showSeconds
     });
     this.setAttribute('aria-valuenow', `${this.displayTime}`);
     this.setAttribute('aria-valuetext', value);


### PR DESCRIPTION
## Description
When clock is tick, Screen reader will announce every seconds. It causes user's action will be interrupted.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings