### PR TITLE
docs(interactive-chart): fix incorrect sample in seasonality section

### DIFF
--- a/documents/src/pages/elements/interactive-chart.md
+++ b/documents/src/pages/elements/interactive-chart.md
@@ -467,7 +467,6 @@ const months = {
 }
 const chart = document.getElementById('seasonality');
 chart.config = {
-  lastValueVisible: false,
   options: {
     timeScale: {
       tickMarkFormatter: (time, tickMarkType, locale) => {
@@ -486,8 +485,11 @@ chart.config = {
     {
       symbol: '2011-2020',
       symbolName: 'Avg. 2011-2020',
-      lastValueVisible: false,
       type: 'line',
+      seriesOptions: {
+        priceLineVisible: false,
+        lastValueVisible: false
+      },
       data: [
         { time: '2020-01-11', value: 20.31 },
         { time: '2020-02-12', value: 30.27 },
@@ -549,7 +551,6 @@ const months = {
 }
 const chart = document.getElementById('seasonality');
 chart.config = {
-  lastValueVisible: false,
   options: {
     timeScale: {
       tickMarkFormatter: (time, tickMarkType, locale) => {
@@ -568,8 +569,11 @@ chart.config = {
     {
       symbol: '2011-2020',
       symbolName: 'Avg. 2011-2020',
-      lastValueVisible: false,
       type: 'line',
+      seriesOptions: {
+        priceLineVisible: false,
+        lastValueVisible: false
+      },
       data: [
         { time: '2020-01-11', value: 20.31 },
         { time: '2020-02-12', value: 30.27 },


### PR DESCRIPTION
Incorrect sample code in Seasonality section.

those options should be a configuration in `series` object.
https://tradingview.github.io/lightweight-charts/docs/api/interfaces/SeriesOptionsCommon

