### PR TITLE
fix: change Halo theme font-weight 600 from bold to semibold

### DIFF
--- a/packages/halo-theme/src/custom-elements/ef-calendar.less
+++ b/packages/halo-theme/src/custom-elements/ef-calendar.less
@@ -136,7 +136,7 @@
 
   [part~=day-name] {
     color: @calendar-header-text-color;
-    font-weight: 500;
+    font-weight: 600;
     [part~=cell-content] {
       background-color: @calendar-header-background-color;
     }

--- a/packages/halo-theme/src/custom-elements/ef-item.less
+++ b/packages/halo-theme/src/custom-elements/ef-item.less
@@ -32,7 +32,7 @@
     &[highlighted], &[focused]{
       color: @list-item-focus-text-color;
     }
-    font-weight: 500;
+    font-weight: 600;
     
   }
 

--- a/packages/halo-theme/src/fonts.less
+++ b/packages/halo-theme/src/fonts.less
@@ -10,7 +10,7 @@
 @font-face {
   font-family: 'Proxima Nova Fin';
   font-style: normal;
-  font-weight: 500;
+  font-weight: 500 600;
   font-display: swap;
   src: url('https://cdn.refinitiv.net/public/libs/elf/assets/elf-theme-halo/resources/fonts/proximanovafin/proximanovafin-semibold.woff2') format('woff2'),
   url('https://cdn.refinitiv.net/public/libs/elf/assets/elf-theme-halo/resources/fonts/proximanovafin/proximanovafin-semibold.woff') format('woff');

--- a/packages/halo-theme/src/native-elements/kbd.less
+++ b/packages/halo-theme/src/native-elements/kbd.less
@@ -3,7 +3,7 @@ kbd {
   color: @scheme-color-complementary;
   background-color: @kbd-background-color;
   box-shadow: 0px 0px 0px 2px @kbd-background-color;
-  font-weight: 500;
+  font-weight: 600;
   font-family: inherit;
   font-size: unit(((@global-text-size - 2) / @global-text-size), em);
   border-radius: 1em;

--- a/packages/halo-theme/src/variants/dark/overrides.less
+++ b/packages/halo-theme/src/variants/dark/overrides.less
@@ -215,7 +215,7 @@ Rules:
 @list-item-focus-text-color               : @color-white;
 @list-item-selected-text-color            : @color-white;
 @list-item-header-font-size               : 83%;
-@list-item-header-font-weight             : 500;
+@list-item-header-font-weight             : 600;
 @list-item-header-text-color              : @color-dusty-grey;
 @list-item-divider-margin                 : 2px 0px;
 @list-item-divider-color                  : @separator-color;


### PR DESCRIPTION
## Description
In Halo theme, font-weight 600 should be semibold. However, EF theme map 500 to semibold and 700 to bold. This means that font-weight 600 will be bold font.

We should map 600 to semibold and keep 500 to semibold as well so it won't have any impacts that using 500 with semibold.

In theme, we also want to replace anywhere that use font-weight 500 to 600 so it will be clean and match to Figma file.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
