### PR TITLE
fix(tree): extend `list` style without importing `ef-list-item`

### DIFF
--- a/packages/elemental-theme/src/custom-elements/ef-list.less
+++ b/packages/elemental-theme/src/custom-elements/ef-list.less
@@ -1,28 +1,9 @@
 @import 'element:ef-list-item';
+@import '../shared-styles/list';
 @import '../shared-styles/scrollbar';
-@import '../responsive';
 
 :host {
-  --item-indent: extract(@list-item-padding, 2);
-  --item-height: @list-item-height;
-  color: @list-text-color;
-  background-color: @list-background-color;
-
-  .touch-action();
-  .ie-scrollbars();
-  .mozilla-scrollbars();
-
-  &:focus {
-    outline: none;
-  }
-
-  &[focused=visible] {
-    outline: 1px solid @scheme-color-primary;
-  }
-
-  &[readonly] [part=list-item] {
-    cursor: default;
-  }
+  .list-defaults;
 }
 
 .webkit-scrollbars();

--- a/packages/elemental-theme/src/custom-elements/ef-tree.less
+++ b/packages/elemental-theme/src/custom-elements/ef-tree.less
@@ -1,6 +1,10 @@
 @import 'element:ef-tree-item';
-@import 'ef-list';
+@import '../shared-styles/list';
+@import '../shared-styles/scrollbar';
 
 :host {
   overflow-x: auto;
+  .list-defaults;
 }
+
+.webkit-scrollbars();

--- a/packages/elemental-theme/src/shared-styles/list.less
+++ b/packages/elemental-theme/src/shared-styles/list.less
@@ -1,0 +1,26 @@
+@import '../responsive';
+@import '../shared-styles/scrollbar';
+
+.list-defaults() {
+  --item-indent: extract(@list-item-padding, 2);
+  --item-height: @list-item-height;
+  color: @list-text-color;
+  background-color: @list-background-color;
+
+  .touch-action();
+  .ie-scrollbars();
+  .mozilla-scrollbars();
+
+  &:focus {
+    outline: none;
+  }
+
+  &[focused=visible] {
+    outline: 1px solid @scheme-color-primary;
+  }
+
+  &[readonly] [part=list-item] {
+    cursor: default;
+  }
+}
+


### PR DESCRIPTION
## Description

- `ef-list` imports `ef-list-item` styles.
- `ef-tree` extends `ef-list` styles.
- Theme extractor found that `ef-list-item` is not part of `ef-tree`, so it tried to import it from the package.
- We did not want to export `ef-list-item` to external users, so we didn't add an export path to `@refinitiv-ui/elements` 

This PR creates a new mixin which contains common list style. This will be used in both `list` and `tree` without tree having to import internal `ef-list-item`.

## Type of change

- [ ] Refactor (improves code without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
