### PR TITLE
ci: fix prod release condition where boolean input from workflow dispatch is actually string

### DIFF
--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -6,6 +6,7 @@ on:
       force:
         description: Force publish all packages?
         type: boolean
+        default: false
 
 jobs:
   publish:
@@ -31,13 +32,13 @@ jobs:
         uses: ./.github/actions/checkout-install-and-build
 
       - name: Bump all package versions and create GitHub release
-        if: ${{ github.event.inputs.force }}
+        if: ${{ inputs.force }}
         run: lerna version --create-release github --conventional-commits --force-publish --yes
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Bump modified package versions and create GitHub release
-        if: ${{ !github.event.inputs.force }}
+        if: ${{ !inputs.force }}
         run: lerna version --create-release github --conventional-commits --yes
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Description

https://github.com/actions/runner/issues/1483
https://github.com/github-community/community/discussions/9343

Inputs from workflow dispatch is string. Replacing `github.event.inputs` with `inputs` which respects boolean.

## Type of change

Please delete options that are not relevant.

- [ ] Refactor (improves code without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
