### PR TITLE
fix: incorrect type delcaration path

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -15,8 +15,9 @@
   },
   "typesVersions": {
     "*": {
-      "*.js": [
-        "lib/*.d.ts"
+      "*": [
+        "lib/*/index.d.ts",
+        "lib/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
## Description

This fix to to point TypeScript to type declaration correctly. Previous `TypedVersion` string pattern requires `*.js` extension which we do not have in exported path.

Fixes https://jira.refinitiv.com/browse/ELF-1860

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
