### PR TITLE
feat(select): support tooltip option with data object

### DIFF
--- a/packages/elements/src/select/index.ts
+++ b/packages/elements/src/select/index.ts
@@ -1008,7 +1008,7 @@ export class Select extends ControlElement implements MultiValue {
       part="item"
       .value=${item.value}
       .label=${item.label}
-      .title=${item.title || ''}
+      title=${item.title}
       ?selected=${this.composer.getItemPropertyValue(item, 'selected') as boolean}
       ?disabled=${item.disabled}
     ></ef-item>`;

--- a/packages/elements/src/select/index.ts
+++ b/packages/elements/src/select/index.ts
@@ -1008,6 +1008,7 @@ export class Select extends ControlElement implements MultiValue {
       part="item"
       .value=${item.value}
       .label=${item.label}
+      .title=${item.title || ''}
       ?selected=${this.composer.getItemPropertyValue(item, 'selected') as boolean}
       ?disabled=${item.disabled}
     ></ef-item>`;


### PR DESCRIPTION
## Description
using coral-select with data object can't add "title"/"tooltip" parameter to the "data" object

Solution
- Passing title data to item element when passing data

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-1712

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
