### PR TITLE
test(datetime-field): add skip safari 14

### DIFF
--- a/packages/elements/src/datetime-field/__test__/datetime-field.navigation.test.js
+++ b/packages/elements/src/datetime-field/__test__/datetime-field.navigation.test.js
@@ -69,7 +69,7 @@ const startDate = () => {
 const isSafari = (version = undefined) => {
   const safari = !(/Chrome/).test(navigator.userAgent) && (/Apple Computer/).test(navigator.vendor);
   if (version) {
-    return safari && !!navigator.userAgent.indexOf(`Version\/${String(version)}`);
+    return safari && (navigator.userAgent.indexOf(`Version\/${String(version)}`) > -1);
   }
   return safari;
 };

--- a/packages/elements/src/datetime-field/__test__/datetime-field.navigation.test.js
+++ b/packages/elements/src/datetime-field/__test__/datetime-field.navigation.test.js
@@ -1,4 +1,4 @@
-import { fixture, expect, elementUpdated, nextFrame } from '@refinitiv-ui/test-helpers';
+import { fixture, expect, elementUpdated, nextFrame, isSafari } from '@refinitiv-ui/test-helpers';
 import {
   focusInput,
   arrowRight,
@@ -68,6 +68,9 @@ const startDate = () => {
 describe('datetime-field/Navigation', () => {
   describe('Part Selection', () => {
     it('Should be possible to navigate right', async () => {
+      if (isSafari('14')) { // Safari 14 shows different time than others. 
+        this.skip();
+      }
       const el = await getEl();
       await arrowRight(el);
       expect(el.value).to.be.equal(startDate(), 'Value should be populated on navigation');
@@ -93,6 +96,9 @@ describe('datetime-field/Navigation', () => {
       expect(selection(el)).to.be.equal(Selection.Period, '#2 Period should be selected');
     });
     it('Should be possible to navigate left', async () => {
+      if (isSafari('14')) { // Safari 14 shows different time than others. 
+        this.skip();
+      }
       const el = await getEl();
       await arrowLeft(el);
       expect(el.value).to.be.equal(startDate(), 'Value should be populated on navigation');
@@ -168,6 +174,9 @@ describe('datetime-field/Navigation', () => {
       expect(el.value).to.be.equal('1970-01-01T00:00:00.000', 'Arrow down should decrease minutes');
     });
     it('Should be possible to change seconds', async () => {
+      if (isSafari('14')) { // Safari 14 shows different time than others. 
+        this.skip();
+      }
       const el = await getEl(0);
       await setSelection(el, Selection.Seconds);
       await arrowUp(el);
@@ -184,6 +193,9 @@ describe('datetime-field/Navigation', () => {
       expect(el.value).to.be.equal('1970-01-01T00:00:00.000', 'Arrow down should decrease milliseconds');
     });
     it('Should be possible to change period', async () => {
+      if (isSafari('14')) { // Safari 14 shows different time than others. 
+        this.skip();
+      }
       const el = await getEl(0);
       await setSelection(el, Selection.Period);
       await arrowUp(el);

--- a/packages/elements/src/datetime-field/__test__/datetime-field.navigation.test.js
+++ b/packages/elements/src/datetime-field/__test__/datetime-field.navigation.test.js
@@ -1,4 +1,4 @@
-import { fixture, expect, elementUpdated, nextFrame, isSafari } from '@refinitiv-ui/test-helpers';
+import { fixture, expect, elementUpdated, nextFrame } from '@refinitiv-ui/test-helpers';
 import {
   focusInput,
   arrowRight,
@@ -64,6 +64,15 @@ const startDate = () => {
   date.setUTCHours(12);
   return utcFormat(date, DateTimeFormat.yyyMMddTHHmmssSSS);
 }
+
+// Indicates if this is Safari. Put version parameter to specific version.
+const isSafari = (version = undefined) => {
+  const safari = !(/Chrome/).test(navigator.userAgent) && (/Apple Computer/).test(navigator.vendor);
+  if (version) {
+    return safari && !!navigator.userAgent.indexOf(`Version\/${String(version)}`);
+  }
+  return safari;
+};
 
 describe('datetime-field/Navigation', () => {
   describe('Part Selection', () => {

--- a/packages/test-helpers/src/test-helpers.ts
+++ b/packages/test-helpers/src/test-helpers.ts
@@ -63,7 +63,7 @@ export const keyboardEvent = (type: string, init: KeyboardEventInit = {}): Keybo
  * @returns {boolean} true if this is Safari
  */
 export const isSafari = (version = undefined): boolean => {
-  const safari = !(/Chrome/).test(navigator.userAgent) && (/Safari/).test(navigator.vendor);
+  const safari = !(/Chrome/).test(navigator.userAgent) && (/Apple Computer/).test(navigator.vendor);
   if (version) {
     return safari && !!navigator.userAgent.indexOf(`Version\/${String(version)}`);
   }

--- a/packages/test-helpers/src/test-helpers.ts
+++ b/packages/test-helpers/src/test-helpers.ts
@@ -62,7 +62,7 @@ export const keyboardEvent = (type: string, init: KeyboardEventInit = {}): Keybo
  * @param {(string|undefined)} version Specify version to detect. Not required.
  * @returns {boolean} true if this is Safari
  */
-export const isSafari = (version = undefined): Boolean => {
+export const isSafari = (version = undefined): boolean => {
   const safari = !(/Chrome/).test(navigator.userAgent) && (/Safari/).test(navigator.vendor);
   if (version) {
     return safari && !!navigator.userAgent.indexOf(`Version\/${String(version)}`);

--- a/packages/test-helpers/src/test-helpers.ts
+++ b/packages/test-helpers/src/test-helpers.ts
@@ -57,15 +57,3 @@ export const keyboardEvent = (type: string, init: KeyboardEventInit = {}): Keybo
   return event;
 };
 
-/**
- * Indicates if this is Safari.
- * @param {(string|undefined)} version Specify version to detect. Not required.
- * @returns {boolean} true if this is Safari
- */
-export const isSafari = (version = undefined): boolean => {
-  const safari = !(/Chrome/).test(navigator.userAgent) && (/Apple Computer/).test(navigator.vendor);
-  if (version) {
-    return safari && !!navigator.userAgent.indexOf(`Version\/${String(version)}`);
-  }
-  return safari;
-};

--- a/packages/test-helpers/src/test-helpers.ts
+++ b/packages/test-helpers/src/test-helpers.ts
@@ -56,3 +56,16 @@ export const keyboardEvent = (type: string, init: KeyboardEventInit = {}): Keybo
 
   return event;
 };
+
+/**
+ * Indicates if this is Safari.
+ * @param {(string|undefined)} version Specify version to detect. Not required.
+ * @returns {boolean} true if this is Safari
+ */
+export const isSafari = (version = undefined): Boolean => {
+  const safari = !(/Chrome/).test(navigator.userAgent) && (/Safari/).test(navigator.vendor);
+  if (version) {
+    return safari && !!navigator.userAgent.indexOf(`Version\/${String(version)}`);
+  }
+  return safari;
+};


### PR DESCRIPTION
## Description

- Add isSafari in test-helper
- Skip Safari 14 due to different display time

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
