### PR TITLE
ci: run unit test browsers on `GitHub Action` instead of `BrowserStack`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,17 +49,17 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     steps:
-      - name: 'BrowserStack Env Setup' # Invokes the setup-env action
-        uses: browserstack/github-actions/setup-env@master
-        with:
-          username: ${{ secrets.BROWSERSTACK_USERNAME }}
-          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      # - name: 'BrowserStack Env Setup' # Invokes the setup-env action
+      #   uses: browserstack/github-actions/setup-env@master
+      #   with:
+      #     username: ${{ secrets.BROWSERSTACK_USERNAME }}
+      #     access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
-      - name: 'BrowserStack Local Tunnel Setup' # Invokes the setup-local action
-        uses: browserstack/github-actions/setup-local@master
-        with:
-          local-testing: start
-          local-identifier: random
+      # - name: 'BrowserStack Local Tunnel Setup' # Invokes the setup-local action
+      #   uses: browserstack/github-actions/setup-local@master
+      #   with:
+      #     local-testing: start
+      #     local-identifier: random
 
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -73,9 +73,9 @@ jobs:
         id: setup
 
       - name: Test
-        run: npm run test:affected -- --base=$BASE_SHA --parallel=3 --browserstack 'default' --output minimal
+        run: npm run test:affected -- --base=$BASE_SHA --parallel=3 --output minimal
 
-      - name: 'BrowserStackLocal Stop'  # Terminating the BrowserStackLocal tunnel connection
-        uses: browserstack/github-actions/setup-local@master
-        with:
-          local-testing: stop
+      # - name: 'BrowserStackLocal Stop'  # Terminating the BrowserStackLocal tunnel connection
+      #   uses: browserstack/github-actions/setup-local@master
+      #   with:
+      #     local-testing: stop

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -35,17 +35,17 @@ jobs:
     name: TestCoverage
     runs-on: ubuntu-latest
     steps:
-      - name: 'BrowserStack Env Setup' # Invokes the setup-env action
-        uses: browserstack/github-actions/setup-env@master
-        with:
-          username: ${{ secrets.BROWSERSTACK_USERNAME }}
-          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      # - name: 'BrowserStack Env Setup' # Invokes the setup-env action
+      #   uses: browserstack/github-actions/setup-env@master
+      #   with:
+      #     username: ${{ secrets.BROWSERSTACK_USERNAME }}
+      #     access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
-      - name: 'BrowserStack Local Tunnel Setup' # Invokes the setup-local action
-        uses: browserstack/github-actions/setup-local@master
-        with:
-          local-testing: start
-          local-identifier: random
+      # - name: 'BrowserStack Local Tunnel Setup' # Invokes the setup-local action
+      #   uses: browserstack/github-actions/setup-local@master
+      #   with:
+      #     local-testing: start
+      #     local-identifier: random
 
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -57,12 +57,12 @@ jobs:
         id: setup
 
       - name: Test
-        run: npm run test:all -- --parallel=3 --browserstack 'chrome' --output minimal
+        run: npm run test:all -- --parallel=3 --output minimal
 
-      - name: 'BrowserStackLocal Stop'  # Terminating the BrowserStackLocal tunnel connection
-        uses: browserstack/github-actions/setup-local@master
-        with:
-          local-testing: stop
+      # - name: 'BrowserStackLocal Stop'  # Terminating the BrowserStackLocal tunnel connection
+      #   uses: browserstack/github-actions/setup-local@master
+      #   with:
+      #     local-testing: stop
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/.github/workflows/test_nightly.yml
+++ b/.github/workflows/test_nightly.yml
@@ -52,17 +52,17 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     steps:
-      - name: 'BrowserStack Env Setup' # Invokes the setup-env action
-        uses: browserstack/github-actions/setup-env@master
-        with:
-          username: ${{ secrets.BROWSERSTACK_USERNAME }}
-          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      # - name: 'BrowserStack Env Setup' # Invokes the setup-env action
+      #   uses: browserstack/github-actions/setup-env@master
+      #   with:
+      #     username: ${{ secrets.BROWSERSTACK_USERNAME }}
+      #     access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
-      - name: 'BrowserStack Local Tunnel Setup' # Invokes the setup-local action
-        uses: browserstack/github-actions/setup-local@master
-        with:
-          local-testing: start
-          local-identifier: random
+      # - name: 'BrowserStack Local Tunnel Setup' # Invokes the setup-local action
+      #   uses: browserstack/github-actions/setup-local@master
+      #   with:
+      #     local-testing: start
+      #     local-identifier: random
 
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -77,9 +77,9 @@ jobs:
 
       - name: Test
         # Prevent NX caching because it must run all testing, even though the code has not chaged.
-        run: npm run test:all -- --parallel=3 --skip-nx-cache --browserstack 'supported' --output minimal
+        run: npm run test:all -- --parallel=3 --skip-nx-cache --output minimal
 
-      - name: 'BrowserStackLocal Stop'  # Terminating the BrowserStackLocal tunnel connection
-        uses: browserstack/github-actions/setup-local@master
-        with:
-          local-testing: stop
+      # - name: 'BrowserStackLocal Stop'  # Terminating the BrowserStackLocal tunnel connection
+      #   uses: browserstack/github-actions/setup-local@master
+      #   with:
+      #     local-testing: stop


### PR DESCRIPTION
Run unit test browsers on `GitHub Action` instead of `BrowserStack` 

This fixing temporary because it has a SSH tunnel service problem on GitHub or BrowserStack

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
