### PR TITLE
fix(calendar): day cell selected style not work with disabled state

### DIFF
--- a/packages/elements/src/calendar/__snapshots__/Defaults.md
+++ b/packages/elements/src/calendar/__snapshots__/Defaults.md
@@ -138,7 +138,7 @@
     >
       <div
         aria-label="Monday, 28 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -153,7 +153,7 @@
     >
       <div
         aria-label="Tuesday, 29 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -168,7 +168,7 @@
     >
       <div
         aria-label="Wednesday, 30 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -183,7 +183,7 @@
     >
       <div
         aria-label="Thursday, 31 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -197,7 +197,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -211,7 +211,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -225,7 +225,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -244,7 +244,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -258,7 +258,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -272,7 +272,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -286,7 +286,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -300,7 +300,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -314,7 +314,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -328,7 +328,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -347,7 +347,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -361,7 +361,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -375,7 +375,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -389,7 +389,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -403,7 +403,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -417,7 +417,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -431,7 +431,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -450,7 +450,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -464,7 +464,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -478,7 +478,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -492,7 +492,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -506,7 +506,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -520,7 +520,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -534,7 +534,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -553,7 +553,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -567,7 +567,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -581,7 +581,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -595,7 +595,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -609,7 +609,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -623,7 +623,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -638,7 +638,7 @@
     >
       <div
         aria-label="Sunday, 1 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -658,7 +658,7 @@
     >
       <div
         aria-label="Monday, 2 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -673,7 +673,7 @@
     >
       <div
         aria-label="Tuesday, 3 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -688,7 +688,7 @@
     >
       <div
         aria-label="Wednesday, 4 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -703,7 +703,7 @@
     >
       <div
         aria-label="Thursday, 5 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -718,7 +718,7 @@
     >
       <div
         aria-label="Friday, 6 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -733,7 +733,7 @@
     >
       <div
         aria-label="Saturday, 7 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -749,7 +749,7 @@
     >
       <div
         aria-label="Sunday, 8 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -928,7 +928,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -942,7 +942,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -956,7 +956,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -975,7 +975,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -989,7 +989,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1003,7 +1003,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1017,7 +1017,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1031,7 +1031,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1045,7 +1045,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1059,7 +1059,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1078,7 +1078,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1092,7 +1092,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1106,7 +1106,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1120,7 +1120,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1134,7 +1134,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1148,7 +1148,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1162,7 +1162,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1181,7 +1181,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1195,7 +1195,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1209,7 +1209,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1223,7 +1223,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1237,7 +1237,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1251,7 +1251,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1265,7 +1265,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1284,7 +1284,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1298,7 +1298,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1312,7 +1312,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1326,7 +1326,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1340,7 +1340,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1355,7 +1355,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1491,7 +1491,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -1506,7 +1506,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1520,7 +1520,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1534,7 +1534,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1553,7 +1553,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1567,7 +1567,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1581,7 +1581,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1595,7 +1595,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1614,7 +1614,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1628,7 +1628,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1642,7 +1642,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1656,7 +1656,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1675,7 +1675,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1689,7 +1689,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1704,7 +1704,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1720,7 +1720,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1794,7 +1794,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -1808,7 +1808,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1822,7 +1822,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1836,7 +1836,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1855,7 +1855,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1869,7 +1869,7 @@
     >
       <div
         aria-label="2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1883,7 +1883,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1897,7 +1897,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1916,7 +1916,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1930,7 +1930,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1944,7 +1944,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1958,7 +1958,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1977,7 +1977,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1991,7 +1991,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2005,7 +2005,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2020,7 +2020,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2178,7 +2178,7 @@
     >
       <div
         aria-label="Tuesday, 1 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -2192,7 +2192,7 @@
     >
       <div
         aria-label="Wednesday, 2 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2206,7 +2206,7 @@
     >
       <div
         aria-label="Thursday, 3 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2220,7 +2220,7 @@
     >
       <div
         aria-label="Friday, 4 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2234,7 +2234,7 @@
     >
       <div
         aria-label="Saturday, 5 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2248,7 +2248,7 @@
     >
       <div
         aria-label="Sunday, 6 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2267,7 +2267,7 @@
     >
       <div
         aria-label="Monday, 7 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2281,7 +2281,7 @@
     >
       <div
         aria-label="Tuesday, 8 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2295,7 +2295,7 @@
     >
       <div
         aria-label="Wednesday, 9 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2309,7 +2309,7 @@
     >
       <div
         aria-label="Thursday, 10 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2323,7 +2323,7 @@
     >
       <div
         aria-label="Friday, 11 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2337,7 +2337,7 @@
     >
       <div
         aria-label="Saturday, 12 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2351,7 +2351,7 @@
     >
       <div
         aria-label="Sunday, 13 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2370,7 +2370,7 @@
     >
       <div
         aria-label="Monday, 14 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2384,7 +2384,7 @@
     >
       <div
         aria-label="Tuesday, 15 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2398,7 +2398,7 @@
     >
       <div
         aria-label="Wednesday, 16 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2412,7 +2412,7 @@
     >
       <div
         aria-label="Thursday, 17 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2426,7 +2426,7 @@
     >
       <div
         aria-label="Friday, 18 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2440,7 +2440,7 @@
     >
       <div
         aria-label="Saturday, 19 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2454,7 +2454,7 @@
     >
       <div
         aria-label="Sunday, 20 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2473,7 +2473,7 @@
     >
       <div
         aria-label="Monday, 21 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2487,7 +2487,7 @@
     >
       <div
         aria-label="Tuesday, 22 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2501,7 +2501,7 @@
     >
       <div
         aria-label="Wednesday, 23 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2515,7 +2515,7 @@
     >
       <div
         aria-label="Thursday, 24 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2529,7 +2529,7 @@
     >
       <div
         aria-label="Friday, 25 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2543,7 +2543,7 @@
     >
       <div
         aria-label="Saturday, 26 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2557,7 +2557,7 @@
     >
       <div
         aria-label="Sunday, 27 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2577,7 +2577,7 @@
     >
       <div
         aria-label="Monday, 28 February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2748,7 +2748,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -2763,7 +2763,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2777,7 +2777,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2791,7 +2791,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2810,7 +2810,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2824,7 +2824,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2838,7 +2838,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2852,7 +2852,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2871,7 +2871,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2885,7 +2885,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2899,7 +2899,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2913,7 +2913,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2932,7 +2932,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2946,7 +2946,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2961,7 +2961,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2977,7 +2977,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3051,7 +3051,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -3065,7 +3065,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3079,7 +3079,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3093,7 +3093,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3112,7 +3112,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3126,7 +3126,7 @@
     >
       <div
         aria-label="2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3140,7 +3140,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3154,7 +3154,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3173,7 +3173,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3187,7 +3187,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3201,7 +3201,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3215,7 +3215,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3234,7 +3234,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3248,7 +3248,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3262,7 +3262,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3277,7 +3277,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3442,7 +3442,7 @@
     >
       <div
         aria-label="Wednesday, 1 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -3456,7 +3456,7 @@
     >
       <div
         aria-label="Thursday, 2 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3470,7 +3470,7 @@
     >
       <div
         aria-label="Friday, 3 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3484,7 +3484,7 @@
     >
       <div
         aria-label="Saturday, 4 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3498,7 +3498,7 @@
     >
       <div
         aria-label="Sunday, 5 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3517,7 +3517,7 @@
     >
       <div
         aria-label="Monday, 6 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3531,7 +3531,7 @@
     >
       <div
         aria-label="Tuesday, 7 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3545,7 +3545,7 @@
     >
       <div
         aria-label="Wednesday, 8 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3559,7 +3559,7 @@
     >
       <div
         aria-label="Thursday, 9 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3573,7 +3573,7 @@
     >
       <div
         aria-label="Friday, 10 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3587,7 +3587,7 @@
     >
       <div
         aria-label="Saturday, 11 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3601,7 +3601,7 @@
     >
       <div
         aria-label="Sunday, 12 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3620,7 +3620,7 @@
     >
       <div
         aria-label="Monday, 13 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3634,7 +3634,7 @@
     >
       <div
         aria-label="Tuesday, 14 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3648,7 +3648,7 @@
     >
       <div
         aria-label="Wednesday, 15 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3662,7 +3662,7 @@
     >
       <div
         aria-label="Thursday, 16 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3676,7 +3676,7 @@
     >
       <div
         aria-label="Friday, 17 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3690,7 +3690,7 @@
     >
       <div
         aria-label="Saturday, 18 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3704,7 +3704,7 @@
     >
       <div
         aria-label="Sunday, 19 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3723,7 +3723,7 @@
     >
       <div
         aria-label="Monday, 20 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3737,7 +3737,7 @@
     >
       <div
         aria-label="Tuesday, 21 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3751,7 +3751,7 @@
     >
       <div
         aria-label="Wednesday, 22 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3765,7 +3765,7 @@
     >
       <div
         aria-label="Thursday, 23 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3779,7 +3779,7 @@
     >
       <div
         aria-label="Friday, 24 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3793,7 +3793,7 @@
     >
       <div
         aria-label="Saturday, 25 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3807,7 +3807,7 @@
     >
       <div
         aria-label="Sunday, 26 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3826,7 +3826,7 @@
     >
       <div
         aria-label="Monday, 27 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3840,7 +3840,7 @@
     >
       <div
         aria-label="Tuesday, 28 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3854,7 +3854,7 @@
     >
       <div
         aria-label="Wednesday, 29 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3868,7 +3868,7 @@
     >
       <div
         aria-label="Thursday, 30 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3883,7 +3883,7 @@
     >
       <div
         aria-label="Friday, 31 December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4026,7 +4026,7 @@
     >
       <div
         aria-label="November 2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -4041,7 +4041,7 @@
     >
       <div
         aria-label="December 2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4055,7 +4055,7 @@
     >
       <div
         aria-label="January 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4069,7 +4069,7 @@
     >
       <div
         aria-label="February 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4088,7 +4088,7 @@
     >
       <div
         aria-label="March 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4102,7 +4102,7 @@
     >
       <div
         aria-label="April 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4116,7 +4116,7 @@
     >
       <div
         aria-label="May 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4130,7 +4130,7 @@
     >
       <div
         aria-label="June 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4149,7 +4149,7 @@
     >
       <div
         aria-label="July 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4163,7 +4163,7 @@
     >
       <div
         aria-label="August 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4177,7 +4177,7 @@
     >
       <div
         aria-label="September 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4191,7 +4191,7 @@
     >
       <div
         aria-label="October 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4210,7 +4210,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4224,7 +4224,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4239,7 +4239,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4255,7 +4255,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4329,7 +4329,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -4343,7 +4343,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4357,7 +4357,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4371,7 +4371,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4390,7 +4390,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4404,7 +4404,7 @@
     >
       <div
         aria-label="2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4418,7 +4418,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4432,7 +4432,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4451,7 +4451,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4465,7 +4465,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4479,7 +4479,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4493,7 +4493,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4512,7 +4512,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4526,7 +4526,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4540,7 +4540,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4555,7 +4555,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4736,7 +4736,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -4750,7 +4750,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4764,7 +4764,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4783,7 +4783,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4797,7 +4797,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4811,7 +4811,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4825,7 +4825,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4839,7 +4839,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4853,7 +4853,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4867,7 +4867,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4886,7 +4886,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4900,7 +4900,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4914,7 +4914,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4928,7 +4928,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4942,7 +4942,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4956,7 +4956,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4970,7 +4970,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4989,7 +4989,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5003,7 +5003,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5017,7 +5017,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5031,7 +5031,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5045,7 +5045,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5059,7 +5059,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5073,7 +5073,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5092,7 +5092,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5106,7 +5106,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5120,7 +5120,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5134,7 +5134,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5148,7 +5148,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5163,7 +5163,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5408,7 +5408,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -5422,7 +5422,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5441,7 +5441,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5455,7 +5455,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5469,7 +5469,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5483,7 +5483,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5497,7 +5497,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5511,7 +5511,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5525,7 +5525,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5544,7 +5544,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5558,7 +5558,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5572,7 +5572,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5586,7 +5586,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5600,7 +5600,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5614,7 +5614,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5628,7 +5628,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5647,7 +5647,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5661,7 +5661,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5675,7 +5675,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5689,7 +5689,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5703,7 +5703,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5717,7 +5717,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5731,7 +5731,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5750,7 +5750,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5764,7 +5764,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5778,7 +5778,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5792,7 +5792,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5806,7 +5806,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5820,7 +5820,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5835,7 +5835,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6049,7 +6049,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -6063,7 +6063,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6077,7 +6077,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6091,7 +6091,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6105,7 +6105,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6119,7 +6119,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6138,7 +6138,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6152,7 +6152,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6166,7 +6166,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6180,7 +6180,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6194,7 +6194,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6208,7 +6208,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6222,7 +6222,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6241,7 +6241,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6255,7 +6255,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6269,7 +6269,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6283,7 +6283,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6297,7 +6297,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6311,7 +6311,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6325,7 +6325,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6344,7 +6344,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6358,7 +6358,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6372,7 +6372,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6386,7 +6386,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6400,7 +6400,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6414,7 +6414,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6428,7 +6428,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6447,7 +6447,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6461,7 +6461,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6476,7 +6476,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6737,7 +6737,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         1
@@ -6751,7 +6751,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -6765,7 +6765,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6783,7 +6783,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         4
@@ -6795,7 +6795,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         5
@@ -6807,7 +6807,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         6
@@ -6819,7 +6819,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         7
@@ -6831,7 +6831,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         8
@@ -6844,7 +6844,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6858,7 +6858,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6876,7 +6876,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         11
@@ -6888,7 +6888,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         12
@@ -6900,7 +6900,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         13
@@ -6912,7 +6912,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         14
@@ -6924,7 +6924,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         15
@@ -6937,7 +6937,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6951,7 +6951,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6969,7 +6969,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         18
@@ -6981,7 +6981,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         19
@@ -6993,7 +6993,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         20
@@ -7005,7 +7005,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         21
@@ -7017,7 +7017,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         22
@@ -7030,7 +7030,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7044,7 +7044,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7062,7 +7062,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         25
@@ -7074,7 +7074,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         26
@@ -7086,7 +7086,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         27
@@ -7098,7 +7098,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         28
@@ -7110,7 +7110,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         29
@@ -7124,7 +7124,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7366,7 +7366,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -7379,7 +7379,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         2
@@ -7391,7 +7391,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         3
@@ -7409,7 +7409,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7423,7 +7423,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7437,7 +7437,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7451,7 +7451,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7465,7 +7465,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7478,7 +7478,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         9
@@ -7490,7 +7490,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         10
@@ -7508,7 +7508,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7522,7 +7522,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7536,7 +7536,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7550,7 +7550,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7564,7 +7564,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7577,7 +7577,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         16
@@ -7589,7 +7589,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         17
@@ -7607,7 +7607,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7621,7 +7621,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7635,7 +7635,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7649,7 +7649,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7663,7 +7663,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7676,7 +7676,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         23
@@ -7688,7 +7688,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         24
@@ -7706,7 +7706,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7720,7 +7720,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7734,7 +7734,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7748,7 +7748,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7762,7 +7762,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7776,7 +7776,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         30
@@ -8015,7 +8015,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         1
@@ -8027,7 +8027,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         2
@@ -8039,7 +8039,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         3
@@ -8056,7 +8056,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         4
@@ -8070,7 +8070,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -8084,7 +8084,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8098,7 +8098,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8112,7 +8112,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8126,7 +8126,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8140,7 +8140,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8159,7 +8159,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8173,7 +8173,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8187,7 +8187,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8201,7 +8201,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8215,7 +8215,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8229,7 +8229,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8243,7 +8243,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8262,7 +8262,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8276,7 +8276,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8290,7 +8290,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8304,7 +8304,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8318,7 +8318,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8332,7 +8332,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8346,7 +8346,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8365,7 +8365,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8379,7 +8379,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8393,7 +8393,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8407,7 +8407,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8421,7 +8421,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8436,7 +8436,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8678,7 +8678,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -8692,7 +8692,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8706,7 +8706,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8725,7 +8725,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8739,7 +8739,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8753,7 +8753,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8767,7 +8767,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8781,7 +8781,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8795,7 +8795,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8809,7 +8809,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8828,7 +8828,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8842,7 +8842,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8856,7 +8856,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8870,7 +8870,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8884,7 +8884,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8898,7 +8898,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8912,7 +8912,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8931,7 +8931,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8945,7 +8945,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8959,7 +8959,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8973,7 +8973,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8987,7 +8987,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9001,7 +9001,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9015,7 +9015,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9034,7 +9034,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9047,7 +9047,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         26
@@ -9059,7 +9059,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         27
@@ -9071,7 +9071,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         28
@@ -9083,7 +9083,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         29
@@ -9096,7 +9096,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         30
@@ -9337,7 +9337,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -9350,7 +9350,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         2
@@ -9363,7 +9363,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9381,7 +9381,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         4
@@ -9394,7 +9394,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9407,7 +9407,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         6
@@ -9420,7 +9420,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9433,7 +9433,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         8
@@ -9446,7 +9446,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9459,7 +9459,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         10
@@ -9477,7 +9477,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9490,7 +9490,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         12
@@ -9503,7 +9503,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9516,7 +9516,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         14
@@ -9529,7 +9529,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9542,7 +9542,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         16
@@ -9555,7 +9555,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9573,7 +9573,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         18
@@ -9586,7 +9586,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9599,7 +9599,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         20
@@ -9612,7 +9612,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9625,7 +9625,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         22
@@ -9638,7 +9638,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9651,7 +9651,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         24
@@ -9669,7 +9669,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9682,7 +9682,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         26
@@ -9695,7 +9695,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9708,7 +9708,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         28
@@ -9721,7 +9721,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9735,7 +9735,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         30
@@ -9972,7 +9972,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         1
@@ -9984,7 +9984,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         2
@@ -9996,7 +9996,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         3
@@ -10013,7 +10013,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         4
@@ -10027,7 +10027,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -10040,7 +10040,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         6
@@ -10053,7 +10053,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10066,7 +10066,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         8
@@ -10078,7 +10078,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         9
@@ -10090,7 +10090,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         10
@@ -10108,7 +10108,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10121,7 +10121,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         12
@@ -10134,7 +10134,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10147,7 +10147,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         14
@@ -10160,7 +10160,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10173,7 +10173,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         16
@@ -10185,7 +10185,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         17
@@ -10202,7 +10202,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         18
@@ -10215,7 +10215,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10228,7 +10228,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         20
@@ -10241,7 +10241,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10254,7 +10254,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         22
@@ -10266,7 +10266,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         23
@@ -10278,7 +10278,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         24
@@ -10296,7 +10296,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10309,7 +10309,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         26
@@ -10321,7 +10321,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         27
@@ -10333,7 +10333,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         28
@@ -10345,7 +10345,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         29
@@ -10358,7 +10358,7 @@
       role="gridcell"
     >
       <div
-        part="cell-content"
+        part="cell-content selection"
         role="button"
       >
         30

--- a/packages/elements/src/calendar/__snapshots__/Defaults.md
+++ b/packages/elements/src/calendar/__snapshots__/Defaults.md
@@ -138,7 +138,7 @@
     >
       <div
         aria-label="Monday, 28 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -153,7 +153,7 @@
     >
       <div
         aria-label="Tuesday, 29 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -168,7 +168,7 @@
     >
       <div
         aria-label="Wednesday, 30 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -183,7 +183,7 @@
     >
       <div
         aria-label="Thursday, 31 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -197,7 +197,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -211,7 +211,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -225,7 +225,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -244,7 +244,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -258,7 +258,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -272,7 +272,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -286,7 +286,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -300,7 +300,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -314,7 +314,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -328,7 +328,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -347,7 +347,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -361,7 +361,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -375,7 +375,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -389,7 +389,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -403,7 +403,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -417,7 +417,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -431,7 +431,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -450,7 +450,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -464,7 +464,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -478,7 +478,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -492,7 +492,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -506,7 +506,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -520,7 +520,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -534,7 +534,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -553,7 +553,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -567,7 +567,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -581,7 +581,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -595,7 +595,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -609,7 +609,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -623,7 +623,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -638,7 +638,7 @@
     >
       <div
         aria-label="Sunday, 1 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -658,7 +658,7 @@
     >
       <div
         aria-label="Monday, 2 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -673,7 +673,7 @@
     >
       <div
         aria-label="Tuesday, 3 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -688,7 +688,7 @@
     >
       <div
         aria-label="Wednesday, 4 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -703,7 +703,7 @@
     >
       <div
         aria-label="Thursday, 5 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -718,7 +718,7 @@
     >
       <div
         aria-label="Friday, 6 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -733,7 +733,7 @@
     >
       <div
         aria-label="Saturday, 7 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -749,7 +749,7 @@
     >
       <div
         aria-label="Sunday, 8 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -928,7 +928,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -942,7 +942,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -956,7 +956,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -975,7 +975,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -989,7 +989,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1003,7 +1003,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1017,7 +1017,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1031,7 +1031,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1045,7 +1045,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1059,7 +1059,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1078,7 +1078,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1092,7 +1092,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1106,7 +1106,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1120,7 +1120,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1134,7 +1134,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1148,7 +1148,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1162,7 +1162,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1181,7 +1181,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1195,7 +1195,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1209,7 +1209,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1223,7 +1223,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1237,7 +1237,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1251,7 +1251,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1265,7 +1265,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1284,7 +1284,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1298,7 +1298,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1312,7 +1312,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1326,7 +1326,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1340,7 +1340,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1355,7 +1355,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1491,7 +1491,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -1506,7 +1506,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1520,7 +1520,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1534,7 +1534,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1553,7 +1553,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1567,7 +1567,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1581,7 +1581,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1595,7 +1595,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1614,7 +1614,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1628,7 +1628,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1642,7 +1642,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1656,7 +1656,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1675,7 +1675,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1689,7 +1689,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1704,7 +1704,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1720,7 +1720,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1794,7 +1794,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -1808,7 +1808,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1822,7 +1822,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1836,7 +1836,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1855,7 +1855,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1869,7 +1869,7 @@
     >
       <div
         aria-label="2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1883,7 +1883,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1897,7 +1897,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1916,7 +1916,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1930,7 +1930,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1944,7 +1944,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1958,7 +1958,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1977,7 +1977,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1991,7 +1991,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2005,7 +2005,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2020,7 +2020,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2178,7 +2178,7 @@
     >
       <div
         aria-label="Tuesday, 1 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -2192,7 +2192,7 @@
     >
       <div
         aria-label="Wednesday, 2 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2206,7 +2206,7 @@
     >
       <div
         aria-label="Thursday, 3 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2220,7 +2220,7 @@
     >
       <div
         aria-label="Friday, 4 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2234,7 +2234,7 @@
     >
       <div
         aria-label="Saturday, 5 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2248,7 +2248,7 @@
     >
       <div
         aria-label="Sunday, 6 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2267,7 +2267,7 @@
     >
       <div
         aria-label="Monday, 7 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2281,7 +2281,7 @@
     >
       <div
         aria-label="Tuesday, 8 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2295,7 +2295,7 @@
     >
       <div
         aria-label="Wednesday, 9 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2309,7 +2309,7 @@
     >
       <div
         aria-label="Thursday, 10 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2323,7 +2323,7 @@
     >
       <div
         aria-label="Friday, 11 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2337,7 +2337,7 @@
     >
       <div
         aria-label="Saturday, 12 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2351,7 +2351,7 @@
     >
       <div
         aria-label="Sunday, 13 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2370,7 +2370,7 @@
     >
       <div
         aria-label="Monday, 14 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2384,7 +2384,7 @@
     >
       <div
         aria-label="Tuesday, 15 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2398,7 +2398,7 @@
     >
       <div
         aria-label="Wednesday, 16 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2412,7 +2412,7 @@
     >
       <div
         aria-label="Thursday, 17 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2426,7 +2426,7 @@
     >
       <div
         aria-label="Friday, 18 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2440,7 +2440,7 @@
     >
       <div
         aria-label="Saturday, 19 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2454,7 +2454,7 @@
     >
       <div
         aria-label="Sunday, 20 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2473,7 +2473,7 @@
     >
       <div
         aria-label="Monday, 21 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2487,7 +2487,7 @@
     >
       <div
         aria-label="Tuesday, 22 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2501,7 +2501,7 @@
     >
       <div
         aria-label="Wednesday, 23 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2515,7 +2515,7 @@
     >
       <div
         aria-label="Thursday, 24 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2529,7 +2529,7 @@
     >
       <div
         aria-label="Friday, 25 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2543,7 +2543,7 @@
     >
       <div
         aria-label="Saturday, 26 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2557,7 +2557,7 @@
     >
       <div
         aria-label="Sunday, 27 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2577,7 +2577,7 @@
     >
       <div
         aria-label="Monday, 28 February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2748,7 +2748,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -2763,7 +2763,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2777,7 +2777,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2791,7 +2791,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2810,7 +2810,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2824,7 +2824,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2838,7 +2838,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2852,7 +2852,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2871,7 +2871,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2885,7 +2885,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2899,7 +2899,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2913,7 +2913,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2932,7 +2932,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2946,7 +2946,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2961,7 +2961,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2977,7 +2977,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3051,7 +3051,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -3065,7 +3065,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3079,7 +3079,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3093,7 +3093,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3112,7 +3112,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3126,7 +3126,7 @@
     >
       <div
         aria-label="2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3140,7 +3140,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3154,7 +3154,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3173,7 +3173,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3187,7 +3187,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3201,7 +3201,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3215,7 +3215,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3234,7 +3234,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3248,7 +3248,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3262,7 +3262,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3277,7 +3277,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3442,7 +3442,7 @@
     >
       <div
         aria-label="Wednesday, 1 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -3456,7 +3456,7 @@
     >
       <div
         aria-label="Thursday, 2 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3470,7 +3470,7 @@
     >
       <div
         aria-label="Friday, 3 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3484,7 +3484,7 @@
     >
       <div
         aria-label="Saturday, 4 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3498,7 +3498,7 @@
     >
       <div
         aria-label="Sunday, 5 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3517,7 +3517,7 @@
     >
       <div
         aria-label="Monday, 6 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3531,7 +3531,7 @@
     >
       <div
         aria-label="Tuesday, 7 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3545,7 +3545,7 @@
     >
       <div
         aria-label="Wednesday, 8 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3559,7 +3559,7 @@
     >
       <div
         aria-label="Thursday, 9 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3573,7 +3573,7 @@
     >
       <div
         aria-label="Friday, 10 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3587,7 +3587,7 @@
     >
       <div
         aria-label="Saturday, 11 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3601,7 +3601,7 @@
     >
       <div
         aria-label="Sunday, 12 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3620,7 +3620,7 @@
     >
       <div
         aria-label="Monday, 13 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3634,7 +3634,7 @@
     >
       <div
         aria-label="Tuesday, 14 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3648,7 +3648,7 @@
     >
       <div
         aria-label="Wednesday, 15 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3662,7 +3662,7 @@
     >
       <div
         aria-label="Thursday, 16 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3676,7 +3676,7 @@
     >
       <div
         aria-label="Friday, 17 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3690,7 +3690,7 @@
     >
       <div
         aria-label="Saturday, 18 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3704,7 +3704,7 @@
     >
       <div
         aria-label="Sunday, 19 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3723,7 +3723,7 @@
     >
       <div
         aria-label="Monday, 20 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3737,7 +3737,7 @@
     >
       <div
         aria-label="Tuesday, 21 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3751,7 +3751,7 @@
     >
       <div
         aria-label="Wednesday, 22 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3765,7 +3765,7 @@
     >
       <div
         aria-label="Thursday, 23 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3779,7 +3779,7 @@
     >
       <div
         aria-label="Friday, 24 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3793,7 +3793,7 @@
     >
       <div
         aria-label="Saturday, 25 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3807,7 +3807,7 @@
     >
       <div
         aria-label="Sunday, 26 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3826,7 +3826,7 @@
     >
       <div
         aria-label="Monday, 27 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3840,7 +3840,7 @@
     >
       <div
         aria-label="Tuesday, 28 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3854,7 +3854,7 @@
     >
       <div
         aria-label="Wednesday, 29 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3868,7 +3868,7 @@
     >
       <div
         aria-label="Thursday, 30 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3883,7 +3883,7 @@
     >
       <div
         aria-label="Friday, 31 December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4026,7 +4026,7 @@
     >
       <div
         aria-label="November 2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -4041,7 +4041,7 @@
     >
       <div
         aria-label="December 2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4055,7 +4055,7 @@
     >
       <div
         aria-label="January 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4069,7 +4069,7 @@
     >
       <div
         aria-label="February 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4088,7 +4088,7 @@
     >
       <div
         aria-label="March 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4102,7 +4102,7 @@
     >
       <div
         aria-label="April 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4116,7 +4116,7 @@
     >
       <div
         aria-label="May 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4130,7 +4130,7 @@
     >
       <div
         aria-label="June 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4149,7 +4149,7 @@
     >
       <div
         aria-label="July 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4163,7 +4163,7 @@
     >
       <div
         aria-label="August 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4177,7 +4177,7 @@
     >
       <div
         aria-label="September 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4191,7 +4191,7 @@
     >
       <div
         aria-label="October 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4210,7 +4210,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4224,7 +4224,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4239,7 +4239,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4255,7 +4255,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4329,7 +4329,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -4343,7 +4343,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4357,7 +4357,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4371,7 +4371,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4390,7 +4390,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4404,7 +4404,7 @@
     >
       <div
         aria-label="2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4418,7 +4418,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4432,7 +4432,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4451,7 +4451,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4465,7 +4465,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4479,7 +4479,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4493,7 +4493,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4512,7 +4512,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4526,7 +4526,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4540,7 +4540,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4555,7 +4555,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4736,7 +4736,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -4750,7 +4750,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4764,7 +4764,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4783,7 +4783,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4797,7 +4797,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4811,7 +4811,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4825,7 +4825,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4839,7 +4839,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4853,7 +4853,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4867,7 +4867,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4886,7 +4886,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4900,7 +4900,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4914,7 +4914,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4928,7 +4928,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4942,7 +4942,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4956,7 +4956,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4970,7 +4970,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4989,7 +4989,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5003,7 +5003,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5017,7 +5017,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5031,7 +5031,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5045,7 +5045,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5059,7 +5059,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5073,7 +5073,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5092,7 +5092,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5106,7 +5106,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5120,7 +5120,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5134,7 +5134,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5148,7 +5148,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5163,7 +5163,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5408,7 +5408,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -5422,7 +5422,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5441,7 +5441,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5455,7 +5455,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5469,7 +5469,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5483,7 +5483,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5497,7 +5497,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5511,7 +5511,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5525,7 +5525,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5544,7 +5544,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5558,7 +5558,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5572,7 +5572,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5586,7 +5586,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5600,7 +5600,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5614,7 +5614,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5628,7 +5628,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5647,7 +5647,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5661,7 +5661,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5675,7 +5675,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5689,7 +5689,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5703,7 +5703,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5717,7 +5717,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5731,7 +5731,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5750,7 +5750,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5764,7 +5764,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5778,7 +5778,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5792,7 +5792,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5806,7 +5806,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5820,7 +5820,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5835,7 +5835,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6049,7 +6049,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -6063,7 +6063,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6077,7 +6077,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6091,7 +6091,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6105,7 +6105,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6119,7 +6119,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6138,7 +6138,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6152,7 +6152,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6166,7 +6166,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6180,7 +6180,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6194,7 +6194,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6208,7 +6208,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6222,7 +6222,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6241,7 +6241,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6255,7 +6255,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6269,7 +6269,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6283,7 +6283,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6297,7 +6297,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6311,7 +6311,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6325,7 +6325,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6344,7 +6344,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6358,7 +6358,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6372,7 +6372,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6386,7 +6386,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6400,7 +6400,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6414,7 +6414,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6428,7 +6428,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6447,7 +6447,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6461,7 +6461,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6476,7 +6476,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6751,7 +6751,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -6765,7 +6765,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6844,7 +6844,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6858,7 +6858,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6937,7 +6937,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6951,7 +6951,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7030,7 +7030,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7044,7 +7044,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7124,7 +7124,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7366,7 +7366,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -7409,7 +7409,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7423,7 +7423,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7437,7 +7437,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7451,7 +7451,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7465,7 +7465,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7508,7 +7508,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7522,7 +7522,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7536,7 +7536,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7550,7 +7550,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7564,7 +7564,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7607,7 +7607,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7621,7 +7621,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7635,7 +7635,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7649,7 +7649,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7663,7 +7663,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7706,7 +7706,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7720,7 +7720,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7734,7 +7734,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7748,7 +7748,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7762,7 +7762,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8070,7 +8070,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -8084,7 +8084,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8098,7 +8098,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8112,7 +8112,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8126,7 +8126,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8140,7 +8140,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8159,7 +8159,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8173,7 +8173,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8187,7 +8187,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8201,7 +8201,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8215,7 +8215,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8229,7 +8229,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8243,7 +8243,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8262,7 +8262,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8276,7 +8276,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8290,7 +8290,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8304,7 +8304,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8318,7 +8318,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8332,7 +8332,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8346,7 +8346,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8365,7 +8365,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8379,7 +8379,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8393,7 +8393,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8407,7 +8407,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8421,7 +8421,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8436,7 +8436,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8678,7 +8678,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -8692,7 +8692,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8706,7 +8706,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8725,7 +8725,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8739,7 +8739,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8753,7 +8753,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8767,7 +8767,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8781,7 +8781,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8795,7 +8795,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8809,7 +8809,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8828,7 +8828,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8842,7 +8842,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8856,7 +8856,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8870,7 +8870,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8884,7 +8884,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8898,7 +8898,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8912,7 +8912,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8931,7 +8931,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8945,7 +8945,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8959,7 +8959,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8973,7 +8973,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8987,7 +8987,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9001,7 +9001,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9015,7 +9015,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9034,7 +9034,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9337,7 +9337,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -9363,7 +9363,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9394,7 +9394,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9420,7 +9420,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9446,7 +9446,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9477,7 +9477,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9503,7 +9503,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9529,7 +9529,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9555,7 +9555,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9586,7 +9586,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9612,7 +9612,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9638,7 +9638,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9669,7 +9669,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9695,7 +9695,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9721,7 +9721,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10027,7 +10027,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -10053,7 +10053,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10108,7 +10108,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10134,7 +10134,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10160,7 +10160,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10215,7 +10215,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10241,7 +10241,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10296,7 +10296,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >

--- a/packages/elements/src/calendar/__snapshots__/KeyboardNavigation.md
+++ b/packages/elements/src/calendar/__snapshots__/KeyboardNavigation.md
@@ -143,7 +143,7 @@
     >
       <div
         aria-label="Tuesday, 1 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -157,7 +157,7 @@
     >
       <div
         aria-label="Wednesday, 2 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -171,7 +171,7 @@
     >
       <div
         aria-label="Thursday, 3 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -185,7 +185,7 @@
     >
       <div
         aria-label="Friday, 4 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -199,7 +199,7 @@
     >
       <div
         aria-label="Saturday, 5 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -213,7 +213,7 @@
     >
       <div
         aria-label="Sunday, 6 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -232,7 +232,7 @@
     >
       <div
         aria-label="Monday, 7 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -246,7 +246,7 @@
     >
       <div
         aria-label="Tuesday, 8 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -260,7 +260,7 @@
     >
       <div
         aria-label="Wednesday, 9 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -274,7 +274,7 @@
     >
       <div
         aria-label="Thursday, 10 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -288,7 +288,7 @@
     >
       <div
         aria-label="Friday, 11 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -302,7 +302,7 @@
     >
       <div
         aria-label="Saturday, 12 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -316,7 +316,7 @@
     >
       <div
         aria-label="Sunday, 13 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -335,7 +335,7 @@
     >
       <div
         aria-label="Monday, 14 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -349,7 +349,7 @@
     >
       <div
         aria-label="Tuesday, 15 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -363,7 +363,7 @@
     >
       <div
         aria-label="Wednesday, 16 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -377,7 +377,7 @@
     >
       <div
         aria-label="Thursday, 17 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -391,7 +391,7 @@
     >
       <div
         aria-label="Friday, 18 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -405,7 +405,7 @@
     >
       <div
         aria-label="Saturday, 19 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -419,7 +419,7 @@
     >
       <div
         aria-label="Sunday, 20 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -438,7 +438,7 @@
     >
       <div
         aria-label="Monday, 21 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -452,7 +452,7 @@
     >
       <div
         aria-label="Tuesday, 22 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -466,7 +466,7 @@
     >
       <div
         aria-label="Wednesday, 23 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -480,7 +480,7 @@
     >
       <div
         aria-label="Thursday, 24 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -494,7 +494,7 @@
     >
       <div
         aria-label="Friday, 25 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -508,7 +508,7 @@
     >
       <div
         aria-label="Saturday, 26 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -522,7 +522,7 @@
     >
       <div
         aria-label="Sunday, 27 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -541,7 +541,7 @@
     >
       <div
         aria-label="Monday, 28 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -555,7 +555,7 @@
     >
       <div
         aria-label="Tuesday, 29 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -569,7 +569,7 @@
     >
       <div
         aria-label="Wednesday, 30 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -585,7 +585,7 @@
     >
       <div
         aria-label="Thursday, 31 March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -837,7 +837,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -851,7 +851,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -865,7 +865,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -884,7 +884,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -898,7 +898,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -912,7 +912,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -926,7 +926,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -940,7 +940,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -954,7 +954,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -968,7 +968,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -987,7 +987,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1001,7 +1001,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1015,7 +1015,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1029,7 +1029,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1043,7 +1043,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1057,7 +1057,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1071,7 +1071,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1090,7 +1090,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1104,7 +1104,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1118,7 +1118,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1132,7 +1132,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1146,7 +1146,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1160,7 +1160,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1174,7 +1174,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1193,7 +1193,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1207,7 +1207,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1221,7 +1221,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1235,7 +1235,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1249,7 +1249,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1264,7 +1264,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1403,7 +1403,7 @@
     >
       <div
         aria-label="November 2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1418,7 +1418,7 @@
     >
       <div
         aria-label="December 2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1432,7 +1432,7 @@
     >
       <div
         aria-label="January 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1446,7 +1446,7 @@
     >
       <div
         aria-label="February 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1465,7 +1465,7 @@
     >
       <div
         aria-label="March 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1479,7 +1479,7 @@
     >
       <div
         aria-label="April 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1493,7 +1493,7 @@
     >
       <div
         aria-label="May 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1507,7 +1507,7 @@
     >
       <div
         aria-label="June 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1526,7 +1526,7 @@
     >
       <div
         aria-label="July 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1540,7 +1540,7 @@
     >
       <div
         aria-label="August 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1554,7 +1554,7 @@
     >
       <div
         aria-label="September 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1568,7 +1568,7 @@
     >
       <div
         aria-label="October 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1587,7 +1587,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1601,7 +1601,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1616,7 +1616,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1633,7 +1633,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -1708,7 +1708,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -1723,7 +1723,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1737,7 +1737,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1751,7 +1751,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1770,7 +1770,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1784,7 +1784,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1798,7 +1798,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1812,7 +1812,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1831,7 +1831,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1845,7 +1845,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1859,7 +1859,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1873,7 +1873,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1892,7 +1892,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1906,7 +1906,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1921,7 +1921,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1937,7 +1937,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2014,7 +2014,7 @@
     >
       <div
         aria-label="1984"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2028,7 +2028,7 @@
     >
       <div
         aria-label="1985"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2042,7 +2042,7 @@
     >
       <div
         aria-label="1986"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2056,7 +2056,7 @@
     >
       <div
         aria-label="1987"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2075,7 +2075,7 @@
     >
       <div
         aria-label="1988"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2089,7 +2089,7 @@
     >
       <div
         aria-label="1989"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2103,7 +2103,7 @@
     >
       <div
         aria-label="1990"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2117,7 +2117,7 @@
     >
       <div
         aria-label="1991"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2136,7 +2136,7 @@
     >
       <div
         aria-label="1992"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2150,7 +2150,7 @@
     >
       <div
         aria-label="1993"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2164,7 +2164,7 @@
     >
       <div
         aria-label="1994"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2178,7 +2178,7 @@
     >
       <div
         aria-label="1995"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2197,7 +2197,7 @@
     >
       <div
         aria-label="1996"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2211,7 +2211,7 @@
     >
       <div
         aria-label="1997"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2225,7 +2225,7 @@
     >
       <div
         aria-label="1998"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2241,7 +2241,7 @@
     >
       <div
         aria-label="1999"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -2315,7 +2315,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -2329,7 +2329,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2343,7 +2343,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2357,7 +2357,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2376,7 +2376,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2390,7 +2390,7 @@
     >
       <div
         aria-label="2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2404,7 +2404,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2418,7 +2418,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2437,7 +2437,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2451,7 +2451,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2465,7 +2465,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2479,7 +2479,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2498,7 +2498,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2512,7 +2512,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2526,7 +2526,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2541,7 +2541,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >

--- a/packages/elements/src/calendar/__snapshots__/KeyboardNavigation.md
+++ b/packages/elements/src/calendar/__snapshots__/KeyboardNavigation.md
@@ -143,7 +143,7 @@
     >
       <div
         aria-label="Tuesday, 1 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -157,7 +157,7 @@
     >
       <div
         aria-label="Wednesday, 2 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -171,7 +171,7 @@
     >
       <div
         aria-label="Thursday, 3 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -185,7 +185,7 @@
     >
       <div
         aria-label="Friday, 4 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -199,7 +199,7 @@
     >
       <div
         aria-label="Saturday, 5 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -213,7 +213,7 @@
     >
       <div
         aria-label="Sunday, 6 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -232,7 +232,7 @@
     >
       <div
         aria-label="Monday, 7 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -246,7 +246,7 @@
     >
       <div
         aria-label="Tuesday, 8 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -260,7 +260,7 @@
     >
       <div
         aria-label="Wednesday, 9 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -274,7 +274,7 @@
     >
       <div
         aria-label="Thursday, 10 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -288,7 +288,7 @@
     >
       <div
         aria-label="Friday, 11 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -302,7 +302,7 @@
     >
       <div
         aria-label="Saturday, 12 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -316,7 +316,7 @@
     >
       <div
         aria-label="Sunday, 13 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -335,7 +335,7 @@
     >
       <div
         aria-label="Monday, 14 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -349,7 +349,7 @@
     >
       <div
         aria-label="Tuesday, 15 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -363,7 +363,7 @@
     >
       <div
         aria-label="Wednesday, 16 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -377,7 +377,7 @@
     >
       <div
         aria-label="Thursday, 17 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -391,7 +391,7 @@
     >
       <div
         aria-label="Friday, 18 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -405,7 +405,7 @@
     >
       <div
         aria-label="Saturday, 19 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -419,7 +419,7 @@
     >
       <div
         aria-label="Sunday, 20 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -438,7 +438,7 @@
     >
       <div
         aria-label="Monday, 21 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -452,7 +452,7 @@
     >
       <div
         aria-label="Tuesday, 22 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -466,7 +466,7 @@
     >
       <div
         aria-label="Wednesday, 23 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -480,7 +480,7 @@
     >
       <div
         aria-label="Thursday, 24 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -494,7 +494,7 @@
     >
       <div
         aria-label="Friday, 25 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -508,7 +508,7 @@
     >
       <div
         aria-label="Saturday, 26 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -522,7 +522,7 @@
     >
       <div
         aria-label="Sunday, 27 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -541,7 +541,7 @@
     >
       <div
         aria-label="Monday, 28 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -555,7 +555,7 @@
     >
       <div
         aria-label="Tuesday, 29 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -569,7 +569,7 @@
     >
       <div
         aria-label="Wednesday, 30 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -585,7 +585,7 @@
     >
       <div
         aria-label="Thursday, 31 March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -837,7 +837,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -851,7 +851,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -865,7 +865,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -884,7 +884,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -898,7 +898,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -912,7 +912,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -926,7 +926,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -940,7 +940,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -954,7 +954,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -968,7 +968,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -987,7 +987,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1001,7 +1001,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1015,7 +1015,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1029,7 +1029,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1043,7 +1043,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1057,7 +1057,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1071,7 +1071,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1090,7 +1090,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1104,7 +1104,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1118,7 +1118,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1132,7 +1132,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1146,7 +1146,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1160,7 +1160,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1174,7 +1174,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1193,7 +1193,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1207,7 +1207,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1221,7 +1221,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1235,7 +1235,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1249,7 +1249,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1264,7 +1264,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1403,7 +1403,7 @@
     >
       <div
         aria-label="November 2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1418,7 +1418,7 @@
     >
       <div
         aria-label="December 2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1432,7 +1432,7 @@
     >
       <div
         aria-label="January 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1446,7 +1446,7 @@
     >
       <div
         aria-label="February 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1465,7 +1465,7 @@
     >
       <div
         aria-label="March 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1479,7 +1479,7 @@
     >
       <div
         aria-label="April 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1493,7 +1493,7 @@
     >
       <div
         aria-label="May 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1507,7 +1507,7 @@
     >
       <div
         aria-label="June 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1526,7 +1526,7 @@
     >
       <div
         aria-label="July 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1540,7 +1540,7 @@
     >
       <div
         aria-label="August 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1554,7 +1554,7 @@
     >
       <div
         aria-label="September 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1568,7 +1568,7 @@
     >
       <div
         aria-label="October 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1587,7 +1587,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1601,7 +1601,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1616,7 +1616,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1633,7 +1633,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -1708,7 +1708,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -1723,7 +1723,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1737,7 +1737,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1751,7 +1751,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1770,7 +1770,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1784,7 +1784,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1798,7 +1798,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1812,7 +1812,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1831,7 +1831,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1845,7 +1845,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1859,7 +1859,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1873,7 +1873,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1892,7 +1892,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1906,7 +1906,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1921,7 +1921,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1937,7 +1937,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2014,7 +2014,7 @@
     >
       <div
         aria-label="1984"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2028,7 +2028,7 @@
     >
       <div
         aria-label="1985"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2042,7 +2042,7 @@
     >
       <div
         aria-label="1986"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2056,7 +2056,7 @@
     >
       <div
         aria-label="1987"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2075,7 +2075,7 @@
     >
       <div
         aria-label="1988"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2089,7 +2089,7 @@
     >
       <div
         aria-label="1989"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2103,7 +2103,7 @@
     >
       <div
         aria-label="1990"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2117,7 +2117,7 @@
     >
       <div
         aria-label="1991"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2136,7 +2136,7 @@
     >
       <div
         aria-label="1992"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2150,7 +2150,7 @@
     >
       <div
         aria-label="1993"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2164,7 +2164,7 @@
     >
       <div
         aria-label="1994"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2178,7 +2178,7 @@
     >
       <div
         aria-label="1995"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2197,7 +2197,7 @@
     >
       <div
         aria-label="1996"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2211,7 +2211,7 @@
     >
       <div
         aria-label="1997"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2225,7 +2225,7 @@
     >
       <div
         aria-label="1998"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2241,7 +2241,7 @@
     >
       <div
         aria-label="1999"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -2315,7 +2315,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -2329,7 +2329,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2343,7 +2343,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2357,7 +2357,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2376,7 +2376,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2390,7 +2390,7 @@
     >
       <div
         aria-label="2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2404,7 +2404,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2418,7 +2418,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2437,7 +2437,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2451,7 +2451,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2465,7 +2465,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2479,7 +2479,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2498,7 +2498,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2512,7 +2512,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2526,7 +2526,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2541,7 +2541,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >

--- a/packages/elements/src/calendar/__snapshots__/Multiple.md
+++ b/packages/elements/src/calendar/__snapshots__/Multiple.md
@@ -164,7 +164,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -178,7 +178,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -192,7 +192,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -211,7 +211,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -225,7 +225,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -239,7 +239,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -253,7 +253,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -267,7 +267,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -281,7 +281,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -295,7 +295,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -314,7 +314,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -328,7 +328,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -342,7 +342,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -356,7 +356,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -370,7 +370,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -384,7 +384,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -398,7 +398,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -417,7 +417,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -431,7 +431,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -445,7 +445,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -461,7 +461,7 @@
     >
       <div
         aria-label="Selected: Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -475,7 +475,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -489,7 +489,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -504,7 +504,7 @@
     >
       <div
         aria-label="Selected: Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -523,7 +523,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -537,7 +537,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -551,7 +551,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -565,7 +565,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -579,7 +579,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -594,7 +594,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -729,7 +729,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -744,7 +744,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -758,7 +758,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -772,7 +772,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -791,7 +791,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -807,7 +807,7 @@
     >
       <div
         aria-label="Selected: April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -821,7 +821,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -835,7 +835,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -854,7 +854,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -868,7 +868,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -882,7 +882,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -896,7 +896,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -915,7 +915,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -929,7 +929,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -944,7 +944,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -960,7 +960,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1033,7 +1033,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1047,7 +1047,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1061,7 +1061,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1075,7 +1075,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1094,7 +1094,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1110,7 +1110,7 @@
     >
       <div
         aria-label="Selected: 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -1124,7 +1124,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1138,7 +1138,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1157,7 +1157,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1172,7 +1172,7 @@
     >
       <div
         aria-label="Selected: 2009"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1186,7 +1186,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1200,7 +1200,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1219,7 +1219,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1233,7 +1233,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1247,7 +1247,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1262,7 +1262,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1441,7 +1441,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -1455,7 +1455,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1469,7 +1469,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1488,7 +1488,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1502,7 +1502,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1516,7 +1516,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1530,7 +1530,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1544,7 +1544,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1558,7 +1558,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1572,7 +1572,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1591,7 +1591,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1605,7 +1605,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1619,7 +1619,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1633,7 +1633,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1647,7 +1647,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1661,7 +1661,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1675,7 +1675,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1694,7 +1694,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1708,7 +1708,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1722,7 +1722,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1736,7 +1736,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1750,7 +1750,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1764,7 +1764,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1778,7 +1778,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1797,7 +1797,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1811,7 +1811,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1825,7 +1825,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1839,7 +1839,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1853,7 +1853,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1868,7 +1868,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >

--- a/packages/elements/src/calendar/__snapshots__/Multiple.md
+++ b/packages/elements/src/calendar/__snapshots__/Multiple.md
@@ -164,7 +164,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -178,7 +178,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -192,7 +192,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -211,7 +211,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -225,7 +225,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -239,7 +239,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -253,7 +253,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -267,7 +267,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -281,7 +281,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -295,7 +295,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -314,7 +314,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -328,7 +328,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -342,7 +342,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -356,7 +356,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -370,7 +370,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -384,7 +384,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -398,7 +398,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -417,7 +417,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -431,7 +431,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -445,7 +445,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -461,7 +461,7 @@
     >
       <div
         aria-label="Selected: Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -475,7 +475,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -489,7 +489,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -504,7 +504,7 @@
     >
       <div
         aria-label="Selected: Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -523,7 +523,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -537,7 +537,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -551,7 +551,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -565,7 +565,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -579,7 +579,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -594,7 +594,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -729,7 +729,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -744,7 +744,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -758,7 +758,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -772,7 +772,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -791,7 +791,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -807,7 +807,7 @@
     >
       <div
         aria-label="Selected: April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -821,7 +821,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -835,7 +835,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -854,7 +854,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -868,7 +868,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -882,7 +882,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -896,7 +896,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -915,7 +915,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -929,7 +929,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -944,7 +944,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -960,7 +960,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1033,7 +1033,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1047,7 +1047,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1061,7 +1061,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1075,7 +1075,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1094,7 +1094,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1110,7 +1110,7 @@
     >
       <div
         aria-label="Selected: 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -1124,7 +1124,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1138,7 +1138,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1157,7 +1157,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1172,7 +1172,7 @@
     >
       <div
         aria-label="Selected: 2009"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1186,7 +1186,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1200,7 +1200,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1219,7 +1219,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1233,7 +1233,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1247,7 +1247,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1262,7 +1262,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1441,7 +1441,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -1455,7 +1455,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1469,7 +1469,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1488,7 +1488,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1502,7 +1502,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1516,7 +1516,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1530,7 +1530,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1544,7 +1544,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1558,7 +1558,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1572,7 +1572,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1591,7 +1591,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1605,7 +1605,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1619,7 +1619,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1633,7 +1633,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1647,7 +1647,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1661,7 +1661,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1675,7 +1675,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1694,7 +1694,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1708,7 +1708,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1722,7 +1722,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1736,7 +1736,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1750,7 +1750,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1764,7 +1764,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1778,7 +1778,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1797,7 +1797,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1811,7 +1811,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1825,7 +1825,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1839,7 +1839,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1853,7 +1853,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1868,7 +1868,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >

--- a/packages/elements/src/calendar/__snapshots__/Navigation.md
+++ b/packages/elements/src/calendar/__snapshots__/Navigation.md
@@ -172,7 +172,7 @@
     >
       <div
         aria-label="Saturday, 1 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -186,7 +186,7 @@
     >
       <div
         aria-label="Sunday, 2 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -205,7 +205,7 @@
     >
       <div
         aria-label="Monday, 3 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -219,7 +219,7 @@
     >
       <div
         aria-label="Tuesday, 4 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -233,7 +233,7 @@
     >
       <div
         aria-label="Wednesday, 5 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -247,7 +247,7 @@
     >
       <div
         aria-label="Thursday, 6 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -261,7 +261,7 @@
     >
       <div
         aria-label="Friday, 7 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -275,7 +275,7 @@
     >
       <div
         aria-label="Saturday, 8 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -289,7 +289,7 @@
     >
       <div
         aria-label="Sunday, 9 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -308,7 +308,7 @@
     >
       <div
         aria-label="Monday, 10 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -322,7 +322,7 @@
     >
       <div
         aria-label="Tuesday, 11 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -336,7 +336,7 @@
     >
       <div
         aria-label="Wednesday, 12 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -350,7 +350,7 @@
     >
       <div
         aria-label="Thursday, 13 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -364,7 +364,7 @@
     >
       <div
         aria-label="Friday, 14 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -378,7 +378,7 @@
     >
       <div
         aria-label="Saturday, 15 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -392,7 +392,7 @@
     >
       <div
         aria-label="Sunday, 16 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -411,7 +411,7 @@
     >
       <div
         aria-label="Monday, 17 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -425,7 +425,7 @@
     >
       <div
         aria-label="Tuesday, 18 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -439,7 +439,7 @@
     >
       <div
         aria-label="Wednesday, 19 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -453,7 +453,7 @@
     >
       <div
         aria-label="Thursday, 20 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -467,7 +467,7 @@
     >
       <div
         aria-label="Friday, 21 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -481,7 +481,7 @@
     >
       <div
         aria-label="Saturday, 22 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -495,7 +495,7 @@
     >
       <div
         aria-label="Sunday, 23 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -514,7 +514,7 @@
     >
       <div
         aria-label="Monday, 24 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -528,7 +528,7 @@
     >
       <div
         aria-label="Tuesday, 25 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -542,7 +542,7 @@
     >
       <div
         aria-label="Wednesday, 26 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -556,7 +556,7 @@
     >
       <div
         aria-label="Thursday, 27 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -570,7 +570,7 @@
     >
       <div
         aria-label="Friday, 28 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -585,7 +585,7 @@
     >
       <div
         aria-label="Saturday, 29 February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -809,7 +809,7 @@
     >
       <div
         aria-label="Wednesday, 1 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -823,7 +823,7 @@
     >
       <div
         aria-label="Thursday, 2 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -837,7 +837,7 @@
     >
       <div
         aria-label="Friday, 3 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -851,7 +851,7 @@
     >
       <div
         aria-label="Saturday, 4 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -865,7 +865,7 @@
     >
       <div
         aria-label="Sunday, 5 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -884,7 +884,7 @@
     >
       <div
         aria-label="Monday, 6 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -898,7 +898,7 @@
     >
       <div
         aria-label="Tuesday, 7 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -912,7 +912,7 @@
     >
       <div
         aria-label="Wednesday, 8 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -926,7 +926,7 @@
     >
       <div
         aria-label="Thursday, 9 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -940,7 +940,7 @@
     >
       <div
         aria-label="Friday, 10 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -954,7 +954,7 @@
     >
       <div
         aria-label="Saturday, 11 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -968,7 +968,7 @@
     >
       <div
         aria-label="Sunday, 12 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -987,7 +987,7 @@
     >
       <div
         aria-label="Monday, 13 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1001,7 +1001,7 @@
     >
       <div
         aria-label="Tuesday, 14 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1015,7 +1015,7 @@
     >
       <div
         aria-label="Wednesday, 15 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1029,7 +1029,7 @@
     >
       <div
         aria-label="Thursday, 16 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1043,7 +1043,7 @@
     >
       <div
         aria-label="Friday, 17 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1057,7 +1057,7 @@
     >
       <div
         aria-label="Saturday, 18 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1071,7 +1071,7 @@
     >
       <div
         aria-label="Sunday, 19 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1090,7 +1090,7 @@
     >
       <div
         aria-label="Monday, 20 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1104,7 +1104,7 @@
     >
       <div
         aria-label="Tuesday, 21 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1118,7 +1118,7 @@
     >
       <div
         aria-label="Wednesday, 22 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1132,7 +1132,7 @@
     >
       <div
         aria-label="Thursday, 23 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1146,7 +1146,7 @@
     >
       <div
         aria-label="Friday, 24 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1160,7 +1160,7 @@
     >
       <div
         aria-label="Saturday, 25 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1174,7 +1174,7 @@
     >
       <div
         aria-label="Sunday, 26 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1193,7 +1193,7 @@
     >
       <div
         aria-label="Monday, 27 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1207,7 +1207,7 @@
     >
       <div
         aria-label="Tuesday, 28 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1221,7 +1221,7 @@
     >
       <div
         aria-label="Wednesday, 29 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1235,7 +1235,7 @@
     >
       <div
         aria-label="Thursday, 30 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1250,7 +1250,7 @@
     >
       <div
         aria-label="Friday, 31 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1509,7 +1509,7 @@
     >
       <div
         aria-label="Sunday, 1 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -1528,7 +1528,7 @@
     >
       <div
         aria-label="Monday, 2 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1542,7 +1542,7 @@
     >
       <div
         aria-label="Tuesday, 3 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1556,7 +1556,7 @@
     >
       <div
         aria-label="Wednesday, 4 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1570,7 +1570,7 @@
     >
       <div
         aria-label="Thursday, 5 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1584,7 +1584,7 @@
     >
       <div
         aria-label="Friday, 6 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1598,7 +1598,7 @@
     >
       <div
         aria-label="Saturday, 7 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1612,7 +1612,7 @@
     >
       <div
         aria-label="Sunday, 8 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1631,7 +1631,7 @@
     >
       <div
         aria-label="Monday, 9 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1645,7 +1645,7 @@
     >
       <div
         aria-label="Tuesday, 10 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1659,7 +1659,7 @@
     >
       <div
         aria-label="Wednesday, 11 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1673,7 +1673,7 @@
     >
       <div
         aria-label="Thursday, 12 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1687,7 +1687,7 @@
     >
       <div
         aria-label="Friday, 13 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1701,7 +1701,7 @@
     >
       <div
         aria-label="Saturday, 14 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1715,7 +1715,7 @@
     >
       <div
         aria-label="Sunday, 15 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1734,7 +1734,7 @@
     >
       <div
         aria-label="Monday, 16 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1748,7 +1748,7 @@
     >
       <div
         aria-label="Tuesday, 17 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1762,7 +1762,7 @@
     >
       <div
         aria-label="Wednesday, 18 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1776,7 +1776,7 @@
     >
       <div
         aria-label="Thursday, 19 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1790,7 +1790,7 @@
     >
       <div
         aria-label="Friday, 20 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1804,7 +1804,7 @@
     >
       <div
         aria-label="Saturday, 21 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1818,7 +1818,7 @@
     >
       <div
         aria-label="Sunday, 22 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1837,7 +1837,7 @@
     >
       <div
         aria-label="Monday, 23 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1851,7 +1851,7 @@
     >
       <div
         aria-label="Tuesday, 24 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1865,7 +1865,7 @@
     >
       <div
         aria-label="Wednesday, 25 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1879,7 +1879,7 @@
     >
       <div
         aria-label="Thursday, 26 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1893,7 +1893,7 @@
     >
       <div
         aria-label="Friday, 27 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1907,7 +1907,7 @@
     >
       <div
         aria-label="Saturday, 28 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1921,7 +1921,7 @@
     >
       <div
         aria-label="Sunday, 29 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1940,7 +1940,7 @@
     >
       <div
         aria-label="Monday, 30 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1955,7 +1955,7 @@
     >
       <div
         aria-label="Tuesday, 31 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2169,7 +2169,7 @@
     >
       <div
         aria-label="Friday, 1 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -2183,7 +2183,7 @@
     >
       <div
         aria-label="Saturday, 2 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2197,7 +2197,7 @@
     >
       <div
         aria-label="Sunday, 3 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2216,7 +2216,7 @@
     >
       <div
         aria-label="Monday, 4 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2230,7 +2230,7 @@
     >
       <div
         aria-label="Tuesday, 5 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2244,7 +2244,7 @@
     >
       <div
         aria-label="Wednesday, 6 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2258,7 +2258,7 @@
     >
       <div
         aria-label="Thursday, 7 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2272,7 +2272,7 @@
     >
       <div
         aria-label="Friday, 8 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2286,7 +2286,7 @@
     >
       <div
         aria-label="Saturday, 9 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2300,7 +2300,7 @@
     >
       <div
         aria-label="Sunday, 10 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2319,7 +2319,7 @@
     >
       <div
         aria-label="Monday, 11 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2333,7 +2333,7 @@
     >
       <div
         aria-label="Tuesday, 12 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2347,7 +2347,7 @@
     >
       <div
         aria-label="Wednesday, 13 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2361,7 +2361,7 @@
     >
       <div
         aria-label="Thursday, 14 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2375,7 +2375,7 @@
     >
       <div
         aria-label="Friday, 15 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2389,7 +2389,7 @@
     >
       <div
         aria-label="Saturday, 16 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2403,7 +2403,7 @@
     >
       <div
         aria-label="Sunday, 17 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2422,7 +2422,7 @@
     >
       <div
         aria-label="Monday, 18 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2436,7 +2436,7 @@
     >
       <div
         aria-label="Tuesday, 19 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2450,7 +2450,7 @@
     >
       <div
         aria-label="Wednesday, 20 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2464,7 +2464,7 @@
     >
       <div
         aria-label="Thursday, 21 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2478,7 +2478,7 @@
     >
       <div
         aria-label="Friday, 22 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2492,7 +2492,7 @@
     >
       <div
         aria-label="Saturday, 23 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2506,7 +2506,7 @@
     >
       <div
         aria-label="Sunday, 24 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2525,7 +2525,7 @@
     >
       <div
         aria-label="Monday, 25 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2539,7 +2539,7 @@
     >
       <div
         aria-label="Tuesday, 26 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2553,7 +2553,7 @@
     >
       <div
         aria-label="Wednesday, 27 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2567,7 +2567,7 @@
     >
       <div
         aria-label="Thursday, 28 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2581,7 +2581,7 @@
     >
       <div
         aria-label="Friday, 29 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2596,7 +2596,7 @@
     >
       <div
         aria-label="Saturday, 30 November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2848,7 +2848,7 @@
     >
       <div
         aria-label="Sunday, 1 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -2867,7 +2867,7 @@
     >
       <div
         aria-label="Monday, 2 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2881,7 +2881,7 @@
     >
       <div
         aria-label="Tuesday, 3 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2895,7 +2895,7 @@
     >
       <div
         aria-label="Wednesday, 4 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2909,7 +2909,7 @@
     >
       <div
         aria-label="Thursday, 5 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2923,7 +2923,7 @@
     >
       <div
         aria-label="Friday, 6 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2937,7 +2937,7 @@
     >
       <div
         aria-label="Saturday, 7 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2951,7 +2951,7 @@
     >
       <div
         aria-label="Sunday, 8 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2970,7 +2970,7 @@
     >
       <div
         aria-label="Monday, 9 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2984,7 +2984,7 @@
     >
       <div
         aria-label="Tuesday, 10 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2998,7 +2998,7 @@
     >
       <div
         aria-label="Wednesday, 11 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3012,7 +3012,7 @@
     >
       <div
         aria-label="Thursday, 12 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3026,7 +3026,7 @@
     >
       <div
         aria-label="Friday, 13 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3040,7 +3040,7 @@
     >
       <div
         aria-label="Saturday, 14 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3054,7 +3054,7 @@
     >
       <div
         aria-label="Sunday, 15 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3073,7 +3073,7 @@
     >
       <div
         aria-label="Monday, 16 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3087,7 +3087,7 @@
     >
       <div
         aria-label="Tuesday, 17 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3101,7 +3101,7 @@
     >
       <div
         aria-label="Wednesday, 18 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3115,7 +3115,7 @@
     >
       <div
         aria-label="Thursday, 19 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3129,7 +3129,7 @@
     >
       <div
         aria-label="Friday, 20 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3143,7 +3143,7 @@
     >
       <div
         aria-label="Saturday, 21 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3157,7 +3157,7 @@
     >
       <div
         aria-label="Sunday, 22 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3176,7 +3176,7 @@
     >
       <div
         aria-label="Monday, 23 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3190,7 +3190,7 @@
     >
       <div
         aria-label="Tuesday, 24 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3204,7 +3204,7 @@
     >
       <div
         aria-label="Wednesday, 25 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3218,7 +3218,7 @@
     >
       <div
         aria-label="Thursday, 26 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3232,7 +3232,7 @@
     >
       <div
         aria-label="Friday, 27 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3246,7 +3246,7 @@
     >
       <div
         aria-label="Saturday, 28 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3260,7 +3260,7 @@
     >
       <div
         aria-label="Sunday, 29 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3279,7 +3279,7 @@
     >
       <div
         aria-label="Monday, 30 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3294,7 +3294,7 @@
     >
       <div
         aria-label="Tuesday, 31 December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3492,7 +3492,7 @@
     >
       <div
         aria-label="Wednesday, 1 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -3506,7 +3506,7 @@
     >
       <div
         aria-label="Thursday, 2 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3520,7 +3520,7 @@
     >
       <div
         aria-label="Friday, 3 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3534,7 +3534,7 @@
     >
       <div
         aria-label="Saturday, 4 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3548,7 +3548,7 @@
     >
       <div
         aria-label="Sunday, 5 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3567,7 +3567,7 @@
     >
       <div
         aria-label="Monday, 6 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3581,7 +3581,7 @@
     >
       <div
         aria-label="Tuesday, 7 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3595,7 +3595,7 @@
     >
       <div
         aria-label="Wednesday, 8 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3609,7 +3609,7 @@
     >
       <div
         aria-label="Thursday, 9 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3623,7 +3623,7 @@
     >
       <div
         aria-label="Friday, 10 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3637,7 +3637,7 @@
     >
       <div
         aria-label="Saturday, 11 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3651,7 +3651,7 @@
     >
       <div
         aria-label="Sunday, 12 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3670,7 +3670,7 @@
     >
       <div
         aria-label="Monday, 13 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3684,7 +3684,7 @@
     >
       <div
         aria-label="Tuesday, 14 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3698,7 +3698,7 @@
     >
       <div
         aria-label="Wednesday, 15 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3712,7 +3712,7 @@
     >
       <div
         aria-label="Thursday, 16 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3726,7 +3726,7 @@
     >
       <div
         aria-label="Friday, 17 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3740,7 +3740,7 @@
     >
       <div
         aria-label="Saturday, 18 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3754,7 +3754,7 @@
     >
       <div
         aria-label="Sunday, 19 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3773,7 +3773,7 @@
     >
       <div
         aria-label="Monday, 20 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3787,7 +3787,7 @@
     >
       <div
         aria-label="Tuesday, 21 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3801,7 +3801,7 @@
     >
       <div
         aria-label="Wednesday, 22 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3815,7 +3815,7 @@
     >
       <div
         aria-label="Thursday, 23 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3829,7 +3829,7 @@
     >
       <div
         aria-label="Friday, 24 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3843,7 +3843,7 @@
     >
       <div
         aria-label="Saturday, 25 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3857,7 +3857,7 @@
     >
       <div
         aria-label="Sunday, 26 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3876,7 +3876,7 @@
     >
       <div
         aria-label="Monday, 27 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3890,7 +3890,7 @@
     >
       <div
         aria-label="Tuesday, 28 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3904,7 +3904,7 @@
     >
       <div
         aria-label="Wednesday, 29 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3918,7 +3918,7 @@
     >
       <div
         aria-label="Thursday, 30 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3933,7 +3933,7 @@
     >
       <div
         aria-label="Friday, 31 January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4175,7 +4175,7 @@
     >
       <div
         aria-label="Thursday, 1 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -4189,7 +4189,7 @@
     >
       <div
         aria-label="Friday, 2 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4203,7 +4203,7 @@
     >
       <div
         aria-label="Saturday, 3 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4217,7 +4217,7 @@
     >
       <div
         aria-label="Sunday, 4 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4236,7 +4236,7 @@
     >
       <div
         aria-label="Monday, 5 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4250,7 +4250,7 @@
     >
       <div
         aria-label="Tuesday, 6 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4264,7 +4264,7 @@
     >
       <div
         aria-label="Wednesday, 7 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4278,7 +4278,7 @@
     >
       <div
         aria-label="Thursday, 8 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4292,7 +4292,7 @@
     >
       <div
         aria-label="Friday, 9 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4306,7 +4306,7 @@
     >
       <div
         aria-label="Saturday, 10 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4320,7 +4320,7 @@
     >
       <div
         aria-label="Sunday, 11 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4339,7 +4339,7 @@
     >
       <div
         aria-label="Monday, 12 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4353,7 +4353,7 @@
     >
       <div
         aria-label="Tuesday, 13 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4367,7 +4367,7 @@
     >
       <div
         aria-label="Wednesday, 14 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4381,7 +4381,7 @@
     >
       <div
         aria-label="Thursday, 15 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4395,7 +4395,7 @@
     >
       <div
         aria-label="Friday, 16 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4409,7 +4409,7 @@
     >
       <div
         aria-label="Saturday, 17 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4423,7 +4423,7 @@
     >
       <div
         aria-label="Sunday, 18 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4442,7 +4442,7 @@
     >
       <div
         aria-label="Monday, 19 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4456,7 +4456,7 @@
     >
       <div
         aria-label="Tuesday, 20 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4470,7 +4470,7 @@
     >
       <div
         aria-label="Wednesday, 21 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4484,7 +4484,7 @@
     >
       <div
         aria-label="Thursday, 22 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4498,7 +4498,7 @@
     >
       <div
         aria-label="Friday, 23 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4512,7 +4512,7 @@
     >
       <div
         aria-label="Saturday, 24 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4526,7 +4526,7 @@
     >
       <div
         aria-label="Sunday, 25 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4545,7 +4545,7 @@
     >
       <div
         aria-label="Monday, 26 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4559,7 +4559,7 @@
     >
       <div
         aria-label="Tuesday, 27 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4574,7 +4574,7 @@
     >
       <div
         aria-label="Wednesday, 28 February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4805,7 +4805,7 @@
     >
       <div
         aria-label="Monday, 1 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -4819,7 +4819,7 @@
     >
       <div
         aria-label="Tuesday, 2 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4833,7 +4833,7 @@
     >
       <div
         aria-label="Wednesday, 3 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4847,7 +4847,7 @@
     >
       <div
         aria-label="Thursday, 4 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4861,7 +4861,7 @@
     >
       <div
         aria-label="Friday, 5 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4875,7 +4875,7 @@
     >
       <div
         aria-label="Saturday, 6 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4889,7 +4889,7 @@
     >
       <div
         aria-label="Sunday, 7 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4908,7 +4908,7 @@
     >
       <div
         aria-label="Monday, 8 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4922,7 +4922,7 @@
     >
       <div
         aria-label="Tuesday, 9 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4936,7 +4936,7 @@
     >
       <div
         aria-label="Wednesday, 10 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4950,7 +4950,7 @@
     >
       <div
         aria-label="Thursday, 11 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4964,7 +4964,7 @@
     >
       <div
         aria-label="Friday, 12 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4978,7 +4978,7 @@
     >
       <div
         aria-label="Saturday, 13 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4992,7 +4992,7 @@
     >
       <div
         aria-label="Sunday, 14 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5011,7 +5011,7 @@
     >
       <div
         aria-label="Monday, 15 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5025,7 +5025,7 @@
     >
       <div
         aria-label="Tuesday, 16 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5039,7 +5039,7 @@
     >
       <div
         aria-label="Wednesday, 17 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5053,7 +5053,7 @@
     >
       <div
         aria-label="Thursday, 18 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5067,7 +5067,7 @@
     >
       <div
         aria-label="Friday, 19 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5081,7 +5081,7 @@
     >
       <div
         aria-label="Saturday, 20 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5095,7 +5095,7 @@
     >
       <div
         aria-label="Sunday, 21 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5114,7 +5114,7 @@
     >
       <div
         aria-label="Monday, 22 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5128,7 +5128,7 @@
     >
       <div
         aria-label="Tuesday, 23 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5142,7 +5142,7 @@
     >
       <div
         aria-label="Wednesday, 24 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5156,7 +5156,7 @@
     >
       <div
         aria-label="Thursday, 25 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5170,7 +5170,7 @@
     >
       <div
         aria-label="Friday, 26 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5184,7 +5184,7 @@
     >
       <div
         aria-label="Saturday, 27 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5198,7 +5198,7 @@
     >
       <div
         aria-label="Sunday, 28 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5217,7 +5217,7 @@
     >
       <div
         aria-label="Monday, 29 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5231,7 +5231,7 @@
     >
       <div
         aria-label="Tuesday, 30 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5246,7 +5246,7 @@
     >
       <div
         aria-label="Wednesday, 31 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5505,7 +5505,7 @@
     >
       <div
         aria-label="Friday, 1 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -5519,7 +5519,7 @@
     >
       <div
         aria-label="Saturday, 2 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5533,7 +5533,7 @@
     >
       <div
         aria-label="Sunday, 3 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5552,7 +5552,7 @@
     >
       <div
         aria-label="Monday, 4 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5566,7 +5566,7 @@
     >
       <div
         aria-label="Tuesday, 5 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5580,7 +5580,7 @@
     >
       <div
         aria-label="Wednesday, 6 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5594,7 +5594,7 @@
     >
       <div
         aria-label="Thursday, 7 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5608,7 +5608,7 @@
     >
       <div
         aria-label="Friday, 8 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5622,7 +5622,7 @@
     >
       <div
         aria-label="Saturday, 9 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5636,7 +5636,7 @@
     >
       <div
         aria-label="Sunday, 10 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5655,7 +5655,7 @@
     >
       <div
         aria-label="Monday, 11 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5669,7 +5669,7 @@
     >
       <div
         aria-label="Tuesday, 12 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5683,7 +5683,7 @@
     >
       <div
         aria-label="Wednesday, 13 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5697,7 +5697,7 @@
     >
       <div
         aria-label="Thursday, 14 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5711,7 +5711,7 @@
     >
       <div
         aria-label="Friday, 15 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5725,7 +5725,7 @@
     >
       <div
         aria-label="Saturday, 16 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5739,7 +5739,7 @@
     >
       <div
         aria-label="Sunday, 17 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5758,7 +5758,7 @@
     >
       <div
         aria-label="Monday, 18 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5772,7 +5772,7 @@
     >
       <div
         aria-label="Tuesday, 19 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5786,7 +5786,7 @@
     >
       <div
         aria-label="Wednesday, 20 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5800,7 +5800,7 @@
     >
       <div
         aria-label="Thursday, 21 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5814,7 +5814,7 @@
     >
       <div
         aria-label="Friday, 22 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5828,7 +5828,7 @@
     >
       <div
         aria-label="Saturday, 23 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5842,7 +5842,7 @@
     >
       <div
         aria-label="Sunday, 24 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5861,7 +5861,7 @@
     >
       <div
         aria-label="Monday, 25 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5875,7 +5875,7 @@
     >
       <div
         aria-label="Tuesday, 26 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5889,7 +5889,7 @@
     >
       <div
         aria-label="Wednesday, 27 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5903,7 +5903,7 @@
     >
       <div
         aria-label="Thursday, 28 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5917,7 +5917,7 @@
     >
       <div
         aria-label="Friday, 29 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5931,7 +5931,7 @@
     >
       <div
         aria-label="Saturday, 30 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5946,7 +5946,7 @@
     >
       <div
         aria-label="Sunday, 31 December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6151,7 +6151,7 @@
     >
       <div
         aria-label="Monday, 1 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -6165,7 +6165,7 @@
     >
       <div
         aria-label="Tuesday, 2 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6179,7 +6179,7 @@
     >
       <div
         aria-label="Wednesday, 3 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6193,7 +6193,7 @@
     >
       <div
         aria-label="Thursday, 4 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6207,7 +6207,7 @@
     >
       <div
         aria-label="Friday, 5 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6221,7 +6221,7 @@
     >
       <div
         aria-label="Saturday, 6 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6235,7 +6235,7 @@
     >
       <div
         aria-label="Sunday, 7 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6254,7 +6254,7 @@
     >
       <div
         aria-label="Monday, 8 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6268,7 +6268,7 @@
     >
       <div
         aria-label="Tuesday, 9 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6282,7 +6282,7 @@
     >
       <div
         aria-label="Wednesday, 10 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6296,7 +6296,7 @@
     >
       <div
         aria-label="Thursday, 11 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6310,7 +6310,7 @@
     >
       <div
         aria-label="Friday, 12 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6324,7 +6324,7 @@
     >
       <div
         aria-label="Saturday, 13 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6338,7 +6338,7 @@
     >
       <div
         aria-label="Sunday, 14 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6357,7 +6357,7 @@
     >
       <div
         aria-label="Monday, 15 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6371,7 +6371,7 @@
     >
       <div
         aria-label="Tuesday, 16 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6385,7 +6385,7 @@
     >
       <div
         aria-label="Wednesday, 17 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6399,7 +6399,7 @@
     >
       <div
         aria-label="Thursday, 18 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6413,7 +6413,7 @@
     >
       <div
         aria-label="Friday, 19 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6427,7 +6427,7 @@
     >
       <div
         aria-label="Saturday, 20 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6441,7 +6441,7 @@
     >
       <div
         aria-label="Sunday, 21 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6460,7 +6460,7 @@
     >
       <div
         aria-label="Monday, 22 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6474,7 +6474,7 @@
     >
       <div
         aria-label="Tuesday, 23 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6488,7 +6488,7 @@
     >
       <div
         aria-label="Wednesday, 24 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6502,7 +6502,7 @@
     >
       <div
         aria-label="Thursday, 25 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6516,7 +6516,7 @@
     >
       <div
         aria-label="Friday, 26 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6530,7 +6530,7 @@
     >
       <div
         aria-label="Saturday, 27 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6544,7 +6544,7 @@
     >
       <div
         aria-label="Sunday, 28 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6563,7 +6563,7 @@
     >
       <div
         aria-label="Monday, 29 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6578,7 +6578,7 @@
     >
       <div
         aria-label="Tuesday, 30 November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6830,7 +6830,7 @@
     >
       <div
         aria-label="Wednesday, 1 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -6844,7 +6844,7 @@
     >
       <div
         aria-label="Thursday, 2 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6858,7 +6858,7 @@
     >
       <div
         aria-label="Friday, 3 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6872,7 +6872,7 @@
     >
       <div
         aria-label="Saturday, 4 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6886,7 +6886,7 @@
     >
       <div
         aria-label="Sunday, 5 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6905,7 +6905,7 @@
     >
       <div
         aria-label="Monday, 6 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6919,7 +6919,7 @@
     >
       <div
         aria-label="Tuesday, 7 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6933,7 +6933,7 @@
     >
       <div
         aria-label="Wednesday, 8 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6947,7 +6947,7 @@
     >
       <div
         aria-label="Thursday, 9 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6961,7 +6961,7 @@
     >
       <div
         aria-label="Friday, 10 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6975,7 +6975,7 @@
     >
       <div
         aria-label="Saturday, 11 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6989,7 +6989,7 @@
     >
       <div
         aria-label="Sunday, 12 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7008,7 +7008,7 @@
     >
       <div
         aria-label="Monday, 13 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7022,7 +7022,7 @@
     >
       <div
         aria-label="Tuesday, 14 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7036,7 +7036,7 @@
     >
       <div
         aria-label="Wednesday, 15 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7050,7 +7050,7 @@
     >
       <div
         aria-label="Thursday, 16 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7064,7 +7064,7 @@
     >
       <div
         aria-label="Friday, 17 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7078,7 +7078,7 @@
     >
       <div
         aria-label="Saturday, 18 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7092,7 +7092,7 @@
     >
       <div
         aria-label="Sunday, 19 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7111,7 +7111,7 @@
     >
       <div
         aria-label="Monday, 20 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7125,7 +7125,7 @@
     >
       <div
         aria-label="Tuesday, 21 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7139,7 +7139,7 @@
     >
       <div
         aria-label="Wednesday, 22 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7153,7 +7153,7 @@
     >
       <div
         aria-label="Thursday, 23 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7167,7 +7167,7 @@
     >
       <div
         aria-label="Friday, 24 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7181,7 +7181,7 @@
     >
       <div
         aria-label="Saturday, 25 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7195,7 +7195,7 @@
     >
       <div
         aria-label="Sunday, 26 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7214,7 +7214,7 @@
     >
       <div
         aria-label="Monday, 27 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7228,7 +7228,7 @@
     >
       <div
         aria-label="Tuesday, 28 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7242,7 +7242,7 @@
     >
       <div
         aria-label="Wednesday, 29 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7256,7 +7256,7 @@
     >
       <div
         aria-label="Thursday, 30 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7271,7 +7271,7 @@
     >
       <div
         aria-label="Friday, 31 December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7523,7 +7523,7 @@
     >
       <div
         aria-label="Saturday, 1 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -7537,7 +7537,7 @@
     >
       <div
         aria-label="Sunday, 2 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7556,7 +7556,7 @@
     >
       <div
         aria-label="Monday, 3 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7570,7 +7570,7 @@
     >
       <div
         aria-label="Tuesday, 4 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7584,7 +7584,7 @@
     >
       <div
         aria-label="Wednesday, 5 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7598,7 +7598,7 @@
     >
       <div
         aria-label="Thursday, 6 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7612,7 +7612,7 @@
     >
       <div
         aria-label="Friday, 7 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7626,7 +7626,7 @@
     >
       <div
         aria-label="Saturday, 8 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7640,7 +7640,7 @@
     >
       <div
         aria-label="Sunday, 9 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7659,7 +7659,7 @@
     >
       <div
         aria-label="Monday, 10 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7673,7 +7673,7 @@
     >
       <div
         aria-label="Tuesday, 11 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7687,7 +7687,7 @@
     >
       <div
         aria-label="Wednesday, 12 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7701,7 +7701,7 @@
     >
       <div
         aria-label="Thursday, 13 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7715,7 +7715,7 @@
     >
       <div
         aria-label="Friday, 14 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7729,7 +7729,7 @@
     >
       <div
         aria-label="Saturday, 15 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7743,7 +7743,7 @@
     >
       <div
         aria-label="Sunday, 16 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7762,7 +7762,7 @@
     >
       <div
         aria-label="Monday, 17 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7776,7 +7776,7 @@
     >
       <div
         aria-label="Tuesday, 18 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7790,7 +7790,7 @@
     >
       <div
         aria-label="Wednesday, 19 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7804,7 +7804,7 @@
     >
       <div
         aria-label="Thursday, 20 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7818,7 +7818,7 @@
     >
       <div
         aria-label="Friday, 21 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7832,7 +7832,7 @@
     >
       <div
         aria-label="Saturday, 22 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7846,7 +7846,7 @@
     >
       <div
         aria-label="Sunday, 23 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7865,7 +7865,7 @@
     >
       <div
         aria-label="Monday, 24 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7879,7 +7879,7 @@
     >
       <div
         aria-label="Tuesday, 25 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7893,7 +7893,7 @@
     >
       <div
         aria-label="Wednesday, 26 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7907,7 +7907,7 @@
     >
       <div
         aria-label="Thursday, 27 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7921,7 +7921,7 @@
     >
       <div
         aria-label="Friday, 28 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7935,7 +7935,7 @@
     >
       <div
         aria-label="Saturday, 29 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7949,7 +7949,7 @@
     >
       <div
         aria-label="Sunday, 30 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7969,7 +7969,7 @@
     >
       <div
         aria-label="Monday, 31 January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8090,7 +8090,7 @@
     >
       <div
         aria-label="November 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -8105,7 +8105,7 @@
     >
       <div
         aria-label="December 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8119,7 +8119,7 @@
     >
       <div
         aria-label="January 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8133,7 +8133,7 @@
     >
       <div
         aria-label="February 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8152,7 +8152,7 @@
     >
       <div
         aria-label="March 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8166,7 +8166,7 @@
     >
       <div
         aria-label="April 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8180,7 +8180,7 @@
     >
       <div
         aria-label="May 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8194,7 +8194,7 @@
     >
       <div
         aria-label="June 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8213,7 +8213,7 @@
     >
       <div
         aria-label="July 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8227,7 +8227,7 @@
     >
       <div
         aria-label="August 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8241,7 +8241,7 @@
     >
       <div
         aria-label="September 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8255,7 +8255,7 @@
     >
       <div
         aria-label="October 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8274,7 +8274,7 @@
     >
       <div
         aria-label="November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8288,7 +8288,7 @@
     >
       <div
         aria-label="December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8303,7 +8303,7 @@
     >
       <div
         aria-label="January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8319,7 +8319,7 @@
     >
       <div
         aria-label="February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8394,7 +8394,7 @@
     >
       <div
         aria-label="November 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -8409,7 +8409,7 @@
     >
       <div
         aria-label="December 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8423,7 +8423,7 @@
     >
       <div
         aria-label="January 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8437,7 +8437,7 @@
     >
       <div
         aria-label="February 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8456,7 +8456,7 @@
     >
       <div
         aria-label="March 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8470,7 +8470,7 @@
     >
       <div
         aria-label="April 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8484,7 +8484,7 @@
     >
       <div
         aria-label="May 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8498,7 +8498,7 @@
     >
       <div
         aria-label="June 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8517,7 +8517,7 @@
     >
       <div
         aria-label="July 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8531,7 +8531,7 @@
     >
       <div
         aria-label="August 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8545,7 +8545,7 @@
     >
       <div
         aria-label="September 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8559,7 +8559,7 @@
     >
       <div
         aria-label="October 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8578,7 +8578,7 @@
     >
       <div
         aria-label="November 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8592,7 +8592,7 @@
     >
       <div
         aria-label="December 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8607,7 +8607,7 @@
     >
       <div
         aria-label="January 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8623,7 +8623,7 @@
     >
       <div
         aria-label="February 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8698,7 +8698,7 @@
     >
       <div
         aria-label="November 2016"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -8713,7 +8713,7 @@
     >
       <div
         aria-label="December 2016"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8727,7 +8727,7 @@
     >
       <div
         aria-label="January 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8741,7 +8741,7 @@
     >
       <div
         aria-label="February 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8760,7 +8760,7 @@
     >
       <div
         aria-label="March 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8774,7 +8774,7 @@
     >
       <div
         aria-label="April 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8788,7 +8788,7 @@
     >
       <div
         aria-label="May 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8802,7 +8802,7 @@
     >
       <div
         aria-label="June 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8821,7 +8821,7 @@
     >
       <div
         aria-label="July 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8835,7 +8835,7 @@
     >
       <div
         aria-label="August 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8849,7 +8849,7 @@
     >
       <div
         aria-label="September 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8863,7 +8863,7 @@
     >
       <div
         aria-label="October 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8882,7 +8882,7 @@
     >
       <div
         aria-label="November 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8896,7 +8896,7 @@
     >
       <div
         aria-label="December 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8911,7 +8911,7 @@
     >
       <div
         aria-label="January 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -8927,7 +8927,7 @@
     >
       <div
         aria-label="February 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9004,7 +9004,7 @@
     >
       <div
         aria-label="November 2016"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -9019,7 +9019,7 @@
     >
       <div
         aria-label="December 2016"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9033,7 +9033,7 @@
     >
       <div
         aria-label="January 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9047,7 +9047,7 @@
     >
       <div
         aria-label="February 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9066,7 +9066,7 @@
     >
       <div
         aria-label="March 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9080,7 +9080,7 @@
     >
       <div
         aria-label="April 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9094,7 +9094,7 @@
     >
       <div
         aria-label="May 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9108,7 +9108,7 @@
     >
       <div
         aria-label="June 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9127,7 +9127,7 @@
     >
       <div
         aria-label="July 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9141,7 +9141,7 @@
     >
       <div
         aria-label="August 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9155,7 +9155,7 @@
     >
       <div
         aria-label="September 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9169,7 +9169,7 @@
     >
       <div
         aria-label="October 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9188,7 +9188,7 @@
     >
       <div
         aria-label="November 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9202,7 +9202,7 @@
     >
       <div
         aria-label="December 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9217,7 +9217,7 @@
     >
       <div
         aria-label="January 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9233,7 +9233,7 @@
     >
       <div
         aria-label="February 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9308,7 +9308,7 @@
     >
       <div
         aria-label="November 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -9323,7 +9323,7 @@
     >
       <div
         aria-label="December 2017"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9337,7 +9337,7 @@
     >
       <div
         aria-label="January 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9351,7 +9351,7 @@
     >
       <div
         aria-label="February 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9370,7 +9370,7 @@
     >
       <div
         aria-label="March 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9384,7 +9384,7 @@
     >
       <div
         aria-label="April 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9398,7 +9398,7 @@
     >
       <div
         aria-label="May 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9412,7 +9412,7 @@
     >
       <div
         aria-label="June 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9431,7 +9431,7 @@
     >
       <div
         aria-label="July 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9445,7 +9445,7 @@
     >
       <div
         aria-label="August 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9459,7 +9459,7 @@
     >
       <div
         aria-label="September 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9473,7 +9473,7 @@
     >
       <div
         aria-label="October 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9492,7 +9492,7 @@
     >
       <div
         aria-label="November 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9506,7 +9506,7 @@
     >
       <div
         aria-label="December 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9521,7 +9521,7 @@
     >
       <div
         aria-label="January 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9537,7 +9537,7 @@
     >
       <div
         aria-label="February 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9612,7 +9612,7 @@
     >
       <div
         aria-label="November 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -9627,7 +9627,7 @@
     >
       <div
         aria-label="December 2018"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9641,7 +9641,7 @@
     >
       <div
         aria-label="January 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9655,7 +9655,7 @@
     >
       <div
         aria-label="February 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9674,7 +9674,7 @@
     >
       <div
         aria-label="March 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9688,7 +9688,7 @@
     >
       <div
         aria-label="April 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9702,7 +9702,7 @@
     >
       <div
         aria-label="May 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9716,7 +9716,7 @@
     >
       <div
         aria-label="June 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9735,7 +9735,7 @@
     >
       <div
         aria-label="July 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9749,7 +9749,7 @@
     >
       <div
         aria-label="August 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9763,7 +9763,7 @@
     >
       <div
         aria-label="September 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9777,7 +9777,7 @@
     >
       <div
         aria-label="October 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9796,7 +9796,7 @@
     >
       <div
         aria-label="November 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9810,7 +9810,7 @@
     >
       <div
         aria-label="December 2019"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9825,7 +9825,7 @@
     >
       <div
         aria-label="January 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9841,7 +9841,7 @@
     >
       <div
         aria-label="February 2020"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9920,7 +9920,7 @@
     >
       <div
         aria-label="November 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -9935,7 +9935,7 @@
     >
       <div
         aria-label="December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9949,7 +9949,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9963,7 +9963,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9982,7 +9982,7 @@
     >
       <div
         aria-label="March 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -9996,7 +9996,7 @@
     >
       <div
         aria-label="April 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10010,7 +10010,7 @@
     >
       <div
         aria-label="May 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10024,7 +10024,7 @@
     >
       <div
         aria-label="June 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10043,7 +10043,7 @@
     >
       <div
         aria-label="July 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10057,7 +10057,7 @@
     >
       <div
         aria-label="August 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10071,7 +10071,7 @@
     >
       <div
         aria-label="September 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10085,7 +10085,7 @@
     >
       <div
         aria-label="October 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10104,7 +10104,7 @@
     >
       <div
         aria-label="November 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10118,7 +10118,7 @@
     >
       <div
         aria-label="December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10133,7 +10133,7 @@
     >
       <div
         aria-label="January 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10149,7 +10149,7 @@
     >
       <div
         aria-label="February 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10224,7 +10224,7 @@
     >
       <div
         aria-label="November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -10239,7 +10239,7 @@
     >
       <div
         aria-label="December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10253,7 +10253,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10267,7 +10267,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10286,7 +10286,7 @@
     >
       <div
         aria-label="March 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10300,7 +10300,7 @@
     >
       <div
         aria-label="April 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10314,7 +10314,7 @@
     >
       <div
         aria-label="May 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10328,7 +10328,7 @@
     >
       <div
         aria-label="June 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10347,7 +10347,7 @@
     >
       <div
         aria-label="July 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10361,7 +10361,7 @@
     >
       <div
         aria-label="August 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10375,7 +10375,7 @@
     >
       <div
         aria-label="September 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10389,7 +10389,7 @@
     >
       <div
         aria-label="October 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10408,7 +10408,7 @@
     >
       <div
         aria-label="November 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10422,7 +10422,7 @@
     >
       <div
         aria-label="December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10437,7 +10437,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10453,7 +10453,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10528,7 +10528,7 @@
     >
       <div
         aria-label="November 3"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -10543,7 +10543,7 @@
     >
       <div
         aria-label="December 3"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10557,7 +10557,7 @@
     >
       <div
         aria-label="January 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10571,7 +10571,7 @@
     >
       <div
         aria-label="February 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10590,7 +10590,7 @@
     >
       <div
         aria-label="March 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10604,7 +10604,7 @@
     >
       <div
         aria-label="April 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10618,7 +10618,7 @@
     >
       <div
         aria-label="May 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10632,7 +10632,7 @@
     >
       <div
         aria-label="June 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10651,7 +10651,7 @@
     >
       <div
         aria-label="July 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10665,7 +10665,7 @@
     >
       <div
         aria-label="August 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10679,7 +10679,7 @@
     >
       <div
         aria-label="September 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10693,7 +10693,7 @@
     >
       <div
         aria-label="October 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10712,7 +10712,7 @@
     >
       <div
         aria-label="November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10726,7 +10726,7 @@
     >
       <div
         aria-label="December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10741,7 +10741,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10757,7 +10757,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10834,7 +10834,7 @@
     >
       <div
         aria-label="November 3"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -10849,7 +10849,7 @@
     >
       <div
         aria-label="December 3"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10863,7 +10863,7 @@
     >
       <div
         aria-label="January 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10877,7 +10877,7 @@
     >
       <div
         aria-label="February 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10896,7 +10896,7 @@
     >
       <div
         aria-label="March 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10910,7 +10910,7 @@
     >
       <div
         aria-label="April 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10924,7 +10924,7 @@
     >
       <div
         aria-label="May 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10938,7 +10938,7 @@
     >
       <div
         aria-label="June 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10957,7 +10957,7 @@
     >
       <div
         aria-label="July 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10971,7 +10971,7 @@
     >
       <div
         aria-label="August 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10985,7 +10985,7 @@
     >
       <div
         aria-label="September 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -10999,7 +10999,7 @@
     >
       <div
         aria-label="October 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11018,7 +11018,7 @@
     >
       <div
         aria-label="November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11032,7 +11032,7 @@
     >
       <div
         aria-label="December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11047,7 +11047,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11063,7 +11063,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11138,7 +11138,7 @@
     >
       <div
         aria-label="November 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -11153,7 +11153,7 @@
     >
       <div
         aria-label="December 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11167,7 +11167,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11181,7 +11181,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11200,7 +11200,7 @@
     >
       <div
         aria-label="March 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11214,7 +11214,7 @@
     >
       <div
         aria-label="April 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11228,7 +11228,7 @@
     >
       <div
         aria-label="May 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11242,7 +11242,7 @@
     >
       <div
         aria-label="June 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11261,7 +11261,7 @@
     >
       <div
         aria-label="July 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11275,7 +11275,7 @@
     >
       <div
         aria-label="August 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11289,7 +11289,7 @@
     >
       <div
         aria-label="September 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11303,7 +11303,7 @@
     >
       <div
         aria-label="October 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11322,7 +11322,7 @@
     >
       <div
         aria-label="November 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11336,7 +11336,7 @@
     >
       <div
         aria-label="December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11351,7 +11351,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11367,7 +11367,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11442,7 +11442,7 @@
     >
       <div
         aria-label="November 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -11457,7 +11457,7 @@
     >
       <div
         aria-label="December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11471,7 +11471,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11485,7 +11485,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11504,7 +11504,7 @@
     >
       <div
         aria-label="March 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11518,7 +11518,7 @@
     >
       <div
         aria-label="April 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11532,7 +11532,7 @@
     >
       <div
         aria-label="May 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11546,7 +11546,7 @@
     >
       <div
         aria-label="June 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11565,7 +11565,7 @@
     >
       <div
         aria-label="July 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11579,7 +11579,7 @@
     >
       <div
         aria-label="August 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11593,7 +11593,7 @@
     >
       <div
         aria-label="September 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11607,7 +11607,7 @@
     >
       <div
         aria-label="October 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11626,7 +11626,7 @@
     >
       <div
         aria-label="November 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11640,7 +11640,7 @@
     >
       <div
         aria-label="December 1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11655,7 +11655,7 @@
     >
       <div
         aria-label="January 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11671,7 +11671,7 @@
     >
       <div
         aria-label="February 2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11749,7 +11749,7 @@
     >
       <div
         aria-label="1968"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -11763,7 +11763,7 @@
     >
       <div
         aria-label="1969"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11777,7 +11777,7 @@
     >
       <div
         aria-label="1970"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11791,7 +11791,7 @@
     >
       <div
         aria-label="1971"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11810,7 +11810,7 @@
     >
       <div
         aria-label="1972"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11824,7 +11824,7 @@
     >
       <div
         aria-label="1973"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11838,7 +11838,7 @@
     >
       <div
         aria-label="1974"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11852,7 +11852,7 @@
     >
       <div
         aria-label="1975"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11871,7 +11871,7 @@
     >
       <div
         aria-label="1976"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11885,7 +11885,7 @@
     >
       <div
         aria-label="1977"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11899,7 +11899,7 @@
     >
       <div
         aria-label="1978"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11913,7 +11913,7 @@
     >
       <div
         aria-label="1979"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11932,7 +11932,7 @@
     >
       <div
         aria-label="1980"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11946,7 +11946,7 @@
     >
       <div
         aria-label="1981"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11960,7 +11960,7 @@
     >
       <div
         aria-label="1982"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -11975,7 +11975,7 @@
     >
       <div
         aria-label="1983"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12049,7 +12049,7 @@
     >
       <div
         aria-label="1952"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -12063,7 +12063,7 @@
     >
       <div
         aria-label="1953"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12077,7 +12077,7 @@
     >
       <div
         aria-label="1954"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12091,7 +12091,7 @@
     >
       <div
         aria-label="1955"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12110,7 +12110,7 @@
     >
       <div
         aria-label="1956"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12124,7 +12124,7 @@
     >
       <div
         aria-label="1957"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12138,7 +12138,7 @@
     >
       <div
         aria-label="1958"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12152,7 +12152,7 @@
     >
       <div
         aria-label="1959"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12171,7 +12171,7 @@
     >
       <div
         aria-label="1960"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12185,7 +12185,7 @@
     >
       <div
         aria-label="1961"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12199,7 +12199,7 @@
     >
       <div
         aria-label="1962"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12213,7 +12213,7 @@
     >
       <div
         aria-label="1963"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12232,7 +12232,7 @@
     >
       <div
         aria-label="1964"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12246,7 +12246,7 @@
     >
       <div
         aria-label="1965"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12260,7 +12260,7 @@
     >
       <div
         aria-label="1966"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12275,7 +12275,7 @@
     >
       <div
         aria-label="1967"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12349,7 +12349,7 @@
     >
       <div
         aria-label="1936"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -12363,7 +12363,7 @@
     >
       <div
         aria-label="1937"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12377,7 +12377,7 @@
     >
       <div
         aria-label="1938"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12391,7 +12391,7 @@
     >
       <div
         aria-label="1939"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12410,7 +12410,7 @@
     >
       <div
         aria-label="1940"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12424,7 +12424,7 @@
     >
       <div
         aria-label="1941"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12438,7 +12438,7 @@
     >
       <div
         aria-label="1942"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12452,7 +12452,7 @@
     >
       <div
         aria-label="1943"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12471,7 +12471,7 @@
     >
       <div
         aria-label="1944"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12485,7 +12485,7 @@
     >
       <div
         aria-label="1945"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12499,7 +12499,7 @@
     >
       <div
         aria-label="1946"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12513,7 +12513,7 @@
     >
       <div
         aria-label="1947"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12532,7 +12532,7 @@
     >
       <div
         aria-label="1948"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12546,7 +12546,7 @@
     >
       <div
         aria-label="1949"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12560,7 +12560,7 @@
     >
       <div
         aria-label="1950"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12575,7 +12575,7 @@
     >
       <div
         aria-label="1951"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12651,7 +12651,7 @@
     >
       <div
         aria-label="1888"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -12665,7 +12665,7 @@
     >
       <div
         aria-label="1889"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12679,7 +12679,7 @@
     >
       <div
         aria-label="1890"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12693,7 +12693,7 @@
     >
       <div
         aria-label="1891"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12712,7 +12712,7 @@
     >
       <div
         aria-label="1892"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12726,7 +12726,7 @@
     >
       <div
         aria-label="1893"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12740,7 +12740,7 @@
     >
       <div
         aria-label="1894"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12754,7 +12754,7 @@
     >
       <div
         aria-label="1895"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12773,7 +12773,7 @@
     >
       <div
         aria-label="1896"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12787,7 +12787,7 @@
     >
       <div
         aria-label="1897"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12801,7 +12801,7 @@
     >
       <div
         aria-label="1898"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12815,7 +12815,7 @@
     >
       <div
         aria-label="1899"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12834,7 +12834,7 @@
     >
       <div
         aria-label="1900"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12848,7 +12848,7 @@
     >
       <div
         aria-label="1901"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12862,7 +12862,7 @@
     >
       <div
         aria-label="1902"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12877,7 +12877,7 @@
     >
       <div
         aria-label="1903"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12951,7 +12951,7 @@
     >
       <div
         aria-label="1904"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -12965,7 +12965,7 @@
     >
       <div
         aria-label="1905"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12979,7 +12979,7 @@
     >
       <div
         aria-label="1906"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -12993,7 +12993,7 @@
     >
       <div
         aria-label="1907"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13012,7 +13012,7 @@
     >
       <div
         aria-label="1908"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13026,7 +13026,7 @@
     >
       <div
         aria-label="1909"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13040,7 +13040,7 @@
     >
       <div
         aria-label="1910"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13054,7 +13054,7 @@
     >
       <div
         aria-label="1911"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13073,7 +13073,7 @@
     >
       <div
         aria-label="1912"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13087,7 +13087,7 @@
     >
       <div
         aria-label="1913"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13101,7 +13101,7 @@
     >
       <div
         aria-label="1914"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13115,7 +13115,7 @@
     >
       <div
         aria-label="1915"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13134,7 +13134,7 @@
     >
       <div
         aria-label="1916"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13148,7 +13148,7 @@
     >
       <div
         aria-label="1917"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13162,7 +13162,7 @@
     >
       <div
         aria-label="1918"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13177,7 +13177,7 @@
     >
       <div
         aria-label="1919"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13251,7 +13251,7 @@
     >
       <div
         aria-label="1920"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -13265,7 +13265,7 @@
     >
       <div
         aria-label="1921"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13279,7 +13279,7 @@
     >
       <div
         aria-label="1922"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13293,7 +13293,7 @@
     >
       <div
         aria-label="1923"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13312,7 +13312,7 @@
     >
       <div
         aria-label="1924"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13326,7 +13326,7 @@
     >
       <div
         aria-label="1925"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13340,7 +13340,7 @@
     >
       <div
         aria-label="1926"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13354,7 +13354,7 @@
     >
       <div
         aria-label="1927"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13373,7 +13373,7 @@
     >
       <div
         aria-label="1928"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13387,7 +13387,7 @@
     >
       <div
         aria-label="1929"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13401,7 +13401,7 @@
     >
       <div
         aria-label="1930"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13415,7 +13415,7 @@
     >
       <div
         aria-label="1931"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13434,7 +13434,7 @@
     >
       <div
         aria-label="1932"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13448,7 +13448,7 @@
     >
       <div
         aria-label="1933"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13462,7 +13462,7 @@
     >
       <div
         aria-label="1934"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13477,7 +13477,7 @@
     >
       <div
         aria-label="1935"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13555,7 +13555,7 @@
     >
       <div
         aria-label="16"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -13569,7 +13569,7 @@
     >
       <div
         aria-label="17"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13583,7 +13583,7 @@
     >
       <div
         aria-label="18"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13597,7 +13597,7 @@
     >
       <div
         aria-label="19"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13616,7 +13616,7 @@
     >
       <div
         aria-label="20"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13630,7 +13630,7 @@
     >
       <div
         aria-label="21"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13644,7 +13644,7 @@
     >
       <div
         aria-label="22"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13658,7 +13658,7 @@
     >
       <div
         aria-label="23"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13677,7 +13677,7 @@
     >
       <div
         aria-label="24"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13691,7 +13691,7 @@
     >
       <div
         aria-label="25"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13705,7 +13705,7 @@
     >
       <div
         aria-label="26"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13719,7 +13719,7 @@
     >
       <div
         aria-label="27"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13738,7 +13738,7 @@
     >
       <div
         aria-label="28"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13752,7 +13752,7 @@
     >
       <div
         aria-label="29"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13766,7 +13766,7 @@
     >
       <div
         aria-label="30"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13781,7 +13781,7 @@
     >
       <div
         aria-label="31"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13855,7 +13855,7 @@
     >
       <div
         aria-label="1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -13869,7 +13869,7 @@
     >
       <div
         aria-label="1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13883,7 +13883,7 @@
     >
       <div
         aria-label="2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13897,7 +13897,7 @@
     >
       <div
         aria-label="3"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13916,7 +13916,7 @@
     >
       <div
         aria-label="4"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13930,7 +13930,7 @@
     >
       <div
         aria-label="5"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13944,7 +13944,7 @@
     >
       <div
         aria-label="6"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13958,7 +13958,7 @@
     >
       <div
         aria-label="7"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13977,7 +13977,7 @@
     >
       <div
         aria-label="8"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -13991,7 +13991,7 @@
     >
       <div
         aria-label="9"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14005,7 +14005,7 @@
     >
       <div
         aria-label="10"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14019,7 +14019,7 @@
     >
       <div
         aria-label="11"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14038,7 +14038,7 @@
     >
       <div
         aria-label="12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14052,7 +14052,7 @@
     >
       <div
         aria-label="13"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14066,7 +14066,7 @@
     >
       <div
         aria-label="14"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14081,7 +14081,7 @@
     >
       <div
         aria-label="15"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14155,7 +14155,7 @@
     >
       <div
         aria-label="17"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -14169,7 +14169,7 @@
     >
       <div
         aria-label="16"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14183,7 +14183,7 @@
     >
       <div
         aria-label="15"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14197,7 +14197,7 @@
     >
       <div
         aria-label="14"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14216,7 +14216,7 @@
     >
       <div
         aria-label="13"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14230,7 +14230,7 @@
     >
       <div
         aria-label="12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14244,7 +14244,7 @@
     >
       <div
         aria-label="11"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14258,7 +14258,7 @@
     >
       <div
         aria-label="10"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14277,7 +14277,7 @@
     >
       <div
         aria-label="9"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14291,7 +14291,7 @@
     >
       <div
         aria-label="8"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14305,7 +14305,7 @@
     >
       <div
         aria-label="7"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14319,7 +14319,7 @@
     >
       <div
         aria-label="6"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14338,7 +14338,7 @@
     >
       <div
         aria-label="5"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14352,7 +14352,7 @@
     >
       <div
         aria-label="4"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14366,7 +14366,7 @@
     >
       <div
         aria-label="3"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14381,7 +14381,7 @@
     >
       <div
         aria-label="2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14457,7 +14457,7 @@
     >
       <div
         aria-label="17"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -14471,7 +14471,7 @@
     >
       <div
         aria-label="16"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14485,7 +14485,7 @@
     >
       <div
         aria-label="15"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14499,7 +14499,7 @@
     >
       <div
         aria-label="14"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14518,7 +14518,7 @@
     >
       <div
         aria-label="13"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14532,7 +14532,7 @@
     >
       <div
         aria-label="12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14546,7 +14546,7 @@
     >
       <div
         aria-label="11"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14560,7 +14560,7 @@
     >
       <div
         aria-label="10"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14579,7 +14579,7 @@
     >
       <div
         aria-label="9"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14593,7 +14593,7 @@
     >
       <div
         aria-label="8"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14607,7 +14607,7 @@
     >
       <div
         aria-label="7"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14621,7 +14621,7 @@
     >
       <div
         aria-label="6"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14640,7 +14640,7 @@
     >
       <div
         aria-label="5"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14654,7 +14654,7 @@
     >
       <div
         aria-label="4"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14668,7 +14668,7 @@
     >
       <div
         aria-label="3"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14683,7 +14683,7 @@
     >
       <div
         aria-label="2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14757,7 +14757,7 @@
     >
       <div
         aria-label="1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -14771,7 +14771,7 @@
     >
       <div
         aria-label="1"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14785,7 +14785,7 @@
     >
       <div
         aria-label="2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14799,7 +14799,7 @@
     >
       <div
         aria-label="3"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14818,7 +14818,7 @@
     >
       <div
         aria-label="4"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14832,7 +14832,7 @@
     >
       <div
         aria-label="5"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14846,7 +14846,7 @@
     >
       <div
         aria-label="6"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14860,7 +14860,7 @@
     >
       <div
         aria-label="7"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14879,7 +14879,7 @@
     >
       <div
         aria-label="8"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14893,7 +14893,7 @@
     >
       <div
         aria-label="9"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14907,7 +14907,7 @@
     >
       <div
         aria-label="10"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14921,7 +14921,7 @@
     >
       <div
         aria-label="11"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14940,7 +14940,7 @@
     >
       <div
         aria-label="12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14954,7 +14954,7 @@
     >
       <div
         aria-label="13"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14968,7 +14968,7 @@
     >
       <div
         aria-label="14"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -14983,7 +14983,7 @@
     >
       <div
         aria-label="15"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15057,7 +15057,7 @@
     >
       <div
         aria-label="16"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -15071,7 +15071,7 @@
     >
       <div
         aria-label="17"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15085,7 +15085,7 @@
     >
       <div
         aria-label="18"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15099,7 +15099,7 @@
     >
       <div
         aria-label="19"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15118,7 +15118,7 @@
     >
       <div
         aria-label="20"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15132,7 +15132,7 @@
     >
       <div
         aria-label="21"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15146,7 +15146,7 @@
     >
       <div
         aria-label="22"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15160,7 +15160,7 @@
     >
       <div
         aria-label="23"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15179,7 +15179,7 @@
     >
       <div
         aria-label="24"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15193,7 +15193,7 @@
     >
       <div
         aria-label="25"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15207,7 +15207,7 @@
     >
       <div
         aria-label="26"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15221,7 +15221,7 @@
     >
       <div
         aria-label="27"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15240,7 +15240,7 @@
     >
       <div
         aria-label="28"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15254,7 +15254,7 @@
     >
       <div
         aria-label="29"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15268,7 +15268,7 @@
     >
       <div
         aria-label="30"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15283,7 +15283,7 @@
     >
       <div
         aria-label="31"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15464,7 +15464,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -15478,7 +15478,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15492,7 +15492,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15511,7 +15511,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15525,7 +15525,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15539,7 +15539,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15553,7 +15553,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15567,7 +15567,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15581,7 +15581,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15595,7 +15595,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15614,7 +15614,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15628,7 +15628,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15642,7 +15642,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15656,7 +15656,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15670,7 +15670,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15684,7 +15684,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15698,7 +15698,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15717,7 +15717,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15731,7 +15731,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15745,7 +15745,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15759,7 +15759,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15773,7 +15773,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15787,7 +15787,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15801,7 +15801,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15820,7 +15820,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15834,7 +15834,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15848,7 +15848,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15862,7 +15862,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15876,7 +15876,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -15891,7 +15891,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16026,7 +16026,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -16040,7 +16040,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16054,7 +16054,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16068,7 +16068,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16087,7 +16087,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16101,7 +16101,7 @@
     >
       <div
         aria-label="2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16115,7 +16115,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16129,7 +16129,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16148,7 +16148,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16162,7 +16162,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16176,7 +16176,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16190,7 +16190,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16209,7 +16209,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16223,7 +16223,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16237,7 +16237,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16252,7 +16252,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16429,7 +16429,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -16443,7 +16443,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16457,7 +16457,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16476,7 +16476,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16490,7 +16490,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16504,7 +16504,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16518,7 +16518,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16532,7 +16532,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16546,7 +16546,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16560,7 +16560,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16579,7 +16579,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16593,7 +16593,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16607,7 +16607,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16621,7 +16621,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16635,7 +16635,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16649,7 +16649,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16663,7 +16663,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16682,7 +16682,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16696,7 +16696,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16710,7 +16710,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16724,7 +16724,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16738,7 +16738,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16752,7 +16752,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16766,7 +16766,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16785,7 +16785,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16799,7 +16799,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16813,7 +16813,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16827,7 +16827,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16841,7 +16841,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16856,7 +16856,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -16992,7 +16992,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -17007,7 +17007,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17021,7 +17021,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17035,7 +17035,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17054,7 +17054,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17068,7 +17068,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17082,7 +17082,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17096,7 +17096,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17115,7 +17115,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17129,7 +17129,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17143,7 +17143,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17157,7 +17157,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17176,7 +17176,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17190,7 +17190,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17205,7 +17205,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17221,7 +17221,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17398,7 +17398,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -17412,7 +17412,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17426,7 +17426,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17445,7 +17445,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17459,7 +17459,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17473,7 +17473,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17487,7 +17487,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17501,7 +17501,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17515,7 +17515,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17529,7 +17529,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17548,7 +17548,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17562,7 +17562,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17576,7 +17576,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17590,7 +17590,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17604,7 +17604,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17618,7 +17618,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17632,7 +17632,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17651,7 +17651,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17665,7 +17665,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17679,7 +17679,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17693,7 +17693,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17707,7 +17707,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17721,7 +17721,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17735,7 +17735,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17754,7 +17754,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17768,7 +17768,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17782,7 +17782,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17796,7 +17796,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17810,7 +17810,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17825,7 +17825,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17964,7 +17964,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -17978,7 +17978,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -17992,7 +17992,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18006,7 +18006,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18025,7 +18025,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18039,7 +18039,7 @@
     >
       <div
         aria-label="2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18053,7 +18053,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18067,7 +18067,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18086,7 +18086,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18100,7 +18100,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18114,7 +18114,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18128,7 +18128,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18147,7 +18147,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18161,7 +18161,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18175,7 +18175,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18190,7 +18190,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18265,7 +18265,7 @@
     >
       <div
         aria-label="November 2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -18280,7 +18280,7 @@
     >
       <div
         aria-label="December 2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18294,7 +18294,7 @@
     >
       <div
         aria-label="January 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18308,7 +18308,7 @@
     >
       <div
         aria-label="February 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18327,7 +18327,7 @@
     >
       <div
         aria-label="March 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18341,7 +18341,7 @@
     >
       <div
         aria-label="April 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18355,7 +18355,7 @@
     >
       <div
         aria-label="May 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18369,7 +18369,7 @@
     >
       <div
         aria-label="June 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18388,7 +18388,7 @@
     >
       <div
         aria-label="July 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18402,7 +18402,7 @@
     >
       <div
         aria-label="August 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18416,7 +18416,7 @@
     >
       <div
         aria-label="September 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18430,7 +18430,7 @@
     >
       <div
         aria-label="October 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18449,7 +18449,7 @@
     >
       <div
         aria-label="November 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18463,7 +18463,7 @@
     >
       <div
         aria-label="December 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18478,7 +18478,7 @@
     >
       <div
         aria-label="January 2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18494,7 +18494,7 @@
     >
       <div
         aria-label="February 2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18569,7 +18569,7 @@
     >
       <div
         aria-label="November 2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -18584,7 +18584,7 @@
     >
       <div
         aria-label="December 2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18598,7 +18598,7 @@
     >
       <div
         aria-label="January 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18612,7 +18612,7 @@
     >
       <div
         aria-label="February 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18631,7 +18631,7 @@
     >
       <div
         aria-label="March 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18645,7 +18645,7 @@
     >
       <div
         aria-label="April 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18659,7 +18659,7 @@
     >
       <div
         aria-label="May 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18673,7 +18673,7 @@
     >
       <div
         aria-label="June 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18692,7 +18692,7 @@
     >
       <div
         aria-label="July 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18706,7 +18706,7 @@
     >
       <div
         aria-label="August 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18720,7 +18720,7 @@
     >
       <div
         aria-label="September 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18734,7 +18734,7 @@
     >
       <div
         aria-label="October 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18753,7 +18753,7 @@
     >
       <div
         aria-label="November 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18767,7 +18767,7 @@
     >
       <div
         aria-label="December 2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18782,7 +18782,7 @@
     >
       <div
         aria-label="January 2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18798,7 +18798,7 @@
     >
       <div
         aria-label="February 2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18875,7 +18875,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -18890,7 +18890,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18904,7 +18904,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18918,7 +18918,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18937,7 +18937,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18951,7 +18951,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18965,7 +18965,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18979,7 +18979,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -18998,7 +18998,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19012,7 +19012,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19026,7 +19026,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19040,7 +19040,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19059,7 +19059,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19073,7 +19073,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19088,7 +19088,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19104,7 +19104,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19181,7 +19181,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -19196,7 +19196,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19210,7 +19210,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19224,7 +19224,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19243,7 +19243,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19257,7 +19257,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19271,7 +19271,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19285,7 +19285,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19304,7 +19304,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19318,7 +19318,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19332,7 +19332,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19346,7 +19346,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19365,7 +19365,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19379,7 +19379,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19394,7 +19394,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19410,7 +19410,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19591,7 +19591,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -19605,7 +19605,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19619,7 +19619,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19638,7 +19638,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19652,7 +19652,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19666,7 +19666,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19680,7 +19680,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19694,7 +19694,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19708,7 +19708,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19722,7 +19722,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19741,7 +19741,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19755,7 +19755,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19769,7 +19769,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19783,7 +19783,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19797,7 +19797,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19811,7 +19811,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19825,7 +19825,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19844,7 +19844,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19858,7 +19858,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19872,7 +19872,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19886,7 +19886,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19900,7 +19900,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19914,7 +19914,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19928,7 +19928,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19947,7 +19947,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19961,7 +19961,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19975,7 +19975,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -19989,7 +19989,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20003,7 +20003,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20018,7 +20018,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20258,7 +20258,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -20272,7 +20272,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20286,7 +20286,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20305,7 +20305,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20319,7 +20319,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20333,7 +20333,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20347,7 +20347,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20361,7 +20361,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20375,7 +20375,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20389,7 +20389,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20408,7 +20408,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20422,7 +20422,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20436,7 +20436,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20450,7 +20450,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20464,7 +20464,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20478,7 +20478,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20492,7 +20492,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20511,7 +20511,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20525,7 +20525,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20539,7 +20539,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20553,7 +20553,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20567,7 +20567,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20581,7 +20581,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20595,7 +20595,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20614,7 +20614,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20628,7 +20628,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20642,7 +20642,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20656,7 +20656,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20670,7 +20670,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20685,7 +20685,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20927,7 +20927,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -20941,7 +20941,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20955,7 +20955,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20974,7 +20974,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -20988,7 +20988,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21002,7 +21002,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21016,7 +21016,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21030,7 +21030,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21044,7 +21044,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21058,7 +21058,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21077,7 +21077,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21091,7 +21091,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21105,7 +21105,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21119,7 +21119,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21133,7 +21133,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21147,7 +21147,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21161,7 +21161,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21180,7 +21180,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21194,7 +21194,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21208,7 +21208,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21222,7 +21222,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21236,7 +21236,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21250,7 +21250,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21264,7 +21264,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21283,7 +21283,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21297,7 +21297,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21311,7 +21311,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21325,7 +21325,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21339,7 +21339,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21354,7 +21354,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21592,7 +21592,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -21606,7 +21606,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21620,7 +21620,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21639,7 +21639,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21653,7 +21653,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21667,7 +21667,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21681,7 +21681,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21695,7 +21695,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21709,7 +21709,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21723,7 +21723,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21742,7 +21742,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21756,7 +21756,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21770,7 +21770,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21784,7 +21784,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21798,7 +21798,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21812,7 +21812,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21826,7 +21826,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21845,7 +21845,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21859,7 +21859,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21873,7 +21873,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21887,7 +21887,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21901,7 +21901,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21915,7 +21915,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21929,7 +21929,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21948,7 +21948,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21962,7 +21962,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21976,7 +21976,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -21990,7 +21990,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -22004,7 +22004,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -22019,7 +22019,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >

--- a/packages/elements/src/calendar/__snapshots__/Navigation.md
+++ b/packages/elements/src/calendar/__snapshots__/Navigation.md
@@ -172,7 +172,7 @@
     >
       <div
         aria-label="Saturday, 1 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -186,7 +186,7 @@
     >
       <div
         aria-label="Sunday, 2 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -205,7 +205,7 @@
     >
       <div
         aria-label="Monday, 3 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -219,7 +219,7 @@
     >
       <div
         aria-label="Tuesday, 4 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -233,7 +233,7 @@
     >
       <div
         aria-label="Wednesday, 5 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -247,7 +247,7 @@
     >
       <div
         aria-label="Thursday, 6 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -261,7 +261,7 @@
     >
       <div
         aria-label="Friday, 7 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -275,7 +275,7 @@
     >
       <div
         aria-label="Saturday, 8 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -289,7 +289,7 @@
     >
       <div
         aria-label="Sunday, 9 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -308,7 +308,7 @@
     >
       <div
         aria-label="Monday, 10 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -322,7 +322,7 @@
     >
       <div
         aria-label="Tuesday, 11 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -336,7 +336,7 @@
     >
       <div
         aria-label="Wednesday, 12 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -350,7 +350,7 @@
     >
       <div
         aria-label="Thursday, 13 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -364,7 +364,7 @@
     >
       <div
         aria-label="Friday, 14 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -378,7 +378,7 @@
     >
       <div
         aria-label="Saturday, 15 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -392,7 +392,7 @@
     >
       <div
         aria-label="Sunday, 16 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -411,7 +411,7 @@
     >
       <div
         aria-label="Monday, 17 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -425,7 +425,7 @@
     >
       <div
         aria-label="Tuesday, 18 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -439,7 +439,7 @@
     >
       <div
         aria-label="Wednesday, 19 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -453,7 +453,7 @@
     >
       <div
         aria-label="Thursday, 20 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -467,7 +467,7 @@
     >
       <div
         aria-label="Friday, 21 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -481,7 +481,7 @@
     >
       <div
         aria-label="Saturday, 22 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -495,7 +495,7 @@
     >
       <div
         aria-label="Sunday, 23 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -514,7 +514,7 @@
     >
       <div
         aria-label="Monday, 24 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -528,7 +528,7 @@
     >
       <div
         aria-label="Tuesday, 25 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -542,7 +542,7 @@
     >
       <div
         aria-label="Wednesday, 26 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -556,7 +556,7 @@
     >
       <div
         aria-label="Thursday, 27 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -570,7 +570,7 @@
     >
       <div
         aria-label="Friday, 28 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -585,7 +585,7 @@
     >
       <div
         aria-label="Saturday, 29 February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -809,7 +809,7 @@
     >
       <div
         aria-label="Wednesday, 1 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -823,7 +823,7 @@
     >
       <div
         aria-label="Thursday, 2 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -837,7 +837,7 @@
     >
       <div
         aria-label="Friday, 3 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -851,7 +851,7 @@
     >
       <div
         aria-label="Saturday, 4 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -865,7 +865,7 @@
     >
       <div
         aria-label="Sunday, 5 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -884,7 +884,7 @@
     >
       <div
         aria-label="Monday, 6 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -898,7 +898,7 @@
     >
       <div
         aria-label="Tuesday, 7 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -912,7 +912,7 @@
     >
       <div
         aria-label="Wednesday, 8 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -926,7 +926,7 @@
     >
       <div
         aria-label="Thursday, 9 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -940,7 +940,7 @@
     >
       <div
         aria-label="Friday, 10 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -954,7 +954,7 @@
     >
       <div
         aria-label="Saturday, 11 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -968,7 +968,7 @@
     >
       <div
         aria-label="Sunday, 12 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -987,7 +987,7 @@
     >
       <div
         aria-label="Monday, 13 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1001,7 +1001,7 @@
     >
       <div
         aria-label="Tuesday, 14 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1015,7 +1015,7 @@
     >
       <div
         aria-label="Wednesday, 15 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1029,7 +1029,7 @@
     >
       <div
         aria-label="Thursday, 16 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1043,7 +1043,7 @@
     >
       <div
         aria-label="Friday, 17 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1057,7 +1057,7 @@
     >
       <div
         aria-label="Saturday, 18 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1071,7 +1071,7 @@
     >
       <div
         aria-label="Sunday, 19 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1090,7 +1090,7 @@
     >
       <div
         aria-label="Monday, 20 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1104,7 +1104,7 @@
     >
       <div
         aria-label="Tuesday, 21 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1118,7 +1118,7 @@
     >
       <div
         aria-label="Wednesday, 22 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1132,7 +1132,7 @@
     >
       <div
         aria-label="Thursday, 23 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1146,7 +1146,7 @@
     >
       <div
         aria-label="Friday, 24 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1160,7 +1160,7 @@
     >
       <div
         aria-label="Saturday, 25 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1174,7 +1174,7 @@
     >
       <div
         aria-label="Sunday, 26 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1193,7 +1193,7 @@
     >
       <div
         aria-label="Monday, 27 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1207,7 +1207,7 @@
     >
       <div
         aria-label="Tuesday, 28 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1221,7 +1221,7 @@
     >
       <div
         aria-label="Wednesday, 29 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1235,7 +1235,7 @@
     >
       <div
         aria-label="Thursday, 30 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1250,7 +1250,7 @@
     >
       <div
         aria-label="Friday, 31 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1509,7 +1509,7 @@
     >
       <div
         aria-label="Sunday, 1 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -1528,7 +1528,7 @@
     >
       <div
         aria-label="Monday, 2 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1542,7 +1542,7 @@
     >
       <div
         aria-label="Tuesday, 3 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1556,7 +1556,7 @@
     >
       <div
         aria-label="Wednesday, 4 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1570,7 +1570,7 @@
     >
       <div
         aria-label="Thursday, 5 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1584,7 +1584,7 @@
     >
       <div
         aria-label="Friday, 6 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1598,7 +1598,7 @@
     >
       <div
         aria-label="Saturday, 7 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1612,7 +1612,7 @@
     >
       <div
         aria-label="Sunday, 8 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1631,7 +1631,7 @@
     >
       <div
         aria-label="Monday, 9 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1645,7 +1645,7 @@
     >
       <div
         aria-label="Tuesday, 10 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1659,7 +1659,7 @@
     >
       <div
         aria-label="Wednesday, 11 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1673,7 +1673,7 @@
     >
       <div
         aria-label="Thursday, 12 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1687,7 +1687,7 @@
     >
       <div
         aria-label="Friday, 13 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1701,7 +1701,7 @@
     >
       <div
         aria-label="Saturday, 14 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1715,7 +1715,7 @@
     >
       <div
         aria-label="Sunday, 15 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1734,7 +1734,7 @@
     >
       <div
         aria-label="Monday, 16 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1748,7 +1748,7 @@
     >
       <div
         aria-label="Tuesday, 17 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1762,7 +1762,7 @@
     >
       <div
         aria-label="Wednesday, 18 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1776,7 +1776,7 @@
     >
       <div
         aria-label="Thursday, 19 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1790,7 +1790,7 @@
     >
       <div
         aria-label="Friday, 20 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1804,7 +1804,7 @@
     >
       <div
         aria-label="Saturday, 21 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1818,7 +1818,7 @@
     >
       <div
         aria-label="Sunday, 22 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1837,7 +1837,7 @@
     >
       <div
         aria-label="Monday, 23 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1851,7 +1851,7 @@
     >
       <div
         aria-label="Tuesday, 24 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1865,7 +1865,7 @@
     >
       <div
         aria-label="Wednesday, 25 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1879,7 +1879,7 @@
     >
       <div
         aria-label="Thursday, 26 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1893,7 +1893,7 @@
     >
       <div
         aria-label="Friday, 27 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1907,7 +1907,7 @@
     >
       <div
         aria-label="Saturday, 28 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1921,7 +1921,7 @@
     >
       <div
         aria-label="Sunday, 29 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1940,7 +1940,7 @@
     >
       <div
         aria-label="Monday, 30 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1955,7 +1955,7 @@
     >
       <div
         aria-label="Tuesday, 31 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2169,7 +2169,7 @@
     >
       <div
         aria-label="Friday, 1 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -2183,7 +2183,7 @@
     >
       <div
         aria-label="Saturday, 2 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2197,7 +2197,7 @@
     >
       <div
         aria-label="Sunday, 3 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2216,7 +2216,7 @@
     >
       <div
         aria-label="Monday, 4 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2230,7 +2230,7 @@
     >
       <div
         aria-label="Tuesday, 5 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2244,7 +2244,7 @@
     >
       <div
         aria-label="Wednesday, 6 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2258,7 +2258,7 @@
     >
       <div
         aria-label="Thursday, 7 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2272,7 +2272,7 @@
     >
       <div
         aria-label="Friday, 8 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2286,7 +2286,7 @@
     >
       <div
         aria-label="Saturday, 9 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2300,7 +2300,7 @@
     >
       <div
         aria-label="Sunday, 10 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2319,7 +2319,7 @@
     >
       <div
         aria-label="Monday, 11 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2333,7 +2333,7 @@
     >
       <div
         aria-label="Tuesday, 12 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2347,7 +2347,7 @@
     >
       <div
         aria-label="Wednesday, 13 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2361,7 +2361,7 @@
     >
       <div
         aria-label="Thursday, 14 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2375,7 +2375,7 @@
     >
       <div
         aria-label="Friday, 15 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2389,7 +2389,7 @@
     >
       <div
         aria-label="Saturday, 16 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2403,7 +2403,7 @@
     >
       <div
         aria-label="Sunday, 17 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2422,7 +2422,7 @@
     >
       <div
         aria-label="Monday, 18 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2436,7 +2436,7 @@
     >
       <div
         aria-label="Tuesday, 19 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2450,7 +2450,7 @@
     >
       <div
         aria-label="Wednesday, 20 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2464,7 +2464,7 @@
     >
       <div
         aria-label="Thursday, 21 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2478,7 +2478,7 @@
     >
       <div
         aria-label="Friday, 22 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2492,7 +2492,7 @@
     >
       <div
         aria-label="Saturday, 23 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2506,7 +2506,7 @@
     >
       <div
         aria-label="Sunday, 24 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2525,7 +2525,7 @@
     >
       <div
         aria-label="Monday, 25 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2539,7 +2539,7 @@
     >
       <div
         aria-label="Tuesday, 26 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2553,7 +2553,7 @@
     >
       <div
         aria-label="Wednesday, 27 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2567,7 +2567,7 @@
     >
       <div
         aria-label="Thursday, 28 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2581,7 +2581,7 @@
     >
       <div
         aria-label="Friday, 29 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2596,7 +2596,7 @@
     >
       <div
         aria-label="Saturday, 30 November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2848,7 +2848,7 @@
     >
       <div
         aria-label="Sunday, 1 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -2867,7 +2867,7 @@
     >
       <div
         aria-label="Monday, 2 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2881,7 +2881,7 @@
     >
       <div
         aria-label="Tuesday, 3 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2895,7 +2895,7 @@
     >
       <div
         aria-label="Wednesday, 4 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2909,7 +2909,7 @@
     >
       <div
         aria-label="Thursday, 5 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2923,7 +2923,7 @@
     >
       <div
         aria-label="Friday, 6 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2937,7 +2937,7 @@
     >
       <div
         aria-label="Saturday, 7 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2951,7 +2951,7 @@
     >
       <div
         aria-label="Sunday, 8 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2970,7 +2970,7 @@
     >
       <div
         aria-label="Monday, 9 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2984,7 +2984,7 @@
     >
       <div
         aria-label="Tuesday, 10 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2998,7 +2998,7 @@
     >
       <div
         aria-label="Wednesday, 11 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3012,7 +3012,7 @@
     >
       <div
         aria-label="Thursday, 12 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3026,7 +3026,7 @@
     >
       <div
         aria-label="Friday, 13 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3040,7 +3040,7 @@
     >
       <div
         aria-label="Saturday, 14 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3054,7 +3054,7 @@
     >
       <div
         aria-label="Sunday, 15 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3073,7 +3073,7 @@
     >
       <div
         aria-label="Monday, 16 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3087,7 +3087,7 @@
     >
       <div
         aria-label="Tuesday, 17 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3101,7 +3101,7 @@
     >
       <div
         aria-label="Wednesday, 18 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3115,7 +3115,7 @@
     >
       <div
         aria-label="Thursday, 19 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3129,7 +3129,7 @@
     >
       <div
         aria-label="Friday, 20 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3143,7 +3143,7 @@
     >
       <div
         aria-label="Saturday, 21 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3157,7 +3157,7 @@
     >
       <div
         aria-label="Sunday, 22 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3176,7 +3176,7 @@
     >
       <div
         aria-label="Monday, 23 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3190,7 +3190,7 @@
     >
       <div
         aria-label="Tuesday, 24 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3204,7 +3204,7 @@
     >
       <div
         aria-label="Wednesday, 25 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3218,7 +3218,7 @@
     >
       <div
         aria-label="Thursday, 26 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3232,7 +3232,7 @@
     >
       <div
         aria-label="Friday, 27 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3246,7 +3246,7 @@
     >
       <div
         aria-label="Saturday, 28 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3260,7 +3260,7 @@
     >
       <div
         aria-label="Sunday, 29 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3279,7 +3279,7 @@
     >
       <div
         aria-label="Monday, 30 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3294,7 +3294,7 @@
     >
       <div
         aria-label="Tuesday, 31 December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3492,7 +3492,7 @@
     >
       <div
         aria-label="Wednesday, 1 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -3506,7 +3506,7 @@
     >
       <div
         aria-label="Thursday, 2 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3520,7 +3520,7 @@
     >
       <div
         aria-label="Friday, 3 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3534,7 +3534,7 @@
     >
       <div
         aria-label="Saturday, 4 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3548,7 +3548,7 @@
     >
       <div
         aria-label="Sunday, 5 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3567,7 +3567,7 @@
     >
       <div
         aria-label="Monday, 6 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3581,7 +3581,7 @@
     >
       <div
         aria-label="Tuesday, 7 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3595,7 +3595,7 @@
     >
       <div
         aria-label="Wednesday, 8 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3609,7 +3609,7 @@
     >
       <div
         aria-label="Thursday, 9 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3623,7 +3623,7 @@
     >
       <div
         aria-label="Friday, 10 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3637,7 +3637,7 @@
     >
       <div
         aria-label="Saturday, 11 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3651,7 +3651,7 @@
     >
       <div
         aria-label="Sunday, 12 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3670,7 +3670,7 @@
     >
       <div
         aria-label="Monday, 13 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3684,7 +3684,7 @@
     >
       <div
         aria-label="Tuesday, 14 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3698,7 +3698,7 @@
     >
       <div
         aria-label="Wednesday, 15 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3712,7 +3712,7 @@
     >
       <div
         aria-label="Thursday, 16 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3726,7 +3726,7 @@
     >
       <div
         aria-label="Friday, 17 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3740,7 +3740,7 @@
     >
       <div
         aria-label="Saturday, 18 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3754,7 +3754,7 @@
     >
       <div
         aria-label="Sunday, 19 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3773,7 +3773,7 @@
     >
       <div
         aria-label="Monday, 20 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3787,7 +3787,7 @@
     >
       <div
         aria-label="Tuesday, 21 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3801,7 +3801,7 @@
     >
       <div
         aria-label="Wednesday, 22 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3815,7 +3815,7 @@
     >
       <div
         aria-label="Thursday, 23 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3829,7 +3829,7 @@
     >
       <div
         aria-label="Friday, 24 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3843,7 +3843,7 @@
     >
       <div
         aria-label="Saturday, 25 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3857,7 +3857,7 @@
     >
       <div
         aria-label="Sunday, 26 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3876,7 +3876,7 @@
     >
       <div
         aria-label="Monday, 27 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3890,7 +3890,7 @@
     >
       <div
         aria-label="Tuesday, 28 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3904,7 +3904,7 @@
     >
       <div
         aria-label="Wednesday, 29 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3918,7 +3918,7 @@
     >
       <div
         aria-label="Thursday, 30 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3933,7 +3933,7 @@
     >
       <div
         aria-label="Friday, 31 January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4175,7 +4175,7 @@
     >
       <div
         aria-label="Thursday, 1 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -4189,7 +4189,7 @@
     >
       <div
         aria-label="Friday, 2 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4203,7 +4203,7 @@
     >
       <div
         aria-label="Saturday, 3 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4217,7 +4217,7 @@
     >
       <div
         aria-label="Sunday, 4 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4236,7 +4236,7 @@
     >
       <div
         aria-label="Monday, 5 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4250,7 +4250,7 @@
     >
       <div
         aria-label="Tuesday, 6 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4264,7 +4264,7 @@
     >
       <div
         aria-label="Wednesday, 7 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4278,7 +4278,7 @@
     >
       <div
         aria-label="Thursday, 8 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4292,7 +4292,7 @@
     >
       <div
         aria-label="Friday, 9 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4306,7 +4306,7 @@
     >
       <div
         aria-label="Saturday, 10 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4320,7 +4320,7 @@
     >
       <div
         aria-label="Sunday, 11 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4339,7 +4339,7 @@
     >
       <div
         aria-label="Monday, 12 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4353,7 +4353,7 @@
     >
       <div
         aria-label="Tuesday, 13 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4367,7 +4367,7 @@
     >
       <div
         aria-label="Wednesday, 14 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4381,7 +4381,7 @@
     >
       <div
         aria-label="Thursday, 15 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4395,7 +4395,7 @@
     >
       <div
         aria-label="Friday, 16 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4409,7 +4409,7 @@
     >
       <div
         aria-label="Saturday, 17 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4423,7 +4423,7 @@
     >
       <div
         aria-label="Sunday, 18 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4442,7 +4442,7 @@
     >
       <div
         aria-label="Monday, 19 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4456,7 +4456,7 @@
     >
       <div
         aria-label="Tuesday, 20 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4470,7 +4470,7 @@
     >
       <div
         aria-label="Wednesday, 21 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4484,7 +4484,7 @@
     >
       <div
         aria-label="Thursday, 22 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4498,7 +4498,7 @@
     >
       <div
         aria-label="Friday, 23 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4512,7 +4512,7 @@
     >
       <div
         aria-label="Saturday, 24 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4526,7 +4526,7 @@
     >
       <div
         aria-label="Sunday, 25 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4545,7 +4545,7 @@
     >
       <div
         aria-label="Monday, 26 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4559,7 +4559,7 @@
     >
       <div
         aria-label="Tuesday, 27 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4574,7 +4574,7 @@
     >
       <div
         aria-label="Wednesday, 28 February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4805,7 +4805,7 @@
     >
       <div
         aria-label="Monday, 1 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -4819,7 +4819,7 @@
     >
       <div
         aria-label="Tuesday, 2 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4833,7 +4833,7 @@
     >
       <div
         aria-label="Wednesday, 3 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4847,7 +4847,7 @@
     >
       <div
         aria-label="Thursday, 4 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4861,7 +4861,7 @@
     >
       <div
         aria-label="Friday, 5 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4875,7 +4875,7 @@
     >
       <div
         aria-label="Saturday, 6 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4889,7 +4889,7 @@
     >
       <div
         aria-label="Sunday, 7 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4908,7 +4908,7 @@
     >
       <div
         aria-label="Monday, 8 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4922,7 +4922,7 @@
     >
       <div
         aria-label="Tuesday, 9 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4936,7 +4936,7 @@
     >
       <div
         aria-label="Wednesday, 10 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4950,7 +4950,7 @@
     >
       <div
         aria-label="Thursday, 11 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4964,7 +4964,7 @@
     >
       <div
         aria-label="Friday, 12 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4978,7 +4978,7 @@
     >
       <div
         aria-label="Saturday, 13 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4992,7 +4992,7 @@
     >
       <div
         aria-label="Sunday, 14 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5011,7 +5011,7 @@
     >
       <div
         aria-label="Monday, 15 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5025,7 +5025,7 @@
     >
       <div
         aria-label="Tuesday, 16 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5039,7 +5039,7 @@
     >
       <div
         aria-label="Wednesday, 17 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5053,7 +5053,7 @@
     >
       <div
         aria-label="Thursday, 18 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5067,7 +5067,7 @@
     >
       <div
         aria-label="Friday, 19 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5081,7 +5081,7 @@
     >
       <div
         aria-label="Saturday, 20 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5095,7 +5095,7 @@
     >
       <div
         aria-label="Sunday, 21 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5114,7 +5114,7 @@
     >
       <div
         aria-label="Monday, 22 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5128,7 +5128,7 @@
     >
       <div
         aria-label="Tuesday, 23 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5142,7 +5142,7 @@
     >
       <div
         aria-label="Wednesday, 24 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5156,7 +5156,7 @@
     >
       <div
         aria-label="Thursday, 25 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5170,7 +5170,7 @@
     >
       <div
         aria-label="Friday, 26 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5184,7 +5184,7 @@
     >
       <div
         aria-label="Saturday, 27 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5198,7 +5198,7 @@
     >
       <div
         aria-label="Sunday, 28 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5217,7 +5217,7 @@
     >
       <div
         aria-label="Monday, 29 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5231,7 +5231,7 @@
     >
       <div
         aria-label="Tuesday, 30 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5246,7 +5246,7 @@
     >
       <div
         aria-label="Wednesday, 31 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5505,7 +5505,7 @@
     >
       <div
         aria-label="Friday, 1 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -5519,7 +5519,7 @@
     >
       <div
         aria-label="Saturday, 2 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5533,7 +5533,7 @@
     >
       <div
         aria-label="Sunday, 3 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5552,7 +5552,7 @@
     >
       <div
         aria-label="Monday, 4 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5566,7 +5566,7 @@
     >
       <div
         aria-label="Tuesday, 5 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5580,7 +5580,7 @@
     >
       <div
         aria-label="Wednesday, 6 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5594,7 +5594,7 @@
     >
       <div
         aria-label="Thursday, 7 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5608,7 +5608,7 @@
     >
       <div
         aria-label="Friday, 8 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5622,7 +5622,7 @@
     >
       <div
         aria-label="Saturday, 9 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5636,7 +5636,7 @@
     >
       <div
         aria-label="Sunday, 10 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5655,7 +5655,7 @@
     >
       <div
         aria-label="Monday, 11 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5669,7 +5669,7 @@
     >
       <div
         aria-label="Tuesday, 12 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5683,7 +5683,7 @@
     >
       <div
         aria-label="Wednesday, 13 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5697,7 +5697,7 @@
     >
       <div
         aria-label="Thursday, 14 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5711,7 +5711,7 @@
     >
       <div
         aria-label="Friday, 15 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5725,7 +5725,7 @@
     >
       <div
         aria-label="Saturday, 16 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5739,7 +5739,7 @@
     >
       <div
         aria-label="Sunday, 17 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5758,7 +5758,7 @@
     >
       <div
         aria-label="Monday, 18 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5772,7 +5772,7 @@
     >
       <div
         aria-label="Tuesday, 19 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5786,7 +5786,7 @@
     >
       <div
         aria-label="Wednesday, 20 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5800,7 +5800,7 @@
     >
       <div
         aria-label="Thursday, 21 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5814,7 +5814,7 @@
     >
       <div
         aria-label="Friday, 22 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5828,7 +5828,7 @@
     >
       <div
         aria-label="Saturday, 23 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5842,7 +5842,7 @@
     >
       <div
         aria-label="Sunday, 24 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5861,7 +5861,7 @@
     >
       <div
         aria-label="Monday, 25 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5875,7 +5875,7 @@
     >
       <div
         aria-label="Tuesday, 26 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5889,7 +5889,7 @@
     >
       <div
         aria-label="Wednesday, 27 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5903,7 +5903,7 @@
     >
       <div
         aria-label="Thursday, 28 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5917,7 +5917,7 @@
     >
       <div
         aria-label="Friday, 29 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5931,7 +5931,7 @@
     >
       <div
         aria-label="Saturday, 30 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5946,7 +5946,7 @@
     >
       <div
         aria-label="Sunday, 31 December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6151,7 +6151,7 @@
     >
       <div
         aria-label="Monday, 1 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -6165,7 +6165,7 @@
     >
       <div
         aria-label="Tuesday, 2 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6179,7 +6179,7 @@
     >
       <div
         aria-label="Wednesday, 3 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6193,7 +6193,7 @@
     >
       <div
         aria-label="Thursday, 4 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6207,7 +6207,7 @@
     >
       <div
         aria-label="Friday, 5 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6221,7 +6221,7 @@
     >
       <div
         aria-label="Saturday, 6 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6235,7 +6235,7 @@
     >
       <div
         aria-label="Sunday, 7 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6254,7 +6254,7 @@
     >
       <div
         aria-label="Monday, 8 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6268,7 +6268,7 @@
     >
       <div
         aria-label="Tuesday, 9 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6282,7 +6282,7 @@
     >
       <div
         aria-label="Wednesday, 10 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6296,7 +6296,7 @@
     >
       <div
         aria-label="Thursday, 11 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6310,7 +6310,7 @@
     >
       <div
         aria-label="Friday, 12 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6324,7 +6324,7 @@
     >
       <div
         aria-label="Saturday, 13 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6338,7 +6338,7 @@
     >
       <div
         aria-label="Sunday, 14 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6357,7 +6357,7 @@
     >
       <div
         aria-label="Monday, 15 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6371,7 +6371,7 @@
     >
       <div
         aria-label="Tuesday, 16 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6385,7 +6385,7 @@
     >
       <div
         aria-label="Wednesday, 17 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6399,7 +6399,7 @@
     >
       <div
         aria-label="Thursday, 18 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6413,7 +6413,7 @@
     >
       <div
         aria-label="Friday, 19 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6427,7 +6427,7 @@
     >
       <div
         aria-label="Saturday, 20 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6441,7 +6441,7 @@
     >
       <div
         aria-label="Sunday, 21 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6460,7 +6460,7 @@
     >
       <div
         aria-label="Monday, 22 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6474,7 +6474,7 @@
     >
       <div
         aria-label="Tuesday, 23 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6488,7 +6488,7 @@
     >
       <div
         aria-label="Wednesday, 24 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6502,7 +6502,7 @@
     >
       <div
         aria-label="Thursday, 25 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6516,7 +6516,7 @@
     >
       <div
         aria-label="Friday, 26 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6530,7 +6530,7 @@
     >
       <div
         aria-label="Saturday, 27 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6544,7 +6544,7 @@
     >
       <div
         aria-label="Sunday, 28 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6563,7 +6563,7 @@
     >
       <div
         aria-label="Monday, 29 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6578,7 +6578,7 @@
     >
       <div
         aria-label="Tuesday, 30 November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6830,7 +6830,7 @@
     >
       <div
         aria-label="Wednesday, 1 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -6844,7 +6844,7 @@
     >
       <div
         aria-label="Thursday, 2 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6858,7 +6858,7 @@
     >
       <div
         aria-label="Friday, 3 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6872,7 +6872,7 @@
     >
       <div
         aria-label="Saturday, 4 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6886,7 +6886,7 @@
     >
       <div
         aria-label="Sunday, 5 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6905,7 +6905,7 @@
     >
       <div
         aria-label="Monday, 6 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6919,7 +6919,7 @@
     >
       <div
         aria-label="Tuesday, 7 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6933,7 +6933,7 @@
     >
       <div
         aria-label="Wednesday, 8 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6947,7 +6947,7 @@
     >
       <div
         aria-label="Thursday, 9 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6961,7 +6961,7 @@
     >
       <div
         aria-label="Friday, 10 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6975,7 +6975,7 @@
     >
       <div
         aria-label="Saturday, 11 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6989,7 +6989,7 @@
     >
       <div
         aria-label="Sunday, 12 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7008,7 +7008,7 @@
     >
       <div
         aria-label="Monday, 13 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7022,7 +7022,7 @@
     >
       <div
         aria-label="Tuesday, 14 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7036,7 +7036,7 @@
     >
       <div
         aria-label="Wednesday, 15 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7050,7 +7050,7 @@
     >
       <div
         aria-label="Thursday, 16 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7064,7 +7064,7 @@
     >
       <div
         aria-label="Friday, 17 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7078,7 +7078,7 @@
     >
       <div
         aria-label="Saturday, 18 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7092,7 +7092,7 @@
     >
       <div
         aria-label="Sunday, 19 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7111,7 +7111,7 @@
     >
       <div
         aria-label="Monday, 20 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7125,7 +7125,7 @@
     >
       <div
         aria-label="Tuesday, 21 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7139,7 +7139,7 @@
     >
       <div
         aria-label="Wednesday, 22 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7153,7 +7153,7 @@
     >
       <div
         aria-label="Thursday, 23 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7167,7 +7167,7 @@
     >
       <div
         aria-label="Friday, 24 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7181,7 +7181,7 @@
     >
       <div
         aria-label="Saturday, 25 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7195,7 +7195,7 @@
     >
       <div
         aria-label="Sunday, 26 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7214,7 +7214,7 @@
     >
       <div
         aria-label="Monday, 27 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7228,7 +7228,7 @@
     >
       <div
         aria-label="Tuesday, 28 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7242,7 +7242,7 @@
     >
       <div
         aria-label="Wednesday, 29 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7256,7 +7256,7 @@
     >
       <div
         aria-label="Thursday, 30 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7271,7 +7271,7 @@
     >
       <div
         aria-label="Friday, 31 December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7523,7 +7523,7 @@
     >
       <div
         aria-label="Saturday, 1 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -7537,7 +7537,7 @@
     >
       <div
         aria-label="Sunday, 2 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7556,7 +7556,7 @@
     >
       <div
         aria-label="Monday, 3 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7570,7 +7570,7 @@
     >
       <div
         aria-label="Tuesday, 4 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7584,7 +7584,7 @@
     >
       <div
         aria-label="Wednesday, 5 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7598,7 +7598,7 @@
     >
       <div
         aria-label="Thursday, 6 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7612,7 +7612,7 @@
     >
       <div
         aria-label="Friday, 7 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7626,7 +7626,7 @@
     >
       <div
         aria-label="Saturday, 8 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7640,7 +7640,7 @@
     >
       <div
         aria-label="Sunday, 9 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7659,7 +7659,7 @@
     >
       <div
         aria-label="Monday, 10 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7673,7 +7673,7 @@
     >
       <div
         aria-label="Tuesday, 11 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7687,7 +7687,7 @@
     >
       <div
         aria-label="Wednesday, 12 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7701,7 +7701,7 @@
     >
       <div
         aria-label="Thursday, 13 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7715,7 +7715,7 @@
     >
       <div
         aria-label="Friday, 14 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7729,7 +7729,7 @@
     >
       <div
         aria-label="Saturday, 15 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7743,7 +7743,7 @@
     >
       <div
         aria-label="Sunday, 16 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7762,7 +7762,7 @@
     >
       <div
         aria-label="Monday, 17 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7776,7 +7776,7 @@
     >
       <div
         aria-label="Tuesday, 18 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7790,7 +7790,7 @@
     >
       <div
         aria-label="Wednesday, 19 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7804,7 +7804,7 @@
     >
       <div
         aria-label="Thursday, 20 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7818,7 +7818,7 @@
     >
       <div
         aria-label="Friday, 21 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7832,7 +7832,7 @@
     >
       <div
         aria-label="Saturday, 22 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7846,7 +7846,7 @@
     >
       <div
         aria-label="Sunday, 23 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7865,7 +7865,7 @@
     >
       <div
         aria-label="Monday, 24 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7879,7 +7879,7 @@
     >
       <div
         aria-label="Tuesday, 25 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7893,7 +7893,7 @@
     >
       <div
         aria-label="Wednesday, 26 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7907,7 +7907,7 @@
     >
       <div
         aria-label="Thursday, 27 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7921,7 +7921,7 @@
     >
       <div
         aria-label="Friday, 28 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7935,7 +7935,7 @@
     >
       <div
         aria-label="Saturday, 29 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7949,7 +7949,7 @@
     >
       <div
         aria-label="Sunday, 30 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7969,7 +7969,7 @@
     >
       <div
         aria-label="Monday, 31 January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8090,7 +8090,7 @@
     >
       <div
         aria-label="November 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -8105,7 +8105,7 @@
     >
       <div
         aria-label="December 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8119,7 +8119,7 @@
     >
       <div
         aria-label="January 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8133,7 +8133,7 @@
     >
       <div
         aria-label="February 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8152,7 +8152,7 @@
     >
       <div
         aria-label="March 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8166,7 +8166,7 @@
     >
       <div
         aria-label="April 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8180,7 +8180,7 @@
     >
       <div
         aria-label="May 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8194,7 +8194,7 @@
     >
       <div
         aria-label="June 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8213,7 +8213,7 @@
     >
       <div
         aria-label="July 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8227,7 +8227,7 @@
     >
       <div
         aria-label="August 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8241,7 +8241,7 @@
     >
       <div
         aria-label="September 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8255,7 +8255,7 @@
     >
       <div
         aria-label="October 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8274,7 +8274,7 @@
     >
       <div
         aria-label="November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8288,7 +8288,7 @@
     >
       <div
         aria-label="December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8303,7 +8303,7 @@
     >
       <div
         aria-label="January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8319,7 +8319,7 @@
     >
       <div
         aria-label="February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8394,7 +8394,7 @@
     >
       <div
         aria-label="November 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -8409,7 +8409,7 @@
     >
       <div
         aria-label="December 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8423,7 +8423,7 @@
     >
       <div
         aria-label="January 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8437,7 +8437,7 @@
     >
       <div
         aria-label="February 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8456,7 +8456,7 @@
     >
       <div
         aria-label="March 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8470,7 +8470,7 @@
     >
       <div
         aria-label="April 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8484,7 +8484,7 @@
     >
       <div
         aria-label="May 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8498,7 +8498,7 @@
     >
       <div
         aria-label="June 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8517,7 +8517,7 @@
     >
       <div
         aria-label="July 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8531,7 +8531,7 @@
     >
       <div
         aria-label="August 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8545,7 +8545,7 @@
     >
       <div
         aria-label="September 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8559,7 +8559,7 @@
     >
       <div
         aria-label="October 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8578,7 +8578,7 @@
     >
       <div
         aria-label="November 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8592,7 +8592,7 @@
     >
       <div
         aria-label="December 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8607,7 +8607,7 @@
     >
       <div
         aria-label="January 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8623,7 +8623,7 @@
     >
       <div
         aria-label="February 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8698,7 +8698,7 @@
     >
       <div
         aria-label="November 2016"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -8713,7 +8713,7 @@
     >
       <div
         aria-label="December 2016"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8727,7 +8727,7 @@
     >
       <div
         aria-label="January 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8741,7 +8741,7 @@
     >
       <div
         aria-label="February 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8760,7 +8760,7 @@
     >
       <div
         aria-label="March 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8774,7 +8774,7 @@
     >
       <div
         aria-label="April 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8788,7 +8788,7 @@
     >
       <div
         aria-label="May 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8802,7 +8802,7 @@
     >
       <div
         aria-label="June 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8821,7 +8821,7 @@
     >
       <div
         aria-label="July 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8835,7 +8835,7 @@
     >
       <div
         aria-label="August 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8849,7 +8849,7 @@
     >
       <div
         aria-label="September 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8863,7 +8863,7 @@
     >
       <div
         aria-label="October 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8882,7 +8882,7 @@
     >
       <div
         aria-label="November 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8896,7 +8896,7 @@
     >
       <div
         aria-label="December 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8911,7 +8911,7 @@
     >
       <div
         aria-label="January 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -8927,7 +8927,7 @@
     >
       <div
         aria-label="February 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9004,7 +9004,7 @@
     >
       <div
         aria-label="November 2016"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -9019,7 +9019,7 @@
     >
       <div
         aria-label="December 2016"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9033,7 +9033,7 @@
     >
       <div
         aria-label="January 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9047,7 +9047,7 @@
     >
       <div
         aria-label="February 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9066,7 +9066,7 @@
     >
       <div
         aria-label="March 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9080,7 +9080,7 @@
     >
       <div
         aria-label="April 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9094,7 +9094,7 @@
     >
       <div
         aria-label="May 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9108,7 +9108,7 @@
     >
       <div
         aria-label="June 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9127,7 +9127,7 @@
     >
       <div
         aria-label="July 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9141,7 +9141,7 @@
     >
       <div
         aria-label="August 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9155,7 +9155,7 @@
     >
       <div
         aria-label="September 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9169,7 +9169,7 @@
     >
       <div
         aria-label="October 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9188,7 +9188,7 @@
     >
       <div
         aria-label="November 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9202,7 +9202,7 @@
     >
       <div
         aria-label="December 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9217,7 +9217,7 @@
     >
       <div
         aria-label="January 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9233,7 +9233,7 @@
     >
       <div
         aria-label="February 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9308,7 +9308,7 @@
     >
       <div
         aria-label="November 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -9323,7 +9323,7 @@
     >
       <div
         aria-label="December 2017"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9337,7 +9337,7 @@
     >
       <div
         aria-label="January 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9351,7 +9351,7 @@
     >
       <div
         aria-label="February 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9370,7 +9370,7 @@
     >
       <div
         aria-label="March 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9384,7 +9384,7 @@
     >
       <div
         aria-label="April 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9398,7 +9398,7 @@
     >
       <div
         aria-label="May 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9412,7 +9412,7 @@
     >
       <div
         aria-label="June 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9431,7 +9431,7 @@
     >
       <div
         aria-label="July 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9445,7 +9445,7 @@
     >
       <div
         aria-label="August 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9459,7 +9459,7 @@
     >
       <div
         aria-label="September 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9473,7 +9473,7 @@
     >
       <div
         aria-label="October 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9492,7 +9492,7 @@
     >
       <div
         aria-label="November 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9506,7 +9506,7 @@
     >
       <div
         aria-label="December 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9521,7 +9521,7 @@
     >
       <div
         aria-label="January 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9537,7 +9537,7 @@
     >
       <div
         aria-label="February 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9612,7 +9612,7 @@
     >
       <div
         aria-label="November 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -9627,7 +9627,7 @@
     >
       <div
         aria-label="December 2018"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9641,7 +9641,7 @@
     >
       <div
         aria-label="January 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9655,7 +9655,7 @@
     >
       <div
         aria-label="February 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9674,7 +9674,7 @@
     >
       <div
         aria-label="March 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9688,7 +9688,7 @@
     >
       <div
         aria-label="April 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9702,7 +9702,7 @@
     >
       <div
         aria-label="May 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9716,7 +9716,7 @@
     >
       <div
         aria-label="June 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9735,7 +9735,7 @@
     >
       <div
         aria-label="July 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9749,7 +9749,7 @@
     >
       <div
         aria-label="August 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9763,7 +9763,7 @@
     >
       <div
         aria-label="September 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9777,7 +9777,7 @@
     >
       <div
         aria-label="October 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9796,7 +9796,7 @@
     >
       <div
         aria-label="November 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9810,7 +9810,7 @@
     >
       <div
         aria-label="December 2019"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9825,7 +9825,7 @@
     >
       <div
         aria-label="January 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9841,7 +9841,7 @@
     >
       <div
         aria-label="February 2020"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9920,7 +9920,7 @@
     >
       <div
         aria-label="November 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -9935,7 +9935,7 @@
     >
       <div
         aria-label="December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9949,7 +9949,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9963,7 +9963,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9982,7 +9982,7 @@
     >
       <div
         aria-label="March 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -9996,7 +9996,7 @@
     >
       <div
         aria-label="April 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10010,7 +10010,7 @@
     >
       <div
         aria-label="May 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10024,7 +10024,7 @@
     >
       <div
         aria-label="June 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10043,7 +10043,7 @@
     >
       <div
         aria-label="July 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10057,7 +10057,7 @@
     >
       <div
         aria-label="August 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10071,7 +10071,7 @@
     >
       <div
         aria-label="September 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10085,7 +10085,7 @@
     >
       <div
         aria-label="October 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10104,7 +10104,7 @@
     >
       <div
         aria-label="November 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10118,7 +10118,7 @@
     >
       <div
         aria-label="December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10133,7 +10133,7 @@
     >
       <div
         aria-label="January 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10149,7 +10149,7 @@
     >
       <div
         aria-label="February 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10224,7 +10224,7 @@
     >
       <div
         aria-label="November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -10239,7 +10239,7 @@
     >
       <div
         aria-label="December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10253,7 +10253,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10267,7 +10267,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10286,7 +10286,7 @@
     >
       <div
         aria-label="March 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10300,7 +10300,7 @@
     >
       <div
         aria-label="April 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10314,7 +10314,7 @@
     >
       <div
         aria-label="May 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10328,7 +10328,7 @@
     >
       <div
         aria-label="June 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10347,7 +10347,7 @@
     >
       <div
         aria-label="July 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10361,7 +10361,7 @@
     >
       <div
         aria-label="August 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10375,7 +10375,7 @@
     >
       <div
         aria-label="September 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10389,7 +10389,7 @@
     >
       <div
         aria-label="October 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10408,7 +10408,7 @@
     >
       <div
         aria-label="November 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10422,7 +10422,7 @@
     >
       <div
         aria-label="December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10437,7 +10437,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10453,7 +10453,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10528,7 +10528,7 @@
     >
       <div
         aria-label="November 3"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -10543,7 +10543,7 @@
     >
       <div
         aria-label="December 3"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10557,7 +10557,7 @@
     >
       <div
         aria-label="January 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10571,7 +10571,7 @@
     >
       <div
         aria-label="February 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10590,7 +10590,7 @@
     >
       <div
         aria-label="March 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10604,7 +10604,7 @@
     >
       <div
         aria-label="April 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10618,7 +10618,7 @@
     >
       <div
         aria-label="May 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10632,7 +10632,7 @@
     >
       <div
         aria-label="June 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10651,7 +10651,7 @@
     >
       <div
         aria-label="July 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10665,7 +10665,7 @@
     >
       <div
         aria-label="August 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10679,7 +10679,7 @@
     >
       <div
         aria-label="September 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10693,7 +10693,7 @@
     >
       <div
         aria-label="October 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10712,7 +10712,7 @@
     >
       <div
         aria-label="November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10726,7 +10726,7 @@
     >
       <div
         aria-label="December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10741,7 +10741,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10757,7 +10757,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10834,7 +10834,7 @@
     >
       <div
         aria-label="November 3"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -10849,7 +10849,7 @@
     >
       <div
         aria-label="December 3"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10863,7 +10863,7 @@
     >
       <div
         aria-label="January 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10877,7 +10877,7 @@
     >
       <div
         aria-label="February 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10896,7 +10896,7 @@
     >
       <div
         aria-label="March 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10910,7 +10910,7 @@
     >
       <div
         aria-label="April 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10924,7 +10924,7 @@
     >
       <div
         aria-label="May 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10938,7 +10938,7 @@
     >
       <div
         aria-label="June 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10957,7 +10957,7 @@
     >
       <div
         aria-label="July 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10971,7 +10971,7 @@
     >
       <div
         aria-label="August 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10985,7 +10985,7 @@
     >
       <div
         aria-label="September 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -10999,7 +10999,7 @@
     >
       <div
         aria-label="October 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11018,7 +11018,7 @@
     >
       <div
         aria-label="November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11032,7 +11032,7 @@
     >
       <div
         aria-label="December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11047,7 +11047,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11063,7 +11063,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11138,7 +11138,7 @@
     >
       <div
         aria-label="November 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -11153,7 +11153,7 @@
     >
       <div
         aria-label="December 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11167,7 +11167,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11181,7 +11181,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11200,7 +11200,7 @@
     >
       <div
         aria-label="March 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11214,7 +11214,7 @@
     >
       <div
         aria-label="April 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11228,7 +11228,7 @@
     >
       <div
         aria-label="May 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11242,7 +11242,7 @@
     >
       <div
         aria-label="June 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11261,7 +11261,7 @@
     >
       <div
         aria-label="July 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11275,7 +11275,7 @@
     >
       <div
         aria-label="August 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11289,7 +11289,7 @@
     >
       <div
         aria-label="September 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11303,7 +11303,7 @@
     >
       <div
         aria-label="October 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11322,7 +11322,7 @@
     >
       <div
         aria-label="November 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11336,7 +11336,7 @@
     >
       <div
         aria-label="December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11351,7 +11351,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11367,7 +11367,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11442,7 +11442,7 @@
     >
       <div
         aria-label="November 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -11457,7 +11457,7 @@
     >
       <div
         aria-label="December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11471,7 +11471,7 @@
     >
       <div
         aria-label="January 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11485,7 +11485,7 @@
     >
       <div
         aria-label="February 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11504,7 +11504,7 @@
     >
       <div
         aria-label="March 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11518,7 +11518,7 @@
     >
       <div
         aria-label="April 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11532,7 +11532,7 @@
     >
       <div
         aria-label="May 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11546,7 +11546,7 @@
     >
       <div
         aria-label="June 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11565,7 +11565,7 @@
     >
       <div
         aria-label="July 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11579,7 +11579,7 @@
     >
       <div
         aria-label="August 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11593,7 +11593,7 @@
     >
       <div
         aria-label="September 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11607,7 +11607,7 @@
     >
       <div
         aria-label="October 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11626,7 +11626,7 @@
     >
       <div
         aria-label="November 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11640,7 +11640,7 @@
     >
       <div
         aria-label="December 1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11655,7 +11655,7 @@
     >
       <div
         aria-label="January 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11671,7 +11671,7 @@
     >
       <div
         aria-label="February 2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11749,7 +11749,7 @@
     >
       <div
         aria-label="1968"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -11763,7 +11763,7 @@
     >
       <div
         aria-label="1969"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11777,7 +11777,7 @@
     >
       <div
         aria-label="1970"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11791,7 +11791,7 @@
     >
       <div
         aria-label="1971"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11810,7 +11810,7 @@
     >
       <div
         aria-label="1972"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11824,7 +11824,7 @@
     >
       <div
         aria-label="1973"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11838,7 +11838,7 @@
     >
       <div
         aria-label="1974"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11852,7 +11852,7 @@
     >
       <div
         aria-label="1975"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11871,7 +11871,7 @@
     >
       <div
         aria-label="1976"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11885,7 +11885,7 @@
     >
       <div
         aria-label="1977"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11899,7 +11899,7 @@
     >
       <div
         aria-label="1978"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11913,7 +11913,7 @@
     >
       <div
         aria-label="1979"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11932,7 +11932,7 @@
     >
       <div
         aria-label="1980"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11946,7 +11946,7 @@
     >
       <div
         aria-label="1981"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11960,7 +11960,7 @@
     >
       <div
         aria-label="1982"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -11975,7 +11975,7 @@
     >
       <div
         aria-label="1983"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12049,7 +12049,7 @@
     >
       <div
         aria-label="1952"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -12063,7 +12063,7 @@
     >
       <div
         aria-label="1953"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12077,7 +12077,7 @@
     >
       <div
         aria-label="1954"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12091,7 +12091,7 @@
     >
       <div
         aria-label="1955"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12110,7 +12110,7 @@
     >
       <div
         aria-label="1956"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12124,7 +12124,7 @@
     >
       <div
         aria-label="1957"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12138,7 +12138,7 @@
     >
       <div
         aria-label="1958"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12152,7 +12152,7 @@
     >
       <div
         aria-label="1959"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12171,7 +12171,7 @@
     >
       <div
         aria-label="1960"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12185,7 +12185,7 @@
     >
       <div
         aria-label="1961"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12199,7 +12199,7 @@
     >
       <div
         aria-label="1962"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12213,7 +12213,7 @@
     >
       <div
         aria-label="1963"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12232,7 +12232,7 @@
     >
       <div
         aria-label="1964"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12246,7 +12246,7 @@
     >
       <div
         aria-label="1965"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12260,7 +12260,7 @@
     >
       <div
         aria-label="1966"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12275,7 +12275,7 @@
     >
       <div
         aria-label="1967"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12349,7 +12349,7 @@
     >
       <div
         aria-label="1936"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -12363,7 +12363,7 @@
     >
       <div
         aria-label="1937"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12377,7 +12377,7 @@
     >
       <div
         aria-label="1938"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12391,7 +12391,7 @@
     >
       <div
         aria-label="1939"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12410,7 +12410,7 @@
     >
       <div
         aria-label="1940"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12424,7 +12424,7 @@
     >
       <div
         aria-label="1941"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12438,7 +12438,7 @@
     >
       <div
         aria-label="1942"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12452,7 +12452,7 @@
     >
       <div
         aria-label="1943"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12471,7 +12471,7 @@
     >
       <div
         aria-label="1944"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12485,7 +12485,7 @@
     >
       <div
         aria-label="1945"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12499,7 +12499,7 @@
     >
       <div
         aria-label="1946"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12513,7 +12513,7 @@
     >
       <div
         aria-label="1947"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12532,7 +12532,7 @@
     >
       <div
         aria-label="1948"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12546,7 +12546,7 @@
     >
       <div
         aria-label="1949"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12560,7 +12560,7 @@
     >
       <div
         aria-label="1950"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12575,7 +12575,7 @@
     >
       <div
         aria-label="1951"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12651,7 +12651,7 @@
     >
       <div
         aria-label="1888"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -12665,7 +12665,7 @@
     >
       <div
         aria-label="1889"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12679,7 +12679,7 @@
     >
       <div
         aria-label="1890"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12693,7 +12693,7 @@
     >
       <div
         aria-label="1891"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12712,7 +12712,7 @@
     >
       <div
         aria-label="1892"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12726,7 +12726,7 @@
     >
       <div
         aria-label="1893"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12740,7 +12740,7 @@
     >
       <div
         aria-label="1894"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12754,7 +12754,7 @@
     >
       <div
         aria-label="1895"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12773,7 +12773,7 @@
     >
       <div
         aria-label="1896"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12787,7 +12787,7 @@
     >
       <div
         aria-label="1897"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12801,7 +12801,7 @@
     >
       <div
         aria-label="1898"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12815,7 +12815,7 @@
     >
       <div
         aria-label="1899"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12834,7 +12834,7 @@
     >
       <div
         aria-label="1900"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12848,7 +12848,7 @@
     >
       <div
         aria-label="1901"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12862,7 +12862,7 @@
     >
       <div
         aria-label="1902"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12877,7 +12877,7 @@
     >
       <div
         aria-label="1903"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12951,7 +12951,7 @@
     >
       <div
         aria-label="1904"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -12965,7 +12965,7 @@
     >
       <div
         aria-label="1905"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12979,7 +12979,7 @@
     >
       <div
         aria-label="1906"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -12993,7 +12993,7 @@
     >
       <div
         aria-label="1907"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13012,7 +13012,7 @@
     >
       <div
         aria-label="1908"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13026,7 +13026,7 @@
     >
       <div
         aria-label="1909"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13040,7 +13040,7 @@
     >
       <div
         aria-label="1910"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13054,7 +13054,7 @@
     >
       <div
         aria-label="1911"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13073,7 +13073,7 @@
     >
       <div
         aria-label="1912"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13087,7 +13087,7 @@
     >
       <div
         aria-label="1913"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13101,7 +13101,7 @@
     >
       <div
         aria-label="1914"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13115,7 +13115,7 @@
     >
       <div
         aria-label="1915"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13134,7 +13134,7 @@
     >
       <div
         aria-label="1916"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13148,7 +13148,7 @@
     >
       <div
         aria-label="1917"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13162,7 +13162,7 @@
     >
       <div
         aria-label="1918"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13177,7 +13177,7 @@
     >
       <div
         aria-label="1919"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13251,7 +13251,7 @@
     >
       <div
         aria-label="1920"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -13265,7 +13265,7 @@
     >
       <div
         aria-label="1921"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13279,7 +13279,7 @@
     >
       <div
         aria-label="1922"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13293,7 +13293,7 @@
     >
       <div
         aria-label="1923"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13312,7 +13312,7 @@
     >
       <div
         aria-label="1924"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13326,7 +13326,7 @@
     >
       <div
         aria-label="1925"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13340,7 +13340,7 @@
     >
       <div
         aria-label="1926"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13354,7 +13354,7 @@
     >
       <div
         aria-label="1927"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13373,7 +13373,7 @@
     >
       <div
         aria-label="1928"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13387,7 +13387,7 @@
     >
       <div
         aria-label="1929"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13401,7 +13401,7 @@
     >
       <div
         aria-label="1930"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13415,7 +13415,7 @@
     >
       <div
         aria-label="1931"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13434,7 +13434,7 @@
     >
       <div
         aria-label="1932"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13448,7 +13448,7 @@
     >
       <div
         aria-label="1933"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13462,7 +13462,7 @@
     >
       <div
         aria-label="1934"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13477,7 +13477,7 @@
     >
       <div
         aria-label="1935"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13555,7 +13555,7 @@
     >
       <div
         aria-label="16"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -13569,7 +13569,7 @@
     >
       <div
         aria-label="17"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13583,7 +13583,7 @@
     >
       <div
         aria-label="18"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13597,7 +13597,7 @@
     >
       <div
         aria-label="19"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13616,7 +13616,7 @@
     >
       <div
         aria-label="20"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13630,7 +13630,7 @@
     >
       <div
         aria-label="21"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13644,7 +13644,7 @@
     >
       <div
         aria-label="22"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13658,7 +13658,7 @@
     >
       <div
         aria-label="23"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13677,7 +13677,7 @@
     >
       <div
         aria-label="24"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13691,7 +13691,7 @@
     >
       <div
         aria-label="25"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13705,7 +13705,7 @@
     >
       <div
         aria-label="26"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13719,7 +13719,7 @@
     >
       <div
         aria-label="27"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13738,7 +13738,7 @@
     >
       <div
         aria-label="28"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13752,7 +13752,7 @@
     >
       <div
         aria-label="29"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13766,7 +13766,7 @@
     >
       <div
         aria-label="30"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13781,7 +13781,7 @@
     >
       <div
         aria-label="31"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13855,7 +13855,7 @@
     >
       <div
         aria-label="1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -13869,7 +13869,7 @@
     >
       <div
         aria-label="1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13883,7 +13883,7 @@
     >
       <div
         aria-label="2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13897,7 +13897,7 @@
     >
       <div
         aria-label="3"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13916,7 +13916,7 @@
     >
       <div
         aria-label="4"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13930,7 +13930,7 @@
     >
       <div
         aria-label="5"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13944,7 +13944,7 @@
     >
       <div
         aria-label="6"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13958,7 +13958,7 @@
     >
       <div
         aria-label="7"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13977,7 +13977,7 @@
     >
       <div
         aria-label="8"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -13991,7 +13991,7 @@
     >
       <div
         aria-label="9"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14005,7 +14005,7 @@
     >
       <div
         aria-label="10"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14019,7 +14019,7 @@
     >
       <div
         aria-label="11"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14038,7 +14038,7 @@
     >
       <div
         aria-label="12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14052,7 +14052,7 @@
     >
       <div
         aria-label="13"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14066,7 +14066,7 @@
     >
       <div
         aria-label="14"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14081,7 +14081,7 @@
     >
       <div
         aria-label="15"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14155,7 +14155,7 @@
     >
       <div
         aria-label="17"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -14169,7 +14169,7 @@
     >
       <div
         aria-label="16"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14183,7 +14183,7 @@
     >
       <div
         aria-label="15"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14197,7 +14197,7 @@
     >
       <div
         aria-label="14"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14216,7 +14216,7 @@
     >
       <div
         aria-label="13"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14230,7 +14230,7 @@
     >
       <div
         aria-label="12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14244,7 +14244,7 @@
     >
       <div
         aria-label="11"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14258,7 +14258,7 @@
     >
       <div
         aria-label="10"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14277,7 +14277,7 @@
     >
       <div
         aria-label="9"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14291,7 +14291,7 @@
     >
       <div
         aria-label="8"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14305,7 +14305,7 @@
     >
       <div
         aria-label="7"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14319,7 +14319,7 @@
     >
       <div
         aria-label="6"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14338,7 +14338,7 @@
     >
       <div
         aria-label="5"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14352,7 +14352,7 @@
     >
       <div
         aria-label="4"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14366,7 +14366,7 @@
     >
       <div
         aria-label="3"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14381,7 +14381,7 @@
     >
       <div
         aria-label="2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14457,7 +14457,7 @@
     >
       <div
         aria-label="17"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -14471,7 +14471,7 @@
     >
       <div
         aria-label="16"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14485,7 +14485,7 @@
     >
       <div
         aria-label="15"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14499,7 +14499,7 @@
     >
       <div
         aria-label="14"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14518,7 +14518,7 @@
     >
       <div
         aria-label="13"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14532,7 +14532,7 @@
     >
       <div
         aria-label="12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14546,7 +14546,7 @@
     >
       <div
         aria-label="11"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14560,7 +14560,7 @@
     >
       <div
         aria-label="10"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14579,7 +14579,7 @@
     >
       <div
         aria-label="9"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14593,7 +14593,7 @@
     >
       <div
         aria-label="8"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14607,7 +14607,7 @@
     >
       <div
         aria-label="7"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14621,7 +14621,7 @@
     >
       <div
         aria-label="6"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14640,7 +14640,7 @@
     >
       <div
         aria-label="5"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14654,7 +14654,7 @@
     >
       <div
         aria-label="4"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14668,7 +14668,7 @@
     >
       <div
         aria-label="3"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14683,7 +14683,7 @@
     >
       <div
         aria-label="2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14757,7 +14757,7 @@
     >
       <div
         aria-label="1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -14771,7 +14771,7 @@
     >
       <div
         aria-label="1"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14785,7 +14785,7 @@
     >
       <div
         aria-label="2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14799,7 +14799,7 @@
     >
       <div
         aria-label="3"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14818,7 +14818,7 @@
     >
       <div
         aria-label="4"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14832,7 +14832,7 @@
     >
       <div
         aria-label="5"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14846,7 +14846,7 @@
     >
       <div
         aria-label="6"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14860,7 +14860,7 @@
     >
       <div
         aria-label="7"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14879,7 +14879,7 @@
     >
       <div
         aria-label="8"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14893,7 +14893,7 @@
     >
       <div
         aria-label="9"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14907,7 +14907,7 @@
     >
       <div
         aria-label="10"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14921,7 +14921,7 @@
     >
       <div
         aria-label="11"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14940,7 +14940,7 @@
     >
       <div
         aria-label="12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14954,7 +14954,7 @@
     >
       <div
         aria-label="13"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14968,7 +14968,7 @@
     >
       <div
         aria-label="14"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -14983,7 +14983,7 @@
     >
       <div
         aria-label="15"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15057,7 +15057,7 @@
     >
       <div
         aria-label="16"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -15071,7 +15071,7 @@
     >
       <div
         aria-label="17"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15085,7 +15085,7 @@
     >
       <div
         aria-label="18"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15099,7 +15099,7 @@
     >
       <div
         aria-label="19"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15118,7 +15118,7 @@
     >
       <div
         aria-label="20"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15132,7 +15132,7 @@
     >
       <div
         aria-label="21"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15146,7 +15146,7 @@
     >
       <div
         aria-label="22"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15160,7 +15160,7 @@
     >
       <div
         aria-label="23"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15179,7 +15179,7 @@
     >
       <div
         aria-label="24"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15193,7 +15193,7 @@
     >
       <div
         aria-label="25"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15207,7 +15207,7 @@
     >
       <div
         aria-label="26"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15221,7 +15221,7 @@
     >
       <div
         aria-label="27"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15240,7 +15240,7 @@
     >
       <div
         aria-label="28"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15254,7 +15254,7 @@
     >
       <div
         aria-label="29"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15268,7 +15268,7 @@
     >
       <div
         aria-label="30"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15283,7 +15283,7 @@
     >
       <div
         aria-label="31"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15464,7 +15464,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -15478,7 +15478,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15492,7 +15492,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15511,7 +15511,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15525,7 +15525,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15539,7 +15539,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15553,7 +15553,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15567,7 +15567,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15581,7 +15581,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15595,7 +15595,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15614,7 +15614,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15628,7 +15628,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15642,7 +15642,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15656,7 +15656,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15670,7 +15670,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15684,7 +15684,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15698,7 +15698,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15717,7 +15717,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15731,7 +15731,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15745,7 +15745,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15759,7 +15759,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15773,7 +15773,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15787,7 +15787,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15801,7 +15801,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15820,7 +15820,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15834,7 +15834,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15848,7 +15848,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15862,7 +15862,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15876,7 +15876,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -15891,7 +15891,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16026,7 +16026,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -16040,7 +16040,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16054,7 +16054,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16068,7 +16068,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16087,7 +16087,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16101,7 +16101,7 @@
     >
       <div
         aria-label="2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16115,7 +16115,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16129,7 +16129,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16148,7 +16148,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16162,7 +16162,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16176,7 +16176,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16190,7 +16190,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16209,7 +16209,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16223,7 +16223,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16237,7 +16237,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16252,7 +16252,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16429,7 +16429,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -16443,7 +16443,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16457,7 +16457,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16476,7 +16476,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16490,7 +16490,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16504,7 +16504,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16518,7 +16518,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16532,7 +16532,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16546,7 +16546,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16560,7 +16560,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16579,7 +16579,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16593,7 +16593,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16607,7 +16607,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16621,7 +16621,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16635,7 +16635,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16649,7 +16649,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16663,7 +16663,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16682,7 +16682,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16696,7 +16696,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16710,7 +16710,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16724,7 +16724,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16738,7 +16738,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16752,7 +16752,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16766,7 +16766,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16785,7 +16785,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16799,7 +16799,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16813,7 +16813,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16827,7 +16827,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16841,7 +16841,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16856,7 +16856,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -16992,7 +16992,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -17007,7 +17007,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17021,7 +17021,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17035,7 +17035,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17054,7 +17054,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17068,7 +17068,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17082,7 +17082,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17096,7 +17096,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17115,7 +17115,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17129,7 +17129,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17143,7 +17143,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17157,7 +17157,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17176,7 +17176,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17190,7 +17190,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17205,7 +17205,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17221,7 +17221,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17398,7 +17398,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -17412,7 +17412,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17426,7 +17426,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17445,7 +17445,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17459,7 +17459,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17473,7 +17473,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17487,7 +17487,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17501,7 +17501,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17515,7 +17515,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17529,7 +17529,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17548,7 +17548,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17562,7 +17562,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17576,7 +17576,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17590,7 +17590,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17604,7 +17604,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17618,7 +17618,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17632,7 +17632,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17651,7 +17651,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17665,7 +17665,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17679,7 +17679,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17693,7 +17693,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17707,7 +17707,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17721,7 +17721,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17735,7 +17735,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17754,7 +17754,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17768,7 +17768,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17782,7 +17782,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17796,7 +17796,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17810,7 +17810,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17825,7 +17825,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17964,7 +17964,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -17978,7 +17978,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -17992,7 +17992,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18006,7 +18006,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18025,7 +18025,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18039,7 +18039,7 @@
     >
       <div
         aria-label="2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18053,7 +18053,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18067,7 +18067,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18086,7 +18086,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18100,7 +18100,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18114,7 +18114,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18128,7 +18128,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18147,7 +18147,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18161,7 +18161,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18175,7 +18175,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18190,7 +18190,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18265,7 +18265,7 @@
     >
       <div
         aria-label="November 2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -18280,7 +18280,7 @@
     >
       <div
         aria-label="December 2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18294,7 +18294,7 @@
     >
       <div
         aria-label="January 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18308,7 +18308,7 @@
     >
       <div
         aria-label="February 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18327,7 +18327,7 @@
     >
       <div
         aria-label="March 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18341,7 +18341,7 @@
     >
       <div
         aria-label="April 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18355,7 +18355,7 @@
     >
       <div
         aria-label="May 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18369,7 +18369,7 @@
     >
       <div
         aria-label="June 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18388,7 +18388,7 @@
     >
       <div
         aria-label="July 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18402,7 +18402,7 @@
     >
       <div
         aria-label="August 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18416,7 +18416,7 @@
     >
       <div
         aria-label="September 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18430,7 +18430,7 @@
     >
       <div
         aria-label="October 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18449,7 +18449,7 @@
     >
       <div
         aria-label="November 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18463,7 +18463,7 @@
     >
       <div
         aria-label="December 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18478,7 +18478,7 @@
     >
       <div
         aria-label="January 2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18494,7 +18494,7 @@
     >
       <div
         aria-label="February 2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18569,7 +18569,7 @@
     >
       <div
         aria-label="November 2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -18584,7 +18584,7 @@
     >
       <div
         aria-label="December 2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18598,7 +18598,7 @@
     >
       <div
         aria-label="January 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18612,7 +18612,7 @@
     >
       <div
         aria-label="February 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18631,7 +18631,7 @@
     >
       <div
         aria-label="March 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18645,7 +18645,7 @@
     >
       <div
         aria-label="April 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18659,7 +18659,7 @@
     >
       <div
         aria-label="May 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18673,7 +18673,7 @@
     >
       <div
         aria-label="June 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18692,7 +18692,7 @@
     >
       <div
         aria-label="July 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18706,7 +18706,7 @@
     >
       <div
         aria-label="August 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18720,7 +18720,7 @@
     >
       <div
         aria-label="September 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18734,7 +18734,7 @@
     >
       <div
         aria-label="October 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18753,7 +18753,7 @@
     >
       <div
         aria-label="November 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18767,7 +18767,7 @@
     >
       <div
         aria-label="December 2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18782,7 +18782,7 @@
     >
       <div
         aria-label="January 2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18798,7 +18798,7 @@
     >
       <div
         aria-label="February 2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18875,7 +18875,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -18890,7 +18890,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18904,7 +18904,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18918,7 +18918,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18937,7 +18937,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18951,7 +18951,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18965,7 +18965,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18979,7 +18979,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -18998,7 +18998,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19012,7 +19012,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19026,7 +19026,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19040,7 +19040,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19059,7 +19059,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19073,7 +19073,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19088,7 +19088,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19104,7 +19104,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19181,7 +19181,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -19196,7 +19196,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19210,7 +19210,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19224,7 +19224,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19243,7 +19243,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19257,7 +19257,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19271,7 +19271,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19285,7 +19285,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19304,7 +19304,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19318,7 +19318,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19332,7 +19332,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19346,7 +19346,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19365,7 +19365,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19379,7 +19379,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19394,7 +19394,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19410,7 +19410,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19591,7 +19591,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -19605,7 +19605,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19619,7 +19619,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19638,7 +19638,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19652,7 +19652,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19666,7 +19666,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19680,7 +19680,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19694,7 +19694,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19708,7 +19708,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19722,7 +19722,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19741,7 +19741,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19755,7 +19755,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19769,7 +19769,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19783,7 +19783,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19797,7 +19797,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19811,7 +19811,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19825,7 +19825,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19844,7 +19844,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19858,7 +19858,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19872,7 +19872,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19886,7 +19886,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19900,7 +19900,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19914,7 +19914,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19928,7 +19928,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19947,7 +19947,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19961,7 +19961,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19975,7 +19975,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -19989,7 +19989,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20003,7 +20003,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20018,7 +20018,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20258,7 +20258,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -20272,7 +20272,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20286,7 +20286,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20305,7 +20305,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20319,7 +20319,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20333,7 +20333,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20347,7 +20347,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20361,7 +20361,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20375,7 +20375,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20389,7 +20389,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20408,7 +20408,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20422,7 +20422,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20436,7 +20436,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20450,7 +20450,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20464,7 +20464,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20478,7 +20478,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20492,7 +20492,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20511,7 +20511,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20525,7 +20525,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20539,7 +20539,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20553,7 +20553,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20567,7 +20567,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20581,7 +20581,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20595,7 +20595,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20614,7 +20614,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20628,7 +20628,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20642,7 +20642,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20656,7 +20656,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20670,7 +20670,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20685,7 +20685,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20927,7 +20927,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -20941,7 +20941,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20955,7 +20955,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20974,7 +20974,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -20988,7 +20988,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21002,7 +21002,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21016,7 +21016,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21030,7 +21030,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21044,7 +21044,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21058,7 +21058,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21077,7 +21077,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21091,7 +21091,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21105,7 +21105,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21119,7 +21119,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21133,7 +21133,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21147,7 +21147,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21161,7 +21161,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21180,7 +21180,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21194,7 +21194,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21208,7 +21208,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21222,7 +21222,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21236,7 +21236,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21250,7 +21250,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21264,7 +21264,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21283,7 +21283,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21297,7 +21297,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21311,7 +21311,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21325,7 +21325,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21339,7 +21339,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21354,7 +21354,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21592,7 +21592,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -21606,7 +21606,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21620,7 +21620,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21639,7 +21639,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21653,7 +21653,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21667,7 +21667,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21681,7 +21681,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21695,7 +21695,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21709,7 +21709,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21723,7 +21723,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21742,7 +21742,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21756,7 +21756,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21770,7 +21770,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21784,7 +21784,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21798,7 +21798,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21812,7 +21812,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21826,7 +21826,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21845,7 +21845,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21859,7 +21859,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21873,7 +21873,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21887,7 +21887,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21901,7 +21901,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21915,7 +21915,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21929,7 +21929,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21948,7 +21948,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21962,7 +21962,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21976,7 +21976,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -21990,7 +21990,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -22004,7 +22004,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -22019,7 +22019,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >

--- a/packages/elements/src/calendar/__snapshots__/Range.md
+++ b/packages/elements/src/calendar/__snapshots__/Range.md
@@ -168,7 +168,7 @@
     >
       <div
         aria-label="Selected: Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -182,7 +182,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -196,7 +196,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -215,7 +215,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -229,7 +229,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -243,7 +243,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -257,7 +257,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -271,7 +271,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -285,7 +285,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -299,7 +299,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -318,7 +318,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -332,7 +332,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -346,7 +346,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -360,7 +360,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -374,7 +374,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -388,7 +388,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -402,7 +402,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -421,7 +421,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -435,7 +435,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -449,7 +449,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -463,7 +463,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -477,7 +477,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -491,7 +491,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -505,7 +505,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -524,7 +524,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -538,7 +538,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -552,7 +552,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -566,7 +566,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -580,7 +580,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -595,7 +595,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -730,7 +730,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -745,7 +745,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -759,7 +759,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -773,7 +773,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -792,7 +792,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -810,7 +810,7 @@
     >
       <div
         aria-label="Selected: April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -824,7 +824,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -838,7 +838,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -857,7 +857,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -871,7 +871,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -885,7 +885,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -899,7 +899,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -918,7 +918,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -932,7 +932,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -947,7 +947,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -963,7 +963,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1036,7 +1036,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1050,7 +1050,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1064,7 +1064,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1078,7 +1078,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1097,7 +1097,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1115,7 +1115,7 @@
     >
       <div
         aria-label="Selected: 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -1129,7 +1129,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1143,7 +1143,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1162,7 +1162,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1176,7 +1176,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1190,7 +1190,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1204,7 +1204,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1223,7 +1223,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1237,7 +1237,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1251,7 +1251,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1266,7 +1266,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1446,7 +1446,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -1461,7 +1461,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1476,7 +1476,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1496,7 +1496,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1511,7 +1511,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1526,7 +1526,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1541,7 +1541,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1556,7 +1556,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1571,7 +1571,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1586,7 +1586,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1606,7 +1606,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1621,7 +1621,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1636,7 +1636,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1651,7 +1651,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1666,7 +1666,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1681,7 +1681,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1696,7 +1696,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1716,7 +1716,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1731,7 +1731,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1746,7 +1746,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1761,7 +1761,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1776,7 +1776,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1791,7 +1791,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1806,7 +1806,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1826,7 +1826,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1841,7 +1841,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1856,7 +1856,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1871,7 +1871,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1886,7 +1886,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1902,7 +1902,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2037,7 +2037,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2052,7 +2052,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2066,7 +2066,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2080,7 +2080,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2102,7 +2102,7 @@
     >
       <div
         aria-label="Selected: March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -2117,7 +2117,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2132,7 +2132,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2147,7 +2147,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2167,7 +2167,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2182,7 +2182,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2197,7 +2197,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2212,7 +2212,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2232,7 +2232,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2247,7 +2247,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2263,7 +2263,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2280,7 +2280,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2353,7 +2353,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2367,7 +2367,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2381,7 +2381,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2395,7 +2395,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2414,7 +2414,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2431,7 +2431,7 @@
     >
       <div
         aria-label="Selected: 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -2446,7 +2446,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2461,7 +2461,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2481,7 +2481,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2497,7 +2497,7 @@
     >
       <div
         aria-label="Selected: 2009"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2511,7 +2511,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2525,7 +2525,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2544,7 +2544,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2558,7 +2558,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2572,7 +2572,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2587,7 +2587,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2772,7 +2772,7 @@
     >
       <div
         aria-label="Saturday, 1 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2786,7 +2786,7 @@
     >
       <div
         aria-label="Sunday, 2 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2805,7 +2805,7 @@
     >
       <div
         aria-label="Monday, 3 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2822,7 +2822,7 @@
     >
       <div
         aria-label="Selected: Tuesday, 4 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -2837,7 +2837,7 @@
     >
       <div
         aria-label="Wednesday, 5 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2852,7 +2852,7 @@
     >
       <div
         aria-label="Thursday, 6 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2867,7 +2867,7 @@
     >
       <div
         aria-label="Friday, 7 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2882,7 +2882,7 @@
     >
       <div
         aria-label="Saturday, 8 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2897,7 +2897,7 @@
     >
       <div
         aria-label="Sunday, 9 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2917,7 +2917,7 @@
     >
       <div
         aria-label="Monday, 10 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2932,7 +2932,7 @@
     >
       <div
         aria-label="Tuesday, 11 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2947,7 +2947,7 @@
     >
       <div
         aria-label="Wednesday, 12 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2962,7 +2962,7 @@
     >
       <div
         aria-label="Thursday, 13 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2977,7 +2977,7 @@
     >
       <div
         aria-label="Friday, 14 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2992,7 +2992,7 @@
     >
       <div
         aria-label="Saturday, 15 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3007,7 +3007,7 @@
     >
       <div
         aria-label="Sunday, 16 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3027,7 +3027,7 @@
     >
       <div
         aria-label="Monday, 17 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3042,7 +3042,7 @@
     >
       <div
         aria-label="Tuesday, 18 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3057,7 +3057,7 @@
     >
       <div
         aria-label="Wednesday, 19 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3072,7 +3072,7 @@
     >
       <div
         aria-label="Thursday, 20 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3088,7 +3088,7 @@
     >
       <div
         aria-label="Selected: Friday, 21 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3102,7 +3102,7 @@
     >
       <div
         aria-label="Saturday, 22 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3116,7 +3116,7 @@
     >
       <div
         aria-label="Sunday, 23 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3135,7 +3135,7 @@
     >
       <div
         aria-label="Monday, 24 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3149,7 +3149,7 @@
     >
       <div
         aria-label="Tuesday, 25 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3163,7 +3163,7 @@
     >
       <div
         aria-label="Wednesday, 26 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3177,7 +3177,7 @@
     >
       <div
         aria-label="Thursday, 27 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3191,7 +3191,7 @@
     >
       <div
         aria-label="Friday, 28 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3205,7 +3205,7 @@
     >
       <div
         aria-label="Saturday, 29 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3220,7 +3220,7 @@
     >
       <div
         aria-label="Sunday, 30 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3348,7 +3348,7 @@
     >
       <div
         aria-label="November 13"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3363,7 +3363,7 @@
     >
       <div
         aria-label="December 13"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3377,7 +3377,7 @@
     >
       <div
         aria-label="January 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3391,7 +3391,7 @@
     >
       <div
         aria-label="February 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3410,7 +3410,7 @@
     >
       <div
         aria-label="March 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3428,7 +3428,7 @@
     >
       <div
         aria-label="Selected: April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -3442,7 +3442,7 @@
     >
       <div
         aria-label="May 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3456,7 +3456,7 @@
     >
       <div
         aria-label="June 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3475,7 +3475,7 @@
     >
       <div
         aria-label="July 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3489,7 +3489,7 @@
     >
       <div
         aria-label="August 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3503,7 +3503,7 @@
     >
       <div
         aria-label="September 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3517,7 +3517,7 @@
     >
       <div
         aria-label="October 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3536,7 +3536,7 @@
     >
       <div
         aria-label="November 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3550,7 +3550,7 @@
     >
       <div
         aria-label="December 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3565,7 +3565,7 @@
     >
       <div
         aria-label="January 11"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3581,7 +3581,7 @@
     >
       <div
         aria-label="February 11"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3654,7 +3654,7 @@
     >
       <div
         aria-label="17"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3668,7 +3668,7 @@
     >
       <div
         aria-label="16"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3682,7 +3682,7 @@
     >
       <div
         aria-label="15"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3696,7 +3696,7 @@
     >
       <div
         aria-label="14"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3715,7 +3715,7 @@
     >
       <div
         aria-label="13"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3733,7 +3733,7 @@
     >
       <div
         aria-label="Selected: 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -3747,7 +3747,7 @@
     >
       <div
         aria-label="11"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3761,7 +3761,7 @@
     >
       <div
         aria-label="10"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3780,7 +3780,7 @@
     >
       <div
         aria-label="9"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3794,7 +3794,7 @@
     >
       <div
         aria-label="8"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3808,7 +3808,7 @@
     >
       <div
         aria-label="7"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3822,7 +3822,7 @@
     >
       <div
         aria-label="6"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3841,7 +3841,7 @@
     >
       <div
         aria-label="5"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3855,7 +3855,7 @@
     >
       <div
         aria-label="4"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3869,7 +3869,7 @@
     >
       <div
         aria-label="3"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3884,7 +3884,7 @@
     >
       <div
         aria-label="2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4064,7 +4064,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4078,7 +4078,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4092,7 +4092,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4111,7 +4111,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4125,7 +4125,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4141,7 +4141,7 @@
     >
       <div
         aria-label="Selected: Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -4155,7 +4155,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4169,7 +4169,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4183,7 +4183,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4197,7 +4197,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4216,7 +4216,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4230,7 +4230,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4244,7 +4244,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4258,7 +4258,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4272,7 +4272,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4286,7 +4286,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4300,7 +4300,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4319,7 +4319,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4333,7 +4333,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4347,7 +4347,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4361,7 +4361,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4375,7 +4375,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4389,7 +4389,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4403,7 +4403,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4422,7 +4422,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4436,7 +4436,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4450,7 +4450,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4464,7 +4464,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4478,7 +4478,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4493,7 +4493,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4730,7 +4730,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4744,7 +4744,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4758,7 +4758,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4777,7 +4777,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4791,7 +4791,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4807,7 +4807,7 @@
     >
       <div
         aria-label="Selected: Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4822,7 +4822,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4837,7 +4837,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4852,7 +4852,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4869,7 +4869,7 @@
     >
       <div
         aria-label="Selected: Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -4888,7 +4888,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4902,7 +4902,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4916,7 +4916,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4930,7 +4930,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4944,7 +4944,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4958,7 +4958,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4972,7 +4972,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4991,7 +4991,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5005,7 +5005,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5019,7 +5019,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5033,7 +5033,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5047,7 +5047,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5061,7 +5061,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5075,7 +5075,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5094,7 +5094,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5108,7 +5108,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5122,7 +5122,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5136,7 +5136,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5150,7 +5150,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5165,7 +5165,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5402,7 +5402,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5416,7 +5416,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5430,7 +5430,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5449,7 +5449,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5463,7 +5463,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5477,7 +5477,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5491,7 +5491,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5505,7 +5505,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5519,7 +5519,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5533,7 +5533,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5552,7 +5552,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5566,7 +5566,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5582,7 +5582,7 @@
     >
       <div
         aria-label="Selected: Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -5596,7 +5596,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5610,7 +5610,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5624,7 +5624,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5638,7 +5638,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5657,7 +5657,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5671,7 +5671,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5685,7 +5685,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5699,7 +5699,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5713,7 +5713,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5727,7 +5727,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5741,7 +5741,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5760,7 +5760,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5774,7 +5774,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5788,7 +5788,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5802,7 +5802,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5816,7 +5816,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5831,7 +5831,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6068,7 +6068,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6082,7 +6082,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6096,7 +6096,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6115,7 +6115,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6129,7 +6129,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6143,7 +6143,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6157,7 +6157,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6171,7 +6171,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6185,7 +6185,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6199,7 +6199,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6218,7 +6218,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6234,7 +6234,7 @@
     >
       <div
         aria-label="Selected: Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -6248,7 +6248,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6262,7 +6262,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6276,7 +6276,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6290,7 +6290,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6304,7 +6304,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6323,7 +6323,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6337,7 +6337,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6351,7 +6351,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6365,7 +6365,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6379,7 +6379,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6393,7 +6393,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6407,7 +6407,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6426,7 +6426,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6440,7 +6440,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6454,7 +6454,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6468,7 +6468,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6482,7 +6482,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6497,7 +6497,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6749,7 +6749,7 @@
     >
       <div
         aria-label="Sunday, 1 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -6768,7 +6768,7 @@
     >
       <div
         aria-label="Monday, 2 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6782,7 +6782,7 @@
     >
       <div
         aria-label="Tuesday, 3 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6796,7 +6796,7 @@
     >
       <div
         aria-label="Wednesday, 4 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6810,7 +6810,7 @@
     >
       <div
         aria-label="Thursday, 5 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6824,7 +6824,7 @@
     >
       <div
         aria-label="Friday, 6 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6838,7 +6838,7 @@
     >
       <div
         aria-label="Saturday, 7 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6852,7 +6852,7 @@
     >
       <div
         aria-label="Sunday, 8 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6871,7 +6871,7 @@
     >
       <div
         aria-label="Monday, 9 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6885,7 +6885,7 @@
     >
       <div
         aria-label="Tuesday, 10 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6899,7 +6899,7 @@
     >
       <div
         aria-label="Wednesday, 11 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6913,7 +6913,7 @@
     >
       <div
         aria-label="Thursday, 12 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6927,7 +6927,7 @@
     >
       <div
         aria-label="Friday, 13 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6941,7 +6941,7 @@
     >
       <div
         aria-label="Saturday, 14 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6955,7 +6955,7 @@
     >
       <div
         aria-label="Sunday, 15 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6974,7 +6974,7 @@
     >
       <div
         aria-label="Monday, 16 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -6988,7 +6988,7 @@
     >
       <div
         aria-label="Tuesday, 17 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7002,7 +7002,7 @@
     >
       <div
         aria-label="Wednesday, 18 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7016,7 +7016,7 @@
     >
       <div
         aria-label="Thursday, 19 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7030,7 +7030,7 @@
     >
       <div
         aria-label="Friday, 20 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7044,7 +7044,7 @@
     >
       <div
         aria-label="Saturday, 21 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7058,7 +7058,7 @@
     >
       <div
         aria-label="Sunday, 22 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7077,7 +7077,7 @@
     >
       <div
         aria-label="Monday, 23 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7091,7 +7091,7 @@
     >
       <div
         aria-label="Tuesday, 24 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7105,7 +7105,7 @@
     >
       <div
         aria-label="Wednesday, 25 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7119,7 +7119,7 @@
     >
       <div
         aria-label="Thursday, 26 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7133,7 +7133,7 @@
     >
       <div
         aria-label="Friday, 27 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7147,7 +7147,7 @@
     >
       <div
         aria-label="Saturday, 28 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7161,7 +7161,7 @@
     >
       <div
         aria-label="Sunday, 29 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7180,7 +7180,7 @@
     >
       <div
         aria-label="Monday, 30 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -7195,7 +7195,7 @@
     >
       <div
         aria-label="Tuesday, 31 May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >

--- a/packages/elements/src/calendar/__snapshots__/Range.md
+++ b/packages/elements/src/calendar/__snapshots__/Range.md
@@ -168,7 +168,7 @@
     >
       <div
         aria-label="Selected: Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -182,7 +182,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -196,7 +196,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -215,7 +215,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -229,7 +229,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -243,7 +243,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -257,7 +257,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -271,7 +271,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -285,7 +285,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -299,7 +299,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -318,7 +318,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -332,7 +332,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -346,7 +346,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -360,7 +360,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -374,7 +374,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -388,7 +388,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -402,7 +402,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -421,7 +421,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -435,7 +435,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -449,7 +449,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -463,7 +463,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -477,7 +477,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -491,7 +491,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -505,7 +505,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -524,7 +524,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -538,7 +538,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -552,7 +552,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -566,7 +566,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -580,7 +580,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -595,7 +595,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -730,7 +730,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -745,7 +745,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -759,7 +759,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -773,7 +773,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -792,7 +792,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -810,7 +810,7 @@
     >
       <div
         aria-label="Selected: April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -824,7 +824,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -838,7 +838,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -857,7 +857,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -871,7 +871,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -885,7 +885,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -899,7 +899,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -918,7 +918,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -932,7 +932,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -947,7 +947,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -963,7 +963,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1036,7 +1036,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1050,7 +1050,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1064,7 +1064,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1078,7 +1078,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1097,7 +1097,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1115,7 +1115,7 @@
     >
       <div
         aria-label="Selected: 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -1129,7 +1129,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1143,7 +1143,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1162,7 +1162,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1176,7 +1176,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1190,7 +1190,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1204,7 +1204,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1223,7 +1223,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1237,7 +1237,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1251,7 +1251,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1266,7 +1266,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1446,7 +1446,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -1461,7 +1461,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1476,7 +1476,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1496,7 +1496,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1511,7 +1511,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1526,7 +1526,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1541,7 +1541,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1556,7 +1556,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1571,7 +1571,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1586,7 +1586,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1606,7 +1606,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1621,7 +1621,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1636,7 +1636,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1651,7 +1651,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1666,7 +1666,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1681,7 +1681,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1696,7 +1696,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1716,7 +1716,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1731,7 +1731,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1746,7 +1746,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1761,7 +1761,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1776,7 +1776,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1791,7 +1791,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1806,7 +1806,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1826,7 +1826,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1841,7 +1841,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1856,7 +1856,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1871,7 +1871,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1886,7 +1886,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1902,7 +1902,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2037,7 +2037,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2052,7 +2052,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2066,7 +2066,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2080,7 +2080,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2102,7 +2102,7 @@
     >
       <div
         aria-label="Selected: March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -2117,7 +2117,7 @@
     >
       <div
         aria-label="April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2132,7 +2132,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2147,7 +2147,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2167,7 +2167,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2182,7 +2182,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2197,7 +2197,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2212,7 +2212,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2232,7 +2232,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2247,7 +2247,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2263,7 +2263,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2280,7 +2280,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2353,7 +2353,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2367,7 +2367,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2381,7 +2381,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2395,7 +2395,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2414,7 +2414,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2431,7 +2431,7 @@
     >
       <div
         aria-label="Selected: 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -2446,7 +2446,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2461,7 +2461,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2481,7 +2481,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2497,7 +2497,7 @@
     >
       <div
         aria-label="Selected: 2009"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2511,7 +2511,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2525,7 +2525,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2544,7 +2544,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2558,7 +2558,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2572,7 +2572,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2587,7 +2587,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2772,7 +2772,7 @@
     >
       <div
         aria-label="Saturday, 1 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2786,7 +2786,7 @@
     >
       <div
         aria-label="Sunday, 2 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2805,7 +2805,7 @@
     >
       <div
         aria-label="Monday, 3 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2822,7 +2822,7 @@
     >
       <div
         aria-label="Selected: Tuesday, 4 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -2837,7 +2837,7 @@
     >
       <div
         aria-label="Wednesday, 5 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2852,7 +2852,7 @@
     >
       <div
         aria-label="Thursday, 6 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2867,7 +2867,7 @@
     >
       <div
         aria-label="Friday, 7 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2882,7 +2882,7 @@
     >
       <div
         aria-label="Saturday, 8 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2897,7 +2897,7 @@
     >
       <div
         aria-label="Sunday, 9 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2917,7 +2917,7 @@
     >
       <div
         aria-label="Monday, 10 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2932,7 +2932,7 @@
     >
       <div
         aria-label="Tuesday, 11 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2947,7 +2947,7 @@
     >
       <div
         aria-label="Wednesday, 12 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2962,7 +2962,7 @@
     >
       <div
         aria-label="Thursday, 13 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2977,7 +2977,7 @@
     >
       <div
         aria-label="Friday, 14 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2992,7 +2992,7 @@
     >
       <div
         aria-label="Saturday, 15 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3007,7 +3007,7 @@
     >
       <div
         aria-label="Sunday, 16 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3027,7 +3027,7 @@
     >
       <div
         aria-label="Monday, 17 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3042,7 +3042,7 @@
     >
       <div
         aria-label="Tuesday, 18 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3057,7 +3057,7 @@
     >
       <div
         aria-label="Wednesday, 19 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3072,7 +3072,7 @@
     >
       <div
         aria-label="Thursday, 20 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3088,7 +3088,7 @@
     >
       <div
         aria-label="Selected: Friday, 21 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3102,7 +3102,7 @@
     >
       <div
         aria-label="Saturday, 22 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3116,7 +3116,7 @@
     >
       <div
         aria-label="Sunday, 23 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3135,7 +3135,7 @@
     >
       <div
         aria-label="Monday, 24 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3149,7 +3149,7 @@
     >
       <div
         aria-label="Tuesday, 25 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3163,7 +3163,7 @@
     >
       <div
         aria-label="Wednesday, 26 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3177,7 +3177,7 @@
     >
       <div
         aria-label="Thursday, 27 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3191,7 +3191,7 @@
     >
       <div
         aria-label="Friday, 28 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3205,7 +3205,7 @@
     >
       <div
         aria-label="Saturday, 29 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3220,7 +3220,7 @@
     >
       <div
         aria-label="Sunday, 30 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3348,7 +3348,7 @@
     >
       <div
         aria-label="November 13"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3363,7 +3363,7 @@
     >
       <div
         aria-label="December 13"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3377,7 +3377,7 @@
     >
       <div
         aria-label="January 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3391,7 +3391,7 @@
     >
       <div
         aria-label="February 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3410,7 +3410,7 @@
     >
       <div
         aria-label="March 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3428,7 +3428,7 @@
     >
       <div
         aria-label="Selected: April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -3442,7 +3442,7 @@
     >
       <div
         aria-label="May 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3456,7 +3456,7 @@
     >
       <div
         aria-label="June 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3475,7 +3475,7 @@
     >
       <div
         aria-label="July 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3489,7 +3489,7 @@
     >
       <div
         aria-label="August 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3503,7 +3503,7 @@
     >
       <div
         aria-label="September 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3517,7 +3517,7 @@
     >
       <div
         aria-label="October 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3536,7 +3536,7 @@
     >
       <div
         aria-label="November 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3550,7 +3550,7 @@
     >
       <div
         aria-label="December 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3565,7 +3565,7 @@
     >
       <div
         aria-label="January 11"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3581,7 +3581,7 @@
     >
       <div
         aria-label="February 11"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3654,7 +3654,7 @@
     >
       <div
         aria-label="17"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3668,7 +3668,7 @@
     >
       <div
         aria-label="16"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3682,7 +3682,7 @@
     >
       <div
         aria-label="15"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3696,7 +3696,7 @@
     >
       <div
         aria-label="14"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3715,7 +3715,7 @@
     >
       <div
         aria-label="13"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3733,7 +3733,7 @@
     >
       <div
         aria-label="Selected: 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -3747,7 +3747,7 @@
     >
       <div
         aria-label="11"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3761,7 +3761,7 @@
     >
       <div
         aria-label="10"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3780,7 +3780,7 @@
     >
       <div
         aria-label="9"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3794,7 +3794,7 @@
     >
       <div
         aria-label="8"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3808,7 +3808,7 @@
     >
       <div
         aria-label="7"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3822,7 +3822,7 @@
     >
       <div
         aria-label="6"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3841,7 +3841,7 @@
     >
       <div
         aria-label="5"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3855,7 +3855,7 @@
     >
       <div
         aria-label="4"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3869,7 +3869,7 @@
     >
       <div
         aria-label="3"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3884,7 +3884,7 @@
     >
       <div
         aria-label="2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4064,7 +4064,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4078,7 +4078,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4092,7 +4092,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4111,7 +4111,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4125,7 +4125,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4141,7 +4141,7 @@
     >
       <div
         aria-label="Selected: Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -4155,7 +4155,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4169,7 +4169,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4183,7 +4183,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4197,7 +4197,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4216,7 +4216,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4230,7 +4230,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4244,7 +4244,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4258,7 +4258,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4272,7 +4272,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4286,7 +4286,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4300,7 +4300,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4319,7 +4319,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4333,7 +4333,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4347,7 +4347,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4361,7 +4361,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4375,7 +4375,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4389,7 +4389,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4403,7 +4403,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4422,7 +4422,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4436,7 +4436,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4450,7 +4450,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4464,7 +4464,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4478,7 +4478,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4493,7 +4493,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4730,7 +4730,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4744,7 +4744,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4758,7 +4758,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4777,7 +4777,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4791,7 +4791,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4807,7 +4807,7 @@
     >
       <div
         aria-label="Selected: Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4822,7 +4822,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4837,7 +4837,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4852,7 +4852,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4869,7 +4869,7 @@
     >
       <div
         aria-label="Selected: Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -4888,7 +4888,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4902,7 +4902,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4916,7 +4916,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4930,7 +4930,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4944,7 +4944,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4958,7 +4958,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4972,7 +4972,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4991,7 +4991,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5005,7 +5005,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5019,7 +5019,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5033,7 +5033,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5047,7 +5047,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5061,7 +5061,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5075,7 +5075,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5094,7 +5094,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5108,7 +5108,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5122,7 +5122,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5136,7 +5136,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5150,7 +5150,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5165,7 +5165,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5402,7 +5402,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5416,7 +5416,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5430,7 +5430,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5449,7 +5449,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5463,7 +5463,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5477,7 +5477,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5491,7 +5491,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5505,7 +5505,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5519,7 +5519,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5533,7 +5533,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5552,7 +5552,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5566,7 +5566,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5582,7 +5582,7 @@
     >
       <div
         aria-label="Selected: Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -5596,7 +5596,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5610,7 +5610,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5624,7 +5624,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5638,7 +5638,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5657,7 +5657,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5671,7 +5671,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5685,7 +5685,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5699,7 +5699,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5713,7 +5713,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5727,7 +5727,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5741,7 +5741,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5760,7 +5760,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5774,7 +5774,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5788,7 +5788,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5802,7 +5802,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5816,7 +5816,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5831,7 +5831,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6068,7 +6068,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6082,7 +6082,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6096,7 +6096,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6115,7 +6115,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6129,7 +6129,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6143,7 +6143,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6157,7 +6157,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6171,7 +6171,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6185,7 +6185,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6199,7 +6199,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6218,7 +6218,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6234,7 +6234,7 @@
     >
       <div
         aria-label="Selected: Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -6248,7 +6248,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6262,7 +6262,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6276,7 +6276,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6290,7 +6290,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6304,7 +6304,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6323,7 +6323,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6337,7 +6337,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6351,7 +6351,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6365,7 +6365,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6379,7 +6379,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6393,7 +6393,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6407,7 +6407,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6426,7 +6426,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6440,7 +6440,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6454,7 +6454,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6468,7 +6468,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6482,7 +6482,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6497,7 +6497,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6749,7 +6749,7 @@
     >
       <div
         aria-label="Sunday, 1 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -6768,7 +6768,7 @@
     >
       <div
         aria-label="Monday, 2 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6782,7 +6782,7 @@
     >
       <div
         aria-label="Tuesday, 3 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6796,7 +6796,7 @@
     >
       <div
         aria-label="Wednesday, 4 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6810,7 +6810,7 @@
     >
       <div
         aria-label="Thursday, 5 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6824,7 +6824,7 @@
     >
       <div
         aria-label="Friday, 6 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6838,7 +6838,7 @@
     >
       <div
         aria-label="Saturday, 7 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6852,7 +6852,7 @@
     >
       <div
         aria-label="Sunday, 8 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6871,7 +6871,7 @@
     >
       <div
         aria-label="Monday, 9 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6885,7 +6885,7 @@
     >
       <div
         aria-label="Tuesday, 10 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6899,7 +6899,7 @@
     >
       <div
         aria-label="Wednesday, 11 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6913,7 +6913,7 @@
     >
       <div
         aria-label="Thursday, 12 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6927,7 +6927,7 @@
     >
       <div
         aria-label="Friday, 13 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6941,7 +6941,7 @@
     >
       <div
         aria-label="Saturday, 14 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6955,7 +6955,7 @@
     >
       <div
         aria-label="Sunday, 15 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6974,7 +6974,7 @@
     >
       <div
         aria-label="Monday, 16 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -6988,7 +6988,7 @@
     >
       <div
         aria-label="Tuesday, 17 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7002,7 +7002,7 @@
     >
       <div
         aria-label="Wednesday, 18 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7016,7 +7016,7 @@
     >
       <div
         aria-label="Thursday, 19 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7030,7 +7030,7 @@
     >
       <div
         aria-label="Friday, 20 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7044,7 +7044,7 @@
     >
       <div
         aria-label="Saturday, 21 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7058,7 +7058,7 @@
     >
       <div
         aria-label="Sunday, 22 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7077,7 +7077,7 @@
     >
       <div
         aria-label="Monday, 23 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7091,7 +7091,7 @@
     >
       <div
         aria-label="Tuesday, 24 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7105,7 +7105,7 @@
     >
       <div
         aria-label="Wednesday, 25 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7119,7 +7119,7 @@
     >
       <div
         aria-label="Thursday, 26 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7133,7 +7133,7 @@
     >
       <div
         aria-label="Friday, 27 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7147,7 +7147,7 @@
     >
       <div
         aria-label="Saturday, 28 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7161,7 +7161,7 @@
     >
       <div
         aria-label="Sunday, 29 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7180,7 +7180,7 @@
     >
       <div
         aria-label="Monday, 30 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -7195,7 +7195,7 @@
     >
       <div
         aria-label="Tuesday, 31 May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >

--- a/packages/elements/src/calendar/__snapshots__/Value.md
+++ b/packages/elements/src/calendar/__snapshots__/Value.md
@@ -164,7 +164,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -178,7 +178,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -192,7 +192,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -211,7 +211,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -225,7 +225,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -239,7 +239,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -253,7 +253,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -267,7 +267,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -281,7 +281,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -295,7 +295,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -314,7 +314,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -328,7 +328,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -342,7 +342,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -356,7 +356,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -370,7 +370,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -384,7 +384,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -398,7 +398,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -417,7 +417,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -431,7 +431,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -445,7 +445,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -461,7 +461,7 @@
     >
       <div
         aria-label="Selected: Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -475,7 +475,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -489,7 +489,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -503,7 +503,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -522,7 +522,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -536,7 +536,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -550,7 +550,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -564,7 +564,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -578,7 +578,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -593,7 +593,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -728,7 +728,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -743,7 +743,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -757,7 +757,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -771,7 +771,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -790,7 +790,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -806,7 +806,7 @@
     >
       <div
         aria-label="Selected: April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -820,7 +820,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -834,7 +834,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -853,7 +853,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -867,7 +867,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -881,7 +881,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -895,7 +895,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -914,7 +914,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -928,7 +928,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -943,7 +943,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -959,7 +959,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1032,7 +1032,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1046,7 +1046,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1060,7 +1060,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1074,7 +1074,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1093,7 +1093,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1109,7 +1109,7 @@
     >
       <div
         aria-label="Selected: 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -1123,7 +1123,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1137,7 +1137,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1156,7 +1156,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1170,7 +1170,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1184,7 +1184,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1198,7 +1198,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1217,7 +1217,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1231,7 +1231,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1245,7 +1245,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1260,7 +1260,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1438,7 +1438,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1452,7 +1452,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1466,7 +1466,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1485,7 +1485,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1499,7 +1499,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1513,7 +1513,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1527,7 +1527,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1541,7 +1541,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1555,7 +1555,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1569,7 +1569,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1588,7 +1588,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1602,7 +1602,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1616,7 +1616,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1630,7 +1630,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1644,7 +1644,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1658,7 +1658,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1672,7 +1672,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1691,7 +1691,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1705,7 +1705,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1719,7 +1719,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1735,7 +1735,7 @@
     >
       <div
         aria-label="Selected: Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -1749,7 +1749,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1763,7 +1763,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1777,7 +1777,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1796,7 +1796,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1810,7 +1810,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1824,7 +1824,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1838,7 +1838,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1852,7 +1852,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -1867,7 +1867,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2113,7 +2113,7 @@
     >
       <div
         aria-label="Saturday, 1 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2127,7 +2127,7 @@
     >
       <div
         aria-label="Sunday, 2 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2146,7 +2146,7 @@
     >
       <div
         aria-label="Monday, 3 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2160,7 +2160,7 @@
     >
       <div
         aria-label="Tuesday, 4 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2174,7 +2174,7 @@
     >
       <div
         aria-label="Wednesday, 5 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2188,7 +2188,7 @@
     >
       <div
         aria-label="Thursday, 6 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2202,7 +2202,7 @@
     >
       <div
         aria-label="Friday, 7 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2216,7 +2216,7 @@
     >
       <div
         aria-label="Saturday, 8 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2230,7 +2230,7 @@
     >
       <div
         aria-label="Sunday, 9 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2249,7 +2249,7 @@
     >
       <div
         aria-label="Monday, 10 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2263,7 +2263,7 @@
     >
       <div
         aria-label="Tuesday, 11 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2277,7 +2277,7 @@
     >
       <div
         aria-label="Wednesday, 12 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2291,7 +2291,7 @@
     >
       <div
         aria-label="Thursday, 13 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2305,7 +2305,7 @@
     >
       <div
         aria-label="Friday, 14 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2319,7 +2319,7 @@
     >
       <div
         aria-label="Saturday, 15 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2333,7 +2333,7 @@
     >
       <div
         aria-label="Sunday, 16 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2352,7 +2352,7 @@
     >
       <div
         aria-label="Monday, 17 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2366,7 +2366,7 @@
     >
       <div
         aria-label="Tuesday, 18 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2380,7 +2380,7 @@
     >
       <div
         aria-label="Wednesday, 19 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2394,7 +2394,7 @@
     >
       <div
         aria-label="Thursday, 20 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2410,7 +2410,7 @@
     >
       <div
         aria-label="Selected: Friday, 21 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -2424,7 +2424,7 @@
     >
       <div
         aria-label="Saturday, 22 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2438,7 +2438,7 @@
     >
       <div
         aria-label="Sunday, 23 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2457,7 +2457,7 @@
     >
       <div
         aria-label="Monday, 24 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2471,7 +2471,7 @@
     >
       <div
         aria-label="Tuesday, 25 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2485,7 +2485,7 @@
     >
       <div
         aria-label="Wednesday, 26 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2499,7 +2499,7 @@
     >
       <div
         aria-label="Thursday, 27 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2513,7 +2513,7 @@
     >
       <div
         aria-label="Friday, 28 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2527,7 +2527,7 @@
     >
       <div
         aria-label="Saturday, 29 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2542,7 +2542,7 @@
     >
       <div
         aria-label="Sunday, 30 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2670,7 +2670,7 @@
     >
       <div
         aria-label="November 13"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2685,7 +2685,7 @@
     >
       <div
         aria-label="December 13"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2699,7 +2699,7 @@
     >
       <div
         aria-label="January 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2713,7 +2713,7 @@
     >
       <div
         aria-label="February 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2732,7 +2732,7 @@
     >
       <div
         aria-label="March 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2748,7 +2748,7 @@
     >
       <div
         aria-label="Selected: April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -2762,7 +2762,7 @@
     >
       <div
         aria-label="May 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2776,7 +2776,7 @@
     >
       <div
         aria-label="June 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2795,7 +2795,7 @@
     >
       <div
         aria-label="July 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2809,7 +2809,7 @@
     >
       <div
         aria-label="August 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2823,7 +2823,7 @@
     >
       <div
         aria-label="September 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2837,7 +2837,7 @@
     >
       <div
         aria-label="October 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2856,7 +2856,7 @@
     >
       <div
         aria-label="November 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2870,7 +2870,7 @@
     >
       <div
         aria-label="December 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2885,7 +2885,7 @@
     >
       <div
         aria-label="January 11"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2901,7 +2901,7 @@
     >
       <div
         aria-label="February 11"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2974,7 +2974,7 @@
     >
       <div
         aria-label="17"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -2988,7 +2988,7 @@
     >
       <div
         aria-label="16"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3002,7 +3002,7 @@
     >
       <div
         aria-label="15"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3016,7 +3016,7 @@
     >
       <div
         aria-label="14"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3035,7 +3035,7 @@
     >
       <div
         aria-label="13"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3051,7 +3051,7 @@
     >
       <div
         aria-label="Selected: 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -3065,7 +3065,7 @@
     >
       <div
         aria-label="11"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3079,7 +3079,7 @@
     >
       <div
         aria-label="10"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3098,7 +3098,7 @@
     >
       <div
         aria-label="9"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3112,7 +3112,7 @@
     >
       <div
         aria-label="8"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3126,7 +3126,7 @@
     >
       <div
         aria-label="7"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3140,7 +3140,7 @@
     >
       <div
         aria-label="6"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3159,7 +3159,7 @@
     >
       <div
         aria-label="5"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3173,7 +3173,7 @@
     >
       <div
         aria-label="4"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3187,7 +3187,7 @@
     >
       <div
         aria-label="3"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3202,7 +3202,7 @@
     >
       <div
         aria-label="2"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3384,7 +3384,7 @@
     >
       <div
         aria-label="Selected: Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -3398,7 +3398,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3412,7 +3412,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3431,7 +3431,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3445,7 +3445,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3459,7 +3459,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3473,7 +3473,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3487,7 +3487,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3501,7 +3501,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3515,7 +3515,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3534,7 +3534,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3548,7 +3548,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3562,7 +3562,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3576,7 +3576,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3590,7 +3590,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3604,7 +3604,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3618,7 +3618,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3637,7 +3637,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3651,7 +3651,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3665,7 +3665,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3679,7 +3679,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3693,7 +3693,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3707,7 +3707,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3721,7 +3721,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3740,7 +3740,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3754,7 +3754,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3768,7 +3768,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3782,7 +3782,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3796,7 +3796,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -3811,7 +3811,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4048,7 +4048,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4062,7 +4062,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4076,7 +4076,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4095,7 +4095,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4109,7 +4109,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4123,7 +4123,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4137,7 +4137,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4151,7 +4151,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4165,7 +4165,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4179,7 +4179,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4198,7 +4198,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4212,7 +4212,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4226,7 +4226,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4240,7 +4240,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4254,7 +4254,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4268,7 +4268,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4282,7 +4282,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4301,7 +4301,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4315,7 +4315,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4329,7 +4329,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4343,7 +4343,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4357,7 +4357,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4371,7 +4371,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4385,7 +4385,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4404,7 +4404,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4418,7 +4418,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4432,7 +4432,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4446,7 +4446,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4460,7 +4460,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4477,7 +4477,7 @@
     >
       <div
         aria-label="Selected: Saturday, 30 April 2005"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -4725,7 +4725,7 @@
     >
       <div
         aria-label="Selected: Saturday, 1 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >
@@ -4739,7 +4739,7 @@
     >
       <div
         aria-label="Sunday, 2 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4758,7 +4758,7 @@
     >
       <div
         aria-label="Monday, 3 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4772,7 +4772,7 @@
     >
       <div
         aria-label="Tuesday, 4 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4786,7 +4786,7 @@
     >
       <div
         aria-label="Wednesday, 5 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4800,7 +4800,7 @@
     >
       <div
         aria-label="Thursday, 6 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4814,7 +4814,7 @@
     >
       <div
         aria-label="Friday, 7 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4828,7 +4828,7 @@
     >
       <div
         aria-label="Saturday, 8 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4842,7 +4842,7 @@
     >
       <div
         aria-label="Sunday, 9 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4861,7 +4861,7 @@
     >
       <div
         aria-label="Monday, 10 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4875,7 +4875,7 @@
     >
       <div
         aria-label="Tuesday, 11 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4889,7 +4889,7 @@
     >
       <div
         aria-label="Wednesday, 12 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4903,7 +4903,7 @@
     >
       <div
         aria-label="Thursday, 13 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4917,7 +4917,7 @@
     >
       <div
         aria-label="Friday, 14 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4931,7 +4931,7 @@
     >
       <div
         aria-label="Saturday, 15 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4945,7 +4945,7 @@
     >
       <div
         aria-label="Sunday, 16 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4964,7 +4964,7 @@
     >
       <div
         aria-label="Monday, 17 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4978,7 +4978,7 @@
     >
       <div
         aria-label="Tuesday, 18 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -4992,7 +4992,7 @@
     >
       <div
         aria-label="Wednesday, 19 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5006,7 +5006,7 @@
     >
       <div
         aria-label="Thursday, 20 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5020,7 +5020,7 @@
     >
       <div
         aria-label="Friday, 21 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5034,7 +5034,7 @@
     >
       <div
         aria-label="Saturday, 22 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5048,7 +5048,7 @@
     >
       <div
         aria-label="Sunday, 23 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5067,7 +5067,7 @@
     >
       <div
         aria-label="Monday, 24 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5081,7 +5081,7 @@
     >
       <div
         aria-label="Tuesday, 25 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5095,7 +5095,7 @@
     >
       <div
         aria-label="Wednesday, 26 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5109,7 +5109,7 @@
     >
       <div
         aria-label="Thursday, 27 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5123,7 +5123,7 @@
     >
       <div
         aria-label="Friday, 28 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5137,7 +5137,7 @@
     >
       <div
         aria-label="Saturday, 29 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5152,7 +5152,7 @@
     >
       <div
         aria-label="Sunday, 30 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5389,7 +5389,7 @@
     >
       <div
         aria-label="Saturday, 1 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5403,7 +5403,7 @@
     >
       <div
         aria-label="Sunday, 2 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5422,7 +5422,7 @@
     >
       <div
         aria-label="Monday, 3 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5436,7 +5436,7 @@
     >
       <div
         aria-label="Tuesday, 4 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5450,7 +5450,7 @@
     >
       <div
         aria-label="Wednesday, 5 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5464,7 +5464,7 @@
     >
       <div
         aria-label="Thursday, 6 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5478,7 +5478,7 @@
     >
       <div
         aria-label="Friday, 7 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5492,7 +5492,7 @@
     >
       <div
         aria-label="Saturday, 8 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5506,7 +5506,7 @@
     >
       <div
         aria-label="Sunday, 9 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5525,7 +5525,7 @@
     >
       <div
         aria-label="Monday, 10 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5539,7 +5539,7 @@
     >
       <div
         aria-label="Tuesday, 11 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5553,7 +5553,7 @@
     >
       <div
         aria-label="Wednesday, 12 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5567,7 +5567,7 @@
     >
       <div
         aria-label="Thursday, 13 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5581,7 +5581,7 @@
     >
       <div
         aria-label="Friday, 14 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5595,7 +5595,7 @@
     >
       <div
         aria-label="Saturday, 15 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5609,7 +5609,7 @@
     >
       <div
         aria-label="Sunday, 16 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5628,7 +5628,7 @@
     >
       <div
         aria-label="Monday, 17 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5642,7 +5642,7 @@
     >
       <div
         aria-label="Tuesday, 18 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5656,7 +5656,7 @@
     >
       <div
         aria-label="Wednesday, 19 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5670,7 +5670,7 @@
     >
       <div
         aria-label="Thursday, 20 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5684,7 +5684,7 @@
     >
       <div
         aria-label="Friday, 21 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5698,7 +5698,7 @@
     >
       <div
         aria-label="Saturday, 22 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5712,7 +5712,7 @@
     >
       <div
         aria-label="Sunday, 23 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5731,7 +5731,7 @@
     >
       <div
         aria-label="Monday, 24 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5745,7 +5745,7 @@
     >
       <div
         aria-label="Tuesday, 25 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5759,7 +5759,7 @@
     >
       <div
         aria-label="Wednesday, 26 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5773,7 +5773,7 @@
     >
       <div
         aria-label="Thursday, 27 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5787,7 +5787,7 @@
     >
       <div
         aria-label="Friday, 28 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5801,7 +5801,7 @@
     >
       <div
         aria-label="Saturday, 29 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="-1"
       >
@@ -5818,7 +5818,7 @@
     >
       <div
         aria-label="Selected: Sunday, 30 April 12"
-        part="cell-content selection"
+        part="cell-content selection selection-selectable"
         role="button"
         tabindex="0"
       >

--- a/packages/elements/src/calendar/__snapshots__/Value.md
+++ b/packages/elements/src/calendar/__snapshots__/Value.md
@@ -164,7 +164,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -178,7 +178,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -192,7 +192,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -211,7 +211,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -225,7 +225,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -239,7 +239,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -253,7 +253,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -267,7 +267,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -281,7 +281,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -295,7 +295,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -314,7 +314,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -328,7 +328,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -342,7 +342,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -356,7 +356,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -370,7 +370,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -384,7 +384,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -398,7 +398,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -417,7 +417,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -431,7 +431,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -445,7 +445,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -461,7 +461,7 @@
     >
       <div
         aria-label="Selected: Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -475,7 +475,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -489,7 +489,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -503,7 +503,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -522,7 +522,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -536,7 +536,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -550,7 +550,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -564,7 +564,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -578,7 +578,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -593,7 +593,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -728,7 +728,7 @@
     >
       <div
         aria-label="November 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -743,7 +743,7 @@
     >
       <div
         aria-label="December 2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -757,7 +757,7 @@
     >
       <div
         aria-label="January 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -771,7 +771,7 @@
     >
       <div
         aria-label="February 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -790,7 +790,7 @@
     >
       <div
         aria-label="March 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -806,7 +806,7 @@
     >
       <div
         aria-label="Selected: April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -820,7 +820,7 @@
     >
       <div
         aria-label="May 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -834,7 +834,7 @@
     >
       <div
         aria-label="June 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -853,7 +853,7 @@
     >
       <div
         aria-label="July 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -867,7 +867,7 @@
     >
       <div
         aria-label="August 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -881,7 +881,7 @@
     >
       <div
         aria-label="September 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -895,7 +895,7 @@
     >
       <div
         aria-label="October 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -914,7 +914,7 @@
     >
       <div
         aria-label="November 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -928,7 +928,7 @@
     >
       <div
         aria-label="December 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -943,7 +943,7 @@
     >
       <div
         aria-label="January 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -959,7 +959,7 @@
     >
       <div
         aria-label="February 2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1032,7 +1032,7 @@
     >
       <div
         aria-label="2000"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1046,7 +1046,7 @@
     >
       <div
         aria-label="2001"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1060,7 +1060,7 @@
     >
       <div
         aria-label="2002"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1074,7 +1074,7 @@
     >
       <div
         aria-label="2003"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1093,7 +1093,7 @@
     >
       <div
         aria-label="2004"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1109,7 +1109,7 @@
     >
       <div
         aria-label="Selected: 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -1123,7 +1123,7 @@
     >
       <div
         aria-label="2006"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1137,7 +1137,7 @@
     >
       <div
         aria-label="2007"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1156,7 +1156,7 @@
     >
       <div
         aria-label="2008"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1170,7 +1170,7 @@
     >
       <div
         aria-label="2009"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1184,7 +1184,7 @@
     >
       <div
         aria-label="2010"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1198,7 +1198,7 @@
     >
       <div
         aria-label="2011"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1217,7 +1217,7 @@
     >
       <div
         aria-label="2012"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1231,7 +1231,7 @@
     >
       <div
         aria-label="2013"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1245,7 +1245,7 @@
     >
       <div
         aria-label="2014"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1260,7 +1260,7 @@
     >
       <div
         aria-label="2015"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1438,7 +1438,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1452,7 +1452,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1466,7 +1466,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1485,7 +1485,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1499,7 +1499,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1513,7 +1513,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1527,7 +1527,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1541,7 +1541,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1555,7 +1555,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1569,7 +1569,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1588,7 +1588,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1602,7 +1602,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1616,7 +1616,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1630,7 +1630,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1644,7 +1644,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1658,7 +1658,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1672,7 +1672,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1691,7 +1691,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1705,7 +1705,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1719,7 +1719,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1735,7 +1735,7 @@
     >
       <div
         aria-label="Selected: Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -1749,7 +1749,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1763,7 +1763,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1777,7 +1777,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1796,7 +1796,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1810,7 +1810,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1824,7 +1824,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1838,7 +1838,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1852,7 +1852,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -1867,7 +1867,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2113,7 +2113,7 @@
     >
       <div
         aria-label="Saturday, 1 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2127,7 +2127,7 @@
     >
       <div
         aria-label="Sunday, 2 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2146,7 +2146,7 @@
     >
       <div
         aria-label="Monday, 3 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2160,7 +2160,7 @@
     >
       <div
         aria-label="Tuesday, 4 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2174,7 +2174,7 @@
     >
       <div
         aria-label="Wednesday, 5 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2188,7 +2188,7 @@
     >
       <div
         aria-label="Thursday, 6 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2202,7 +2202,7 @@
     >
       <div
         aria-label="Friday, 7 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2216,7 +2216,7 @@
     >
       <div
         aria-label="Saturday, 8 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2230,7 +2230,7 @@
     >
       <div
         aria-label="Sunday, 9 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2249,7 +2249,7 @@
     >
       <div
         aria-label="Monday, 10 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2263,7 +2263,7 @@
     >
       <div
         aria-label="Tuesday, 11 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2277,7 +2277,7 @@
     >
       <div
         aria-label="Wednesday, 12 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2291,7 +2291,7 @@
     >
       <div
         aria-label="Thursday, 13 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2305,7 +2305,7 @@
     >
       <div
         aria-label="Friday, 14 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2319,7 +2319,7 @@
     >
       <div
         aria-label="Saturday, 15 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2333,7 +2333,7 @@
     >
       <div
         aria-label="Sunday, 16 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2352,7 +2352,7 @@
     >
       <div
         aria-label="Monday, 17 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2366,7 +2366,7 @@
     >
       <div
         aria-label="Tuesday, 18 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2380,7 +2380,7 @@
     >
       <div
         aria-label="Wednesday, 19 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2394,7 +2394,7 @@
     >
       <div
         aria-label="Thursday, 20 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2410,7 +2410,7 @@
     >
       <div
         aria-label="Selected: Friday, 21 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -2424,7 +2424,7 @@
     >
       <div
         aria-label="Saturday, 22 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2438,7 +2438,7 @@
     >
       <div
         aria-label="Sunday, 23 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2457,7 +2457,7 @@
     >
       <div
         aria-label="Monday, 24 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2471,7 +2471,7 @@
     >
       <div
         aria-label="Tuesday, 25 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2485,7 +2485,7 @@
     >
       <div
         aria-label="Wednesday, 26 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2499,7 +2499,7 @@
     >
       <div
         aria-label="Thursday, 27 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2513,7 +2513,7 @@
     >
       <div
         aria-label="Friday, 28 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2527,7 +2527,7 @@
     >
       <div
         aria-label="Saturday, 29 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2542,7 +2542,7 @@
     >
       <div
         aria-label="Sunday, 30 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2670,7 +2670,7 @@
     >
       <div
         aria-label="November 13"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2685,7 +2685,7 @@
     >
       <div
         aria-label="December 13"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2699,7 +2699,7 @@
     >
       <div
         aria-label="January 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2713,7 +2713,7 @@
     >
       <div
         aria-label="February 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2732,7 +2732,7 @@
     >
       <div
         aria-label="March 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2748,7 +2748,7 @@
     >
       <div
         aria-label="Selected: April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -2762,7 +2762,7 @@
     >
       <div
         aria-label="May 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2776,7 +2776,7 @@
     >
       <div
         aria-label="June 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2795,7 +2795,7 @@
     >
       <div
         aria-label="July 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2809,7 +2809,7 @@
     >
       <div
         aria-label="August 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2823,7 +2823,7 @@
     >
       <div
         aria-label="September 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2837,7 +2837,7 @@
     >
       <div
         aria-label="October 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2856,7 +2856,7 @@
     >
       <div
         aria-label="November 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2870,7 +2870,7 @@
     >
       <div
         aria-label="December 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2885,7 +2885,7 @@
     >
       <div
         aria-label="January 11"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2901,7 +2901,7 @@
     >
       <div
         aria-label="February 11"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2974,7 +2974,7 @@
     >
       <div
         aria-label="17"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -2988,7 +2988,7 @@
     >
       <div
         aria-label="16"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3002,7 +3002,7 @@
     >
       <div
         aria-label="15"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3016,7 +3016,7 @@
     >
       <div
         aria-label="14"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3035,7 +3035,7 @@
     >
       <div
         aria-label="13"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3051,7 +3051,7 @@
     >
       <div
         aria-label="Selected: 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -3065,7 +3065,7 @@
     >
       <div
         aria-label="11"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3079,7 +3079,7 @@
     >
       <div
         aria-label="10"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3098,7 +3098,7 @@
     >
       <div
         aria-label="9"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3112,7 +3112,7 @@
     >
       <div
         aria-label="8"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3126,7 +3126,7 @@
     >
       <div
         aria-label="7"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3140,7 +3140,7 @@
     >
       <div
         aria-label="6"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3159,7 +3159,7 @@
     >
       <div
         aria-label="5"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3173,7 +3173,7 @@
     >
       <div
         aria-label="4"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3187,7 +3187,7 @@
     >
       <div
         aria-label="3"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3202,7 +3202,7 @@
     >
       <div
         aria-label="2"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3384,7 +3384,7 @@
     >
       <div
         aria-label="Selected: Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -3398,7 +3398,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3412,7 +3412,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3431,7 +3431,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3445,7 +3445,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3459,7 +3459,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3473,7 +3473,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3487,7 +3487,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3501,7 +3501,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3515,7 +3515,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3534,7 +3534,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3548,7 +3548,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3562,7 +3562,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3576,7 +3576,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3590,7 +3590,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3604,7 +3604,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3618,7 +3618,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3637,7 +3637,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3651,7 +3651,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3665,7 +3665,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3679,7 +3679,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3693,7 +3693,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3707,7 +3707,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3721,7 +3721,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3740,7 +3740,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3754,7 +3754,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3768,7 +3768,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3782,7 +3782,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3796,7 +3796,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -3811,7 +3811,7 @@
     >
       <div
         aria-label="Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4048,7 +4048,7 @@
     >
       <div
         aria-label="Friday, 1 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4062,7 +4062,7 @@
     >
       <div
         aria-label="Saturday, 2 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4076,7 +4076,7 @@
     >
       <div
         aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4095,7 +4095,7 @@
     >
       <div
         aria-label="Monday, 4 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4109,7 +4109,7 @@
     >
       <div
         aria-label="Tuesday, 5 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4123,7 +4123,7 @@
     >
       <div
         aria-label="Wednesday, 6 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4137,7 +4137,7 @@
     >
       <div
         aria-label="Thursday, 7 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4151,7 +4151,7 @@
     >
       <div
         aria-label="Friday, 8 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4165,7 +4165,7 @@
     >
       <div
         aria-label="Saturday, 9 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4179,7 +4179,7 @@
     >
       <div
         aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4198,7 +4198,7 @@
     >
       <div
         aria-label="Monday, 11 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4212,7 +4212,7 @@
     >
       <div
         aria-label="Tuesday, 12 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4226,7 +4226,7 @@
     >
       <div
         aria-label="Wednesday, 13 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4240,7 +4240,7 @@
     >
       <div
         aria-label="Thursday, 14 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4254,7 +4254,7 @@
     >
       <div
         aria-label="Friday, 15 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4268,7 +4268,7 @@
     >
       <div
         aria-label="Saturday, 16 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4282,7 +4282,7 @@
     >
       <div
         aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4301,7 +4301,7 @@
     >
       <div
         aria-label="Monday, 18 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4315,7 +4315,7 @@
     >
       <div
         aria-label="Tuesday, 19 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4329,7 +4329,7 @@
     >
       <div
         aria-label="Wednesday, 20 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4343,7 +4343,7 @@
     >
       <div
         aria-label="Thursday, 21 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4357,7 +4357,7 @@
     >
       <div
         aria-label="Friday, 22 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4371,7 +4371,7 @@
     >
       <div
         aria-label="Saturday, 23 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4385,7 +4385,7 @@
     >
       <div
         aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4404,7 +4404,7 @@
     >
       <div
         aria-label="Monday, 25 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4418,7 +4418,7 @@
     >
       <div
         aria-label="Tuesday, 26 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4432,7 +4432,7 @@
     >
       <div
         aria-label="Wednesday, 27 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4446,7 +4446,7 @@
     >
       <div
         aria-label="Thursday, 28 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4460,7 +4460,7 @@
     >
       <div
         aria-label="Friday, 29 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4477,7 +4477,7 @@
     >
       <div
         aria-label="Selected: Saturday, 30 April 2005"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -4725,7 +4725,7 @@
     >
       <div
         aria-label="Selected: Saturday, 1 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
@@ -4739,7 +4739,7 @@
     >
       <div
         aria-label="Sunday, 2 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4758,7 +4758,7 @@
     >
       <div
         aria-label="Monday, 3 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4772,7 +4772,7 @@
     >
       <div
         aria-label="Tuesday, 4 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4786,7 +4786,7 @@
     >
       <div
         aria-label="Wednesday, 5 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4800,7 +4800,7 @@
     >
       <div
         aria-label="Thursday, 6 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4814,7 +4814,7 @@
     >
       <div
         aria-label="Friday, 7 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4828,7 +4828,7 @@
     >
       <div
         aria-label="Saturday, 8 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4842,7 +4842,7 @@
     >
       <div
         aria-label="Sunday, 9 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4861,7 +4861,7 @@
     >
       <div
         aria-label="Monday, 10 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4875,7 +4875,7 @@
     >
       <div
         aria-label="Tuesday, 11 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4889,7 +4889,7 @@
     >
       <div
         aria-label="Wednesday, 12 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4903,7 +4903,7 @@
     >
       <div
         aria-label="Thursday, 13 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4917,7 +4917,7 @@
     >
       <div
         aria-label="Friday, 14 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4931,7 +4931,7 @@
     >
       <div
         aria-label="Saturday, 15 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4945,7 +4945,7 @@
     >
       <div
         aria-label="Sunday, 16 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4964,7 +4964,7 @@
     >
       <div
         aria-label="Monday, 17 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4978,7 +4978,7 @@
     >
       <div
         aria-label="Tuesday, 18 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -4992,7 +4992,7 @@
     >
       <div
         aria-label="Wednesday, 19 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5006,7 +5006,7 @@
     >
       <div
         aria-label="Thursday, 20 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5020,7 +5020,7 @@
     >
       <div
         aria-label="Friday, 21 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5034,7 +5034,7 @@
     >
       <div
         aria-label="Saturday, 22 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5048,7 +5048,7 @@
     >
       <div
         aria-label="Sunday, 23 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5067,7 +5067,7 @@
     >
       <div
         aria-label="Monday, 24 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5081,7 +5081,7 @@
     >
       <div
         aria-label="Tuesday, 25 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5095,7 +5095,7 @@
     >
       <div
         aria-label="Wednesday, 26 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5109,7 +5109,7 @@
     >
       <div
         aria-label="Thursday, 27 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5123,7 +5123,7 @@
     >
       <div
         aria-label="Friday, 28 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5137,7 +5137,7 @@
     >
       <div
         aria-label="Saturday, 29 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5152,7 +5152,7 @@
     >
       <div
         aria-label="Sunday, 30 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5389,7 +5389,7 @@
     >
       <div
         aria-label="Saturday, 1 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5403,7 +5403,7 @@
     >
       <div
         aria-label="Sunday, 2 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5422,7 +5422,7 @@
     >
       <div
         aria-label="Monday, 3 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5436,7 +5436,7 @@
     >
       <div
         aria-label="Tuesday, 4 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5450,7 +5450,7 @@
     >
       <div
         aria-label="Wednesday, 5 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5464,7 +5464,7 @@
     >
       <div
         aria-label="Thursday, 6 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5478,7 +5478,7 @@
     >
       <div
         aria-label="Friday, 7 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5492,7 +5492,7 @@
     >
       <div
         aria-label="Saturday, 8 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5506,7 +5506,7 @@
     >
       <div
         aria-label="Sunday, 9 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5525,7 +5525,7 @@
     >
       <div
         aria-label="Monday, 10 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5539,7 +5539,7 @@
     >
       <div
         aria-label="Tuesday, 11 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5553,7 +5553,7 @@
     >
       <div
         aria-label="Wednesday, 12 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5567,7 +5567,7 @@
     >
       <div
         aria-label="Thursday, 13 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5581,7 +5581,7 @@
     >
       <div
         aria-label="Friday, 14 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5595,7 +5595,7 @@
     >
       <div
         aria-label="Saturday, 15 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5609,7 +5609,7 @@
     >
       <div
         aria-label="Sunday, 16 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5628,7 +5628,7 @@
     >
       <div
         aria-label="Monday, 17 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5642,7 +5642,7 @@
     >
       <div
         aria-label="Tuesday, 18 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5656,7 +5656,7 @@
     >
       <div
         aria-label="Wednesday, 19 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5670,7 +5670,7 @@
     >
       <div
         aria-label="Thursday, 20 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5684,7 +5684,7 @@
     >
       <div
         aria-label="Friday, 21 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5698,7 +5698,7 @@
     >
       <div
         aria-label="Saturday, 22 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5712,7 +5712,7 @@
     >
       <div
         aria-label="Sunday, 23 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5731,7 +5731,7 @@
     >
       <div
         aria-label="Monday, 24 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5745,7 +5745,7 @@
     >
       <div
         aria-label="Tuesday, 25 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5759,7 +5759,7 @@
     >
       <div
         aria-label="Wednesday, 26 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5773,7 +5773,7 @@
     >
       <div
         aria-label="Thursday, 27 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5787,7 +5787,7 @@
     >
       <div
         aria-label="Friday, 28 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5801,7 +5801,7 @@
     >
       <div
         aria-label="Saturday, 29 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
@@ -5818,7 +5818,7 @@
     >
       <div
         aria-label="Selected: Sunday, 30 April 12"
-        part="cell-content selection selection-selectable"
+        part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >

--- a/packages/elements/src/calendar/index.ts
+++ b/packages/elements/src/calendar/index.ts
@@ -436,7 +436,7 @@ export class Calendar extends ControlElement implements MultiValue {
    * @returns button HTML date button element or null
    */
   private getDateButtonByIndex (index: CellIndex): DateButtonElement | undefined {
-    const elements = Array.from(this.renderRoot.querySelectorAll('[part~=cell] > [part~=selection]'));
+    const elements = Array.from(this.renderRoot.querySelectorAll('[part~=cell] > [part~=selection-selectable]'));
     return elements.find((element): element is DateButtonElement => this.isDateButton(element) && String(element.index) === String(index));
   }
 
@@ -445,7 +445,7 @@ export class Calendar extends ControlElement implements MultiValue {
    * @returns button HTML date button element or null
    */
   private get activeDateButton (): DateButtonElement | null {
-    return this.renderRoot.querySelector('[part~=cell][active] > [part~=selection]');
+    return this.renderRoot.querySelector('[part~=cell][active] > [part~=selection-selectable]');
   }
 
   /**
@@ -1359,7 +1359,8 @@ export class Calendar extends ControlElement implements MultiValue {
    * @returns template result
    */
   private renderCell (cell: Cell): TemplateResult {
-    const isSelectable = cell.value !== undefined && !cell.disabled;
+    const isSelection = cell.value !== undefined;
+    const isSelectable = isSelection && !cell.disabled;
 
     return html`<div
       role="gridcell"
@@ -1382,7 +1383,7 @@ export class Calendar extends ControlElement implements MultiValue {
                value: parse(cell.value!),
                view: this.renderView
              }) : undefined)}"
-             part="cell-content${isSelectable ? ' selection' : ''}"
+             part="cell-content${isSelectable ? ' selection-selectable' : ''}${isSelection ? ' selection' : ''}"
              .value=${cell.value}
              .index=${cell.index}>${cell.text}</div>
     </div>`;

--- a/packages/elements/src/calendar/index.ts
+++ b/packages/elements/src/calendar/index.ts
@@ -180,7 +180,7 @@ export class Calendar extends ControlElement implements MultiValue {
       [part~=cell-content]:not([tabindex]) {
         pointer-events: none;
       }
-      [part~=selection] {
+      [part~=selectable] {
         cursor: pointer;
       }
     `;
@@ -436,7 +436,7 @@ export class Calendar extends ControlElement implements MultiValue {
    * @returns button HTML date button element or null
    */
   private getDateButtonByIndex (index: CellIndex): DateButtonElement | undefined {
-    const elements = Array.from(this.renderRoot.querySelectorAll('[part~=cell] > [part~=selection-selectable]'));
+    const elements = Array.from(this.renderRoot.querySelectorAll('[part~=cell] > [part~=selectable]'));
     return elements.find((element): element is DateButtonElement => this.isDateButton(element) && String(element.index) === String(index));
   }
 
@@ -445,7 +445,7 @@ export class Calendar extends ControlElement implements MultiValue {
    * @returns button HTML date button element or null
    */
   private get activeDateButton (): DateButtonElement | null {
-    return this.renderRoot.querySelector('[part~=cell][active] > [part~=selection-selectable]');
+    return this.renderRoot.querySelector('[part~=cell][active] > [part~=selectable]');
   }
 
   /**
@@ -1383,7 +1383,7 @@ export class Calendar extends ControlElement implements MultiValue {
                value: parse(cell.value!),
                view: this.renderView
              }) : undefined)}"
-             part="cell-content${isSelection ? ' selection' : ''}${isSelectable ? ' selection-selectable' : ''}"
+             part="cell-content${isSelection ? ' selection' : ''}${isSelectable ? ' selectable' : ''}"
              .value=${cell.value}
              .index=${cell.index}>${cell.text}</div>
     </div>`;

--- a/packages/elements/src/calendar/index.ts
+++ b/packages/elements/src/calendar/index.ts
@@ -1383,7 +1383,7 @@ export class Calendar extends ControlElement implements MultiValue {
                value: parse(cell.value!),
                view: this.renderView
              }) : undefined)}"
-             part="cell-content${isSelectable ? ' selection-selectable' : ''}${isSelection ? ' selection' : ''}"
+             part="cell-content${isSelection ? ' selection' : ''}${isSelectable ? ' selection-selectable' : ''}"
              .value=${cell.value}
              .index=${cell.index}>${cell.text}</div>
     </div>`;

--- a/packages/halo-theme/src/custom-elements/ef-calendar.less
+++ b/packages/halo-theme/src/custom-elements/ef-calendar.less
@@ -97,7 +97,7 @@
         border-color: @calendar-cell-hover-background-color;
       }
 
-      &:active [part~=selection] {
+      &:not([disabled]):active [part~=selection] {
         color: @calendar-cell-hover-text-color;
         background-color: @calendar-cell-press-background-color;
       }
@@ -108,7 +108,7 @@
         border-color: @calendar-cell-hover-background-color;
       }
 
-      &:active [part~=selection] {
+      &:not([disabled]):active [part~=selection] {
         color: @calendar-cell-hover-text-color;
         background-color: @calendar-cell-press-background-color;
       }


### PR DESCRIPTION
## Description
Incorrect day background color when selected disabled.

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-1937

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
