### PR TITLE
fix(interactive-chart): show dash text when legend is hidden

### DIFF
--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -56,6 +56,7 @@ export type {
 
 const NOT_AVAILABLE_DATA = 'N/A';
 const NO_DATA_POINT = '--';
+const HIDE_DATA_POINT = '';
 
 /**
  * A charting component that allows you to create several use cases of financial chart.
@@ -800,7 +801,7 @@ export class InteractiveChart extends ResponsiveElement {
         }
         // when there's no data point in the series object.
         else if (!eventMove?.seriesPrices.get(this.seriesList[idx]) && eventMove?.time) {
-          value = NO_DATA_POINT;
+          value = symbol ? NO_DATA_POINT : HIDE_DATA_POINT;
           this.isCrosshairVisible = true;
           this.hasDataPoint = false;
         }
@@ -901,7 +902,7 @@ export class InteractiveChart extends ResponsiveElement {
         /**
          * Create a new span OHLC after displaying (--) or (N/A)
          */
-        if (spanElem.textContent === NOT_AVAILABLE_DATA || spanElem.textContent === NO_DATA_POINT) {
+        if (spanElem.textContent === NOT_AVAILABLE_DATA || spanElem.textContent === NO_DATA_POINT || spanElem.textContent === HIDE_DATA_POINT) {
           rowLegend[index].removeChild(spanElem);
           this.createSpanOHLC(rowLegend[index] as HTMLElement, rowData, priceColor);
         }
@@ -939,7 +940,7 @@ export class InteractiveChart extends ResponsiveElement {
   private createTextPrice (rowLegend: RowLegend, price: number | string, priceColor: string, index: number): void {
     const formatter = this.internalConfig.series[index].legendPriceFormatter;
     // Formats legend only when formatter and data point are provided
-    const formattedPrice = !!formatter && price !== NO_DATA_POINT ? formatter(price) : price;
+    const formattedPrice = !!formatter && price !== NO_DATA_POINT && price !== HIDE_DATA_POINT ? formatter(price) : price;
 
     // Create text price after chart has rendered
     if (rowLegend instanceof HTMLElement) {


### PR DESCRIPTION
## Description
Interactive chart show dash text (--) when the user hovers on the point that doesn't have the data and the legend is hidden.

Solution
- add `HIDE_DATA_POINT` variable to handle case when doesn't have the data and legend is hidden


Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-1932

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
