### PR TITLE
docs: create redirects starting with sandbox

### DIFF
--- a/documents/package.json
+++ b/documents/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start:dev": "concurrently \"pandora src dist --watch\" \"serve dist -s\"",
     "start": "serve dist -s",
-    "copy:resources": "cp -r resources dist/resources && cp src/theme-loader.js dist/theme-loader.js",
+    "copy:resources": "cp src/_redirects dist/_redirects && cp -r resources dist/resources && cp src/theme-loader.js dist/theme-loader.js",
     "build:api": "lerna run --scope @refinitiv-ui/elements api-analyzer --stream && node ./scripts/element.injector.js",
     "build": "rm -rf build && npm run build:api && pandora build dist --clean && npm run copy:resources"
   },

--- a/documents/src/_redirects
+++ b/documents/src/_redirects
@@ -1,0 +1,1 @@
+/sandbox https://codepen.io/element-framework/pen/GRxveeP


### PR DESCRIPTION
Will allow ui.refinitiv.com/sandbox to redirect to copepen sandbox.

E.g. https://add-redirects.refinitiv-ui.pages.dev/sandbox