### PR TITLE
fix(tree): tree query selection issues

### DIFF
--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -490,7 +490,7 @@ describe('tree/Tree', () => {
       descendants.forEach(item => expect(el.manager.isItemHidden(item)).to.equal(false, 'Descendants of matched items must be included'));
     });
 
-    it('Text filter applied, single selection', async () => {
+    it('Should be able to select value after filter is applied', async () => {
       const el = await fixture('<ef-tree></ef-tree>');
       el.data = flatData;
       await elementUpdated(el);

--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -490,6 +490,50 @@ describe('tree/Tree', () => {
       descendants.forEach(item => expect(el.manager.isItemHidden(item)).to.equal(false, 'Descendants of matched items must be included'));
     });
 
+    it('Text filter applied, single selection', async () => {
+      const el = await fixture('<ef-tree></ef-tree>');
+      el.data = flatData;
+      await elementUpdated(el);
+
+      el.children[0].click();
+      await elementUpdated(el);
+
+      el.query = 'Item 4';
+      await elementUpdated(el);
+
+      el.children[0].click();
+      await elementUpdated(el);
+
+      expect(el.value).to.equal('4', 'selected item in single mode should be change');
+    });
+    
+    it('Text filter applied, check/uncheck item switch between single selection and multiple selection mode', async () => {
+      const el = await fixture('<ef-tree></ef-tree>');
+      el.data = flatData;
+      await elementUpdated(el);
+
+      el.children[0].click();
+      await elementUpdated(el);
+
+      el.query = 'Item 4';
+      await elementUpdated(el);
+
+      el.multiple = true
+      await elementUpdated(el);
+
+      el.uncheckAll();
+      await elementUpdated(el);
+      expect(el.value).to.equal('1', 'hidden selected item in multiple mode shouldn\'t unchecked');
+
+      el.multiple = false
+      await elementUpdated(el);
+
+      el.children[0].click();
+      await elementUpdated(el);
+      expect(el.value).to.equal('4', 'selected item in single mode should be change');
+
+    });
+
   });
 });
 

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -274,7 +274,9 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
       this.manager.setMode(this.mode);
     }
 
-    if (changeProperties.has('query') || changeProperties.has('data')) {
+    if (changeProperties.has('query') || changeProperties.has('data')
+        || (this.query && changeProperties.has('multiple')) // This code is here to filter items when selection mode is change
+    ) {
       this.filterItems();
     }
   }
@@ -298,7 +300,7 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
           this.manager.includeItem(item);
         }
         else {
-          this.manager.excludeItem(item);
+          this.manager.excludeItem(item, this.multiple);
         }
 
         return result;

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -274,9 +274,7 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
       this.manager.setMode(this.mode);
     }
 
-    if (changeProperties.has('query') || changeProperties.has('data')
-        || (this.query && changeProperties.has('multiple')) // This code is here to filter items when selection mode is change
-    ) {
+    if (changeProperties.has('query') || changeProperties.has('data') || (this.query && changeProperties.has('multiple'))) {
       this.filterItems();
     }
   }

--- a/packages/elements/src/tree/managers/tree-manager.ts
+++ b/packages/elements/src/tree/managers/tree-manager.ts
@@ -239,7 +239,7 @@ export class TreeManager<T extends TreeDataItem> {
   /**
    * Excludes an item as part of the tree.
    * @param item Item to exclude
-   * @param lock Item lock
+   * @param lock Option to lock or unlock when exclude
    * @returns `True` if the item is newly excluded
    */
   public excludeItem (item: T, lock = true): boolean {

--- a/packages/elements/src/tree/managers/tree-manager.ts
+++ b/packages/elements/src/tree/managers/tree-manager.ts
@@ -239,11 +239,12 @@ export class TreeManager<T extends TreeDataItem> {
   /**
    * Excludes an item as part of the tree.
    * @param item Item to exclude
+   * @param lock Item lock
    * @returns `True` if the item is newly excluded
    */
-  public excludeItem (item: T): boolean {
+  public excludeItem (item: T, lock = true): boolean {
     this.hideItem(item);
-    return this.composer.lockItem(item);
+    return lock ? this.composer.lockItem(item) : this.composer.unlockItem(item);
   }
 
   /**


### PR DESCRIPTION
## Description
Tree fire incorrect item in `value-changed` event, when using tree `query` property.

The problem is when filtering items, the exclude item will be locked and can't perform any action.

This PR made 2 changes
1. Only lock the item in single selection mode.
2. Re-filter items when selection mode change.

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-1851

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
