### PR TITLE
fix(datetime-picker): parse invalid value to date object

### DIFF
--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -28,6 +28,26 @@ describe('datetime-picker/Value', () => {
       expect(el.min).to.be.equal('', 'Invalid min should reset min');
       expect(el.max).to.be.equal('', 'Invalid max should reset max');
     });
+
+    it('It must not error when user input empty string value', async () => {
+      const el = await fixture('<ef-datetime-picker lang="en-gb" min="2022-04-01" max="2022-04-30"></ef-datetime-picker>');
+      el.value = '2022-05-15';
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(true);
+      typeText(el.inputEl, '');
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(false, 'input empty string must not make element error');
+
+      // Test range mode
+      el.range = true;
+      el.values = ['2022-03-15', '2022-04-23'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(true);
+      typeText(el.inputEl, '');
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(false, 'input empty string must not make element error in range mode');
+    });
+
     it('Typing invalid value in input should mark datetime picker as invalid and error-changed event is fired', async () => {
       const el = await fixture('<ef-datetime-picker lang="en-gb" opened></ef-datetime-picker>');
       setTimeout(() => typeText(el.inputEl, 'Invalid Value'));

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -473,12 +473,6 @@ export class DatetimePicker extends ControlElement implements MultiValue {
    * @returns {void}
    */
   public validateInput (): void {
-    // No need to validate empty string value
-    if (this.inputValues.every(value => value === '')) {
-      this.error = false;
-      return;
-    }
-
     const hasError = this.hasError();
     if (this.error !== hasError) {
       this.error = hasError;
@@ -1058,15 +1052,17 @@ export class DatetimePicker extends ControlElement implements MultiValue {
    */
   private isValueWithinMinMax (): boolean {
     if (this.min || this.max) {
-      const minTime = this.min ? parse(this.min).getTime() : -Infinity;
-      const maxTime = this.max ? parse(this.max).getTime() : Infinity;
       for (let i = 0; i < this.values.length; i += 1) {
-        if (!this.values[i]) {
-          continue;
-        }
-        const valueTime = parse(this.values[i]).getTime();
-        if (minTime > valueTime || maxTime < valueTime) {
-          return false;
+        const value = this.values[i];
+        if (value) {
+          // Value before min
+          if (this.min && value !== this.min && isBefore(value, this.min)) {
+            return false;
+          }
+          // Value after max
+          if (this.max && value !== this.max && isAfter(value, this.max)) {
+            return false;
+          }
         }
       }
     }

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -1062,7 +1062,7 @@ export class DatetimePicker extends ControlElement implements MultiValue {
       const maxTime = this.max ? parse(this.max).getTime() : Infinity;
       for (let i = 0; i < this.values.length; i += 1) {
         if (!this.values[i]) {
-          return false;
+          continue;
         }
         const valueTime = parse(this.values[i]).getTime();
         if (minTime > valueTime || maxTime < valueTime) {

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -155,7 +155,7 @@ export class DatetimePicker extends ControlElement implements MultiValue {
         cursor: pointer;
       }
       :host([popup-disabled]) [part=icon], :host([readonly]) [part=icon] {
-        pointer-event: none;
+        pointer-events: none;
       }
     `;
   }
@@ -473,6 +473,12 @@ export class DatetimePicker extends ControlElement implements MultiValue {
    * @returns {void}
    */
   public validateInput (): void {
+    // No need to validate empty string value
+    if (this.inputValues.every(value => value === '')) {
+      this.error = false;
+      return;
+    }
+
     const hasError = this.hasError();
     if (this.error !== hasError) {
       this.error = hasError;
@@ -1055,6 +1061,9 @@ export class DatetimePicker extends ControlElement implements MultiValue {
       const minTime = this.min ? parse(this.min).getTime() : -Infinity;
       const maxTime = this.max ? parse(this.max).getTime() : Infinity;
       for (let i = 0; i < this.values.length; i += 1) {
+        if (!this.values[i]) {
+          return false;
+        }
         const valueTime = parse(this.values[i]).getTime();
         if (minTime > valueTime || maxTime < valueTime) {
           return false;


### PR DESCRIPTION
## Description

There is a bug in the function `isValueWithinMinMax` it parses invalid values to date object. which make the error in console
### Fixing

- refactor `isValueWithinMinMax` to handle empty values


[ELF-1949](https://jira.refinitiv.com/browse/ELF-1949) [datetime-picker] Console error when clear value in input when using max/min

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
