### PR TITLE
fix(clock): sync interactiveChange code with rating

### DIFF
--- a/packages/elements/src/clock/__test__/clock.interactive.test.js
+++ b/packages/elements/src/clock/__test__/clock.interactive.test.js
@@ -157,7 +157,6 @@ describe('clock/Interactive', () => {
         el.interactive = false;
         await elementUpdated(el);
         expect(el.getAttribute('role')).to.be.equal(null);
-        expect(el.getAttribute('tabindex')).to.be.equal(null);
         expect(el.getAttribute('aria-valuenow')).to.be.equal(null);
         expect(el.getAttribute('aria-valuetext')).to.be.equal(null);
       });

--- a/packages/elements/src/clock/index.ts
+++ b/packages/elements/src/clock/index.ts
@@ -700,7 +700,9 @@ export class Clock extends ResponsiveElement {
       void this.updateAriaValue();
     }
     else {
-      this.removeAttribute('role');
+      if (this.getAttribute('role') === 'spinbutton') {
+        this.removeAttribute('role');
+      }
       this.removeAttribute('aria-valuenow');
       this.removeAttribute('aria-valuetext');
     }

--- a/packages/elements/src/clock/index.ts
+++ b/packages/elements/src/clock/index.ts
@@ -702,7 +702,6 @@ export class Clock extends ResponsiveElement {
     }
     else {
       this.removeAttribute('role');
-      this.removeAttribute('tabindex');
       this.removeAttribute('aria-valuenow');
       this.removeAttribute('aria-valuetext');
     }

--- a/packages/elements/src/clock/index.ts
+++ b/packages/elements/src/clock/index.ts
@@ -695,9 +695,8 @@ export class Clock extends ResponsiveElement {
    */
   private interactiveChanged (): void {
     if (this.interactive) {
-      const tabIndex = (this.tabIndex >= 0) ? this.tabIndex.toString() : '0';
       this.setAttribute('role', 'spinbutton');
-      this.setAttribute('tabindex', tabIndex);
+      this.setAttribute('tabindex', this.getAttribute('tabindex') || '0');
       void this.updateAriaValue();
     }
     else {


### PR DESCRIPTION
## Description
Sync code to be same as interactiveChanged in Rating.
When interactive: check user tabindex before assign, set role, and set aria attributes.
When non interactive: remove role, don't change tabindex, remove aria attributes.

Fixes # (issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings