### PR TITLE
fix(chart): donut center text selected segment cut off tooltip 

### DIFF
--- a/packages/elements/src/chart/__demo__/index.html
+++ b/packages/elements/src/chart/__demo__/index.html
@@ -501,7 +501,7 @@
             text: 'Operating Segments of AAPL.O in 2014'
           },
           tooltips: {
-            enabled: false
+            enabled: true
           }
         }
       };
@@ -579,7 +579,7 @@
             text: 'Operating Segments of AAPL.O in 2020'
           },
           tooltips: {
-            enabled: false
+            enabled: true
           }
         }
       };

--- a/packages/elements/src/chart/plugins/doughnut-center-label.ts
+++ b/packages/elements/src/chart/plugins/doughnut-center-label.ts
@@ -234,7 +234,7 @@ const plugins: Chart.PluginServiceRegistrationOptions = {
     const items = chart.getDatasetMeta(datasetIndex).data[selectedIndex];
     chart.selected = items ? [items] : [];
   },
-  afterDraw: function (chart: DoughnutChart & Selectable): void {
+  afterDatasetsDraw: function (chart: DoughnutChart & Selectable): void {
     if (getPluginConfig(chart)) {
       // Draw active element
       // Note: use logic from chart.js - chart.js/src/elements/element.arc.js :draw()


### PR DESCRIPTION
## Description
When turn on tooltip in chart (donut center tooltip), tooltip is cut off.
https://codepen.io/juliausanova/pen/xxYQRmW

Here is link of list of hook that available on chartjs.
https://www.chartjs.org/docs/2.9.4/developers/plugins.html?h=afterdatasetsdraw

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
