### PR TITLE
fix(halo-theme): sync color due to Grid style updated

### DIFF
--- a/packages/halo-theme/src/variants/light/overrides.less
+++ b/packages/halo-theme/src/variants/light/overrides.less
@@ -29,7 +29,7 @@
 @grid-header-hover-text-color             : @global-text-color;
 @grid-header-hover-background-color       : @color-concrete;
 @grid-row-hover-text-color                : @grid-row-text-color;
-@grid-row-hover-background-color          : @color-white;
+@grid-row-hover-background-color          : @color-alabaster;
 @grid-row-active-background-color         : @color-concrete;
 @grid-row-active-text-color               : @global-text-color;
 @grid-column-active-border-color          : @scheme-color-primary;


### PR DESCRIPTION
## Description
Sync grid color from v4 

figma: https://www.figma.com/file/aI8edV7kzSdeEuOP0HZqx6/Grid-UI-Specs?node-id=7151%3A23033

Fixes # (issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
