### PR TITLE
fix(overlay): Tab does not work with slotted elements

### DIFF
--- a/packages/elements/src/overlay/managers/focus-manager.ts
+++ b/packages/elements/src/overlay/managers/focus-manager.ts
@@ -131,13 +131,13 @@ export class FocusManager {
 
   private isFocusBoundaryDescendant (element: HTMLElement): boolean {
     const focusBoundaryElements = this.focusBoundaryElements;
-    let node = element.parentNode;
+    let node = element.assignedSlot || element.parentNode;
     while (node) {
       if ((node instanceof HTMLElement || node instanceof ShadowRoot) && focusBoundaryElements.includes(node)) {
         return true;
       }
       // parenNode is not defined if the node is inside document fragment. Use host instead
-      node = node.nodeType === Node.DOCUMENT_FRAGMENT_NODE ? (node as ShadowRoot).host : node.parentNode;
+      node = node.nodeType === Node.DOCUMENT_FRAGMENT_NODE ? (node as ShadowRoot).host : ((node as Element).assignedSlot || node.parentNode);
     }
 
     return false;


### PR DESCRIPTION
## Description

focus-manager does nor correctly Tab through elements which are included via slot element.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
