### PR TITLE
fix(accordion): The element should interact only with its direct children

### DIFF
--- a/packages/elements/src/accordion/__test__/accordion.test.js
+++ b/packages/elements/src/accordion/__test__/accordion.test.js
@@ -3,9 +3,11 @@ import { fixture, expect, elementUpdated, oneEvent } from '@refinitiv-ui/test-he
 // import element and theme
 import '@refinitiv-ui/elements/collapse';
 import '@refinitiv-ui/elements/accordion';
+import '@refinitiv-ui/elements/tree';
 
 import '@refinitiv-ui/elemental-theme/light/ef-accordion';
 import '@refinitiv-ui/elemental-theme/light/ef-collapse';
+import '@refinitiv-ui/elemental-theme/light/ef-tree';
 
 describe('accordion/Accordion', () => {
   describe('Should Have A Correct DOM', () => {
@@ -121,6 +123,35 @@ describe('accordion/Accordion', () => {
 
     expect(nestedCollapses[0].expanded).to.equal(false);
     expect(nestedCollapses[1].expanded).to.equal(true);
+  });
+
+  it('Should process nested tree without affecting parent collapse', async () => {
+    const el = await fixture(`
+      <ef-accordion>
+        <ef-collapse class="top-level" expanded>
+          <ef-tree></ef-tree>
+        </ef-collapse>
+      </ef-accordion>
+    `);
+    const collapse = el.querySelector('ef-collapse');
+    const tree = el.querySelector('ef-tree');
+
+    tree.data = [{
+      label: 'Item 1',
+      value: '1',
+      expanded: true,
+      items: [{
+        label: 'Item 1.1',
+        value: '1.1'
+      }
+      ]
+    }]
+    await elementUpdated(el);
+    expect(collapse.expanded).to.equal(true);
+    tree.children[0].click();
+    await elementUpdated(el);
+    expect(collapse.expanded).to.equal(true);
+
   });
 
   describe('Should Have Correct Properties', () => {

--- a/packages/elements/src/accordion/index.ts
+++ b/packages/elements/src/accordion/index.ts
@@ -18,8 +18,8 @@ import { Collapse } from '../collapse/index.js';
  */
 const getClosestAccordion = (element: Element | null): Accordion | null => {
   while (element) {
-    if (element.localName === 'ef-accordion') {
-      return element as Accordion;
+    if (element instanceof Accordion) {
+      return element;
     }
     else {
       element = element.parentElement;
@@ -35,7 +35,7 @@ const getClosestAccordion = (element: Element | null): Accordion | null => {
  * @returns is current accordion has child accordion that wraps checked element
  */
 const isDirectAccordionChild = (element: Element, accordion: Accordion): boolean => {
-  return element.localName === 'ef-collapse' && getClosestAccordion(element) === accordion;
+  return element instanceof Collapse && getClosestAccordion(element) === accordion;
 };
 
 /**

--- a/packages/elements/src/accordion/index.ts
+++ b/packages/elements/src/accordion/index.ts
@@ -35,7 +35,7 @@ const getClosestAccordion = (element: Element | null): Accordion | null => {
  * @returns is current accordion has child accordion that wraps checked element
  */
 const isDirectAccordionChild = (element: Element, accordion: Accordion): boolean => {
-  return getClosestAccordion(element) === accordion;
+  return element.localName === 'ef-collapse' && getClosestAccordion(element) === accordion;
 };
 
 /**


### PR DESCRIPTION
## Description

The accordion listens to expanded-changed events from elements that aren't its direct children.

This PR is sync from v4 https://git.sami.int.thomsonreuters.com/elf/elements/merge_requests/200

Solution
- Add a condition to check if the clicked element is coral-collapse

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-1638

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
