### PR TITLE
fix(list-item): incorrect style on halo theme

### DIFF
--- a/packages/halo-theme/src/custom-elements/ef-list-item.less
+++ b/packages/halo-theme/src/custom-elements/ef-list-item.less
@@ -1,1 +1,1 @@
-@import "ef-item";
+@import 'ef-item';

--- a/packages/halo-theme/src/custom-elements/ef-list-item.less
+++ b/packages/halo-theme/src/custom-elements/ef-list-item.less
@@ -1,1 +1,1 @@
-@import '@refinitiv-ui/elemental-theme/src/custom-elements/ef-list-item';
+@import "ef-item";

--- a/packages/solar-theme/src/custom-elements/ef-list-item.less
+++ b/packages/solar-theme/src/custom-elements/ef-list-item.less
@@ -1,1 +1,1 @@
-@import "ef-item";
+@import 'ef-item';

--- a/packages/solar-theme/src/custom-elements/ef-list-item.less
+++ b/packages/solar-theme/src/custom-elements/ef-list-item.less
@@ -1,1 +1,1 @@
-@import '@refinitiv-ui/elemental-theme/src/custom-elements/ef-list-item';
+@import "ef-item";


### PR DESCRIPTION
## Description
The `ef-list-item` element have import an incorrect style in halo-theme, it makes `ef-combo-box` and `ef-list` has an incorrect style too.

Solution
- change `ef-list-item` halo-theme to import theme from `ef-item` halo-theme instead of elemental-theme.
- and solar-theme as well.

## Type of change
- [x] Refactor (improves code without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

