### PR TITLE
fix(tree): tree query selection issues

### DIFF
--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -490,6 +490,49 @@ describe('tree/Tree', () => {
       descendants.forEach(item => expect(el.manager.isItemHidden(item)).to.equal(false, 'Descendants of matched items must be included'));
     });
 
+    it('Should be able to select value after filter is applied', async () => {
+      const el = await fixture('<ef-tree></ef-tree>');
+      el.data = flatData;
+      await elementUpdated(el);
+  
+      el.children[0].click();
+      await elementUpdated(el);
+  
+      el.query = 'Item 4';
+      await elementUpdated(el);
+  
+      el.children[0].click();
+      await elementUpdated(el);
+  
+      expect(el.value).to.equal('4', 'selected item in single mode should be change');
+    });
+  
+    it('Text filter applied, check/uncheck item switch between single selection and multiple selection mode', async () => {
+      const el = await fixture('<ef-tree></ef-tree>');
+      el.data = flatData;
+      await elementUpdated(el);
+  
+      el.children[0].click();
+      await elementUpdated(el);
+  
+      el.query = 'Item 4';
+      await elementUpdated(el);
+  
+      el.multiple = true
+      await elementUpdated(el);
+  
+      el.uncheckAll();
+      await elementUpdated(el);
+      expect(el.value).to.equal('1', 'hidden selected item in multiple mode shouldn\'t unchecked');
+  
+      el.multiple = false
+      await elementUpdated(el);
+  
+      el.children[0].click();
+      await elementUpdated(el);
+      expect(el.value).to.equal('4', 'selected item in single mode should be change');
+  
+    });
   });
 });
 

--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -504,10 +504,10 @@ describe('tree/Tree', () => {
       el.children[0].click();
       await elementUpdated(el);
   
-      expect(el.value).to.equal('4', 'selected item in single mode should be change');
+      expect(el.value).to.equal('4', 'Value should be update when selecting a new item on filter applied.');
     });
-  
-    it('Text filter applied, check/uncheck item switch between single selection and multiple selection mode', async () => {
+    
+    it('Text filter applied, check/uncheck item and switch between single and multiple selection mode', async () => {
       const el = await fixture('<ef-tree></ef-tree>');
       el.data = flatData;
       await elementUpdated(el);
@@ -530,7 +530,7 @@ describe('tree/Tree', () => {
   
       el.children[0].click();
       await elementUpdated(el);
-      expect(el.value).to.equal('4', 'selected item in single mode should be change');
+      expect(el.value).to.equal('4', 'Value should be update when selecting a new item on filter applied.');
   
     });
   });

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -132,11 +132,22 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
     // Single selection - check item
     if (this.manager.checkItem(item)) {
       this.manager.checkedItems.forEach(checkedItem => {
-        checkedItem !== item && this.manager.uncheckItem(checkedItem);
+        checkedItem !== item && this.forceUncheckItem(checkedItem);
       });
       return true;
     }
     return false;
+  }
+
+  /**
+   * Force uncheck item when item is locked
+   * @param item Original data item
+   * @returns {void}
+   */
+  protected forceUncheckItem (item: T): void {
+    const result = this.composer.unlockItem(item);
+    this.manager.uncheckItem(item);
+    result && this.composer.lockItem(item);
   }
 
   /**


### PR DESCRIPTION
## Description
Tree fire incorrect item in `value-changed` event, when using tree `query` property.

The problem is when filtering items, the exclude item will be locked and can't perform any action.

Solution
- add force uncheck item method for uncheck locked item

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-1851

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
