### PR TITLE
fix: utils TypeScript type declaration path

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,6 +4,7 @@
   "description": "Shared utilities for Element Framework",
   "main": "lib/index.js",
   "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "typesVersions": {
     "*": {
       "*.js": [
@@ -31,7 +32,6 @@
     "./navigation.js": "./lib/navigation.js",
     "./uuid.js": "./lib/uuid.js"
   },
-  "types": "lib/utils.d.ts",
   "repository": {
     "type": "git",
     "url": "git@github.com:Refinitiv/refinitiv-ui.git",


### PR DESCRIPTION
## Description

Fixes utils TypeScript type declaration path. `utils.d.ts` does not exist. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
