### PR TITLE
fix(interactive-chart): fix left position on legend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
         "@formatjs/intl-locale": "^2.4.41",
         "@formatjs/intl-numberformat": "^7.2.6",
         "@formatjs/intl-pluralrules": "^4.1.6",
-        "@nrwl/cli": "*",
-        "@nrwl/tao": "*",
-        "@nrwl/workspace": "*",
+        "@nrwl/cli": "latest",
+        "@nrwl/tao": "latest",
+        "@nrwl/workspace": "latest",
         "@open-wc/karma-esm": "^4.0.0",
         "@web/dev-server": "^0.1.17",
         "@web/dev-server-legacy": "^0.1.7",
@@ -57,10 +57,10 @@
     },
     "documents": {
       "name": "@refinitiv-ui/docs",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@refinitiv-ui/elements": "^6.1.0",
+        "@refinitiv-ui/elements": "^6.1.1",
         "fast-glob": "^3.2.7",
         "fs-extra": "^10.0.0"
       },
@@ -21135,7 +21135,7 @@
     },
     "packages/configurations": {
       "name": "@refinitiv-ui/configurations",
-      "version": "6.0.3",
+      "version": "6.0.4",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.29.0",
@@ -21148,7 +21148,7 @@
     },
     "packages/core": {
       "name": "@refinitiv-ui/core",
-      "version": "6.0.4",
+      "version": "6.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@juggle/resize-observer": "^3.3.1",
@@ -21156,86 +21156,86 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@refinitiv-ui/test-helpers": "^6.0.3",
-        "@refinitiv-ui/utils": "^6.0.3"
+        "@refinitiv-ui/test-helpers": "^6.0.4",
+        "@refinitiv-ui/utils": "^6.0.4"
       },
       "peerDependencies": {
-        "@refinitiv-ui/utils": "^6.0.3"
+        "@refinitiv-ui/utils": "^6.0.4"
       }
     },
     "packages/demo-block": {
       "name": "@refinitiv-ui/demo-block",
-      "version": "6.0.5",
+      "version": "6.0.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@refinitiv-ui/elemental-theme": "^6.0.4",
-        "@refinitiv-ui/halo-theme": "^6.1.3",
-        "@refinitiv-ui/solar-theme": "^6.0.4",
+        "@refinitiv-ui/elemental-theme": "^6.0.5",
+        "@refinitiv-ui/halo-theme": "^6.1.4",
+        "@refinitiv-ui/solar-theme": "^6.0.5",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@refinitiv-ui/core": "^6.0.4",
-        "@refinitiv-ui/test-helpers": "^6.0.3"
+        "@refinitiv-ui/core": "^6.0.5",
+        "@refinitiv-ui/test-helpers": "^6.0.4"
       },
       "peerDependencies": {
-        "@refinitiv-ui/core": "^6.0.4"
+        "@refinitiv-ui/core": "^6.0.5"
       }
     },
     "packages/elemental-theme": {
       "name": "@refinitiv-ui/elemental-theme",
-      "version": "6.0.4",
+      "version": "6.0.5",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@refinitiv-ui/theme-compiler": "^6.0.3"
+        "@refinitiv-ui/theme-compiler": "^6.0.4"
       }
     },
     "packages/elements": {
       "name": "@refinitiv-ui/elements",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@refinitiv-ui/browser-sparkline": "1.1.8",
-        "@refinitiv-ui/halo-theme": "^6.1.3",
-        "@refinitiv-ui/solar-theme": "^6.0.4",
+        "@refinitiv-ui/halo-theme": "^6.1.4",
+        "@refinitiv-ui/solar-theme": "^6.0.5",
         "@types/chart.js": "^2.9.31",
         "chart.js": "~2.9.4",
         "d3-interpolate": "^3.0.1",
         "date-fns": "^2.22.1",
-        "lightweight-charts": "^3.3.0",
+        "lightweight-charts": "^3.8.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@refinitiv-ui/core": "^6.0.4",
-        "@refinitiv-ui/demo-block": "^6.0.5",
-        "@refinitiv-ui/i18n": "^6.0.3",
-        "@refinitiv-ui/phrasebook": "^6.1.2",
-        "@refinitiv-ui/test-helpers": "^6.0.3",
-        "@refinitiv-ui/translate": "^6.0.4",
-        "@refinitiv-ui/utils": "^6.0.3",
+        "@refinitiv-ui/core": "^6.0.5",
+        "@refinitiv-ui/demo-block": "^6.0.6",
+        "@refinitiv-ui/i18n": "^6.0.4",
+        "@refinitiv-ui/phrasebook": "^6.1.3",
+        "@refinitiv-ui/test-helpers": "^6.0.4",
+        "@refinitiv-ui/translate": "^6.0.5",
+        "@refinitiv-ui/utils": "^6.0.4",
         "@types/d3-interpolate": "^3.0.1"
       },
       "peerDependencies": {
-        "@refinitiv-ui/core": "^6.0.4",
-        "@refinitiv-ui/i18n": "^6.0.3",
-        "@refinitiv-ui/phrasebook": "^6.1.2",
-        "@refinitiv-ui/translate": "^6.0.4",
-        "@refinitiv-ui/utils": "^6.0.3"
+        "@refinitiv-ui/core": "^6.0.5",
+        "@refinitiv-ui/i18n": "^6.0.4",
+        "@refinitiv-ui/phrasebook": "^6.1.3",
+        "@refinitiv-ui/translate": "^6.0.5",
+        "@refinitiv-ui/utils": "^6.0.4"
       }
     },
     "packages/halo-theme": {
       "name": "@refinitiv-ui/halo-theme",
-      "version": "6.1.3",
+      "version": "6.1.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@refinitiv-ui/elemental-theme": "^6.0.4"
+        "@refinitiv-ui/elemental-theme": "^6.0.5"
       },
       "devDependencies": {
-        "@refinitiv-ui/theme-compiler": "^6.0.3"
+        "@refinitiv-ui/theme-compiler": "^6.0.4"
       }
     },
     "packages/i18n": {
       "name": "@refinitiv-ui/i18n",
-      "version": "6.0.3",
+      "version": "6.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@formatjs/icu-messageformat-parser": "^2.0.15",
@@ -21245,16 +21245,16 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@refinitiv-ui/phrasebook": "^6.1.2",
-        "@refinitiv-ui/test-helpers": "^6.0.3"
+        "@refinitiv-ui/phrasebook": "^6.1.3",
+        "@refinitiv-ui/test-helpers": "^6.0.4"
       },
       "peerDependencies": {
-        "@refinitiv-ui/phrasebook": "^6.1.2"
+        "@refinitiv-ui/phrasebook": "^6.1.3"
       }
     },
     "packages/phrasebook": {
       "name": "@refinitiv-ui/phrasebook",
-      "version": "6.1.2",
+      "version": "6.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -21267,7 +21267,7 @@
     },
     "packages/polyfills": {
       "name": "@refinitiv-ui/polyfills",
-      "version": "6.0.4",
+      "version": "6.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@webcomponents/custom-elements": "^1.4.1",
@@ -21281,18 +21281,18 @@
     },
     "packages/solar-theme": {
       "name": "@refinitiv-ui/solar-theme",
-      "version": "6.0.4",
+      "version": "6.0.5",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@refinitiv-ui/elemental-theme": "^6.0.4"
+        "@refinitiv-ui/elemental-theme": "^6.0.5"
       },
       "devDependencies": {
-        "@refinitiv-ui/theme-compiler": "^6.0.3"
+        "@refinitiv-ui/theme-compiler": "^6.0.4"
       }
     },
     "packages/test-helpers": {
       "name": "@refinitiv-ui/test-helpers",
-      "version": "6.0.3",
+      "version": "6.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-wc/testing": "^3.0.0-next.5",
@@ -21760,7 +21760,7 @@
     },
     "packages/theme-compiler": {
       "name": "@refinitiv-ui/theme-compiler",
-      "version": "6.0.3",
+      "version": "6.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "autoprefixer": "^10.4.2",
@@ -21842,26 +21842,26 @@
     },
     "packages/translate": {
       "name": "@refinitiv-ui/translate",
-      "version": "6.0.4",
+      "version": "6.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "lit": "^2.2.7",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@refinitiv-ui/core": "^6.0.4",
-        "@refinitiv-ui/i18n": "^6.0.3",
-        "@refinitiv-ui/phrasebook": "^6.1.2",
-        "@refinitiv-ui/test-helpers": "^6.0.3"
+        "@refinitiv-ui/core": "^6.0.5",
+        "@refinitiv-ui/i18n": "^6.0.4",
+        "@refinitiv-ui/phrasebook": "^6.1.3",
+        "@refinitiv-ui/test-helpers": "^6.0.4"
       },
       "peerDependencies": {
-        "@refinitiv-ui/i18n": "^6.0.3",
-        "@refinitiv-ui/phrasebook": "^6.1.2"
+        "@refinitiv-ui/i18n": "^6.0.4",
+        "@refinitiv-ui/phrasebook": "^6.1.3"
       }
     },
     "packages/utils": {
       "name": "@refinitiv-ui/utils",
-      "version": "6.0.3",
+      "version": "6.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/d3-color": "^3.0.2",
@@ -25735,8 +25735,8 @@
       "version": "file:packages/core",
       "requires": {
         "@juggle/resize-observer": "^3.3.1",
-        "@refinitiv-ui/test-helpers": "^6.0.3",
-        "@refinitiv-ui/utils": "^6.0.3",
+        "@refinitiv-ui/test-helpers": "^6.0.4",
+        "@refinitiv-ui/utils": "^6.0.4",
         "lit": "^2.2.7",
         "tslib": "^2.3.1"
       }
@@ -25744,18 +25744,18 @@
     "@refinitiv-ui/demo-block": {
       "version": "file:packages/demo-block",
       "requires": {
-        "@refinitiv-ui/core": "^6.0.4",
-        "@refinitiv-ui/elemental-theme": "^6.0.4",
-        "@refinitiv-ui/halo-theme": "^6.1.3",
-        "@refinitiv-ui/solar-theme": "^6.0.4",
-        "@refinitiv-ui/test-helpers": "^6.0.3",
+        "@refinitiv-ui/core": "^6.0.5",
+        "@refinitiv-ui/elemental-theme": "^6.0.5",
+        "@refinitiv-ui/halo-theme": "^6.1.4",
+        "@refinitiv-ui/solar-theme": "^6.0.5",
+        "@refinitiv-ui/test-helpers": "^6.0.4",
         "tslib": "^2.3.1"
       }
     },
     "@refinitiv-ui/docs": {
       "version": "file:documents",
       "requires": {
-        "@refinitiv-ui/elements": "^6.1.0",
+        "@refinitiv-ui/elements": "^6.1.1",
         "chalk": "^4.1.2",
         "concurrently": "^6.4.0",
         "fast-glob": "^3.2.7",
@@ -25767,36 +25767,36 @@
     "@refinitiv-ui/elemental-theme": {
       "version": "file:packages/elemental-theme",
       "requires": {
-        "@refinitiv-ui/theme-compiler": "^6.0.3"
+        "@refinitiv-ui/theme-compiler": "^6.0.4"
       }
     },
     "@refinitiv-ui/elements": {
       "version": "file:packages/elements",
       "requires": {
         "@refinitiv-ui/browser-sparkline": "1.1.8",
-        "@refinitiv-ui/core": "^6.0.4",
-        "@refinitiv-ui/demo-block": "^6.0.5",
-        "@refinitiv-ui/halo-theme": "^6.1.3",
-        "@refinitiv-ui/i18n": "^6.0.3",
-        "@refinitiv-ui/phrasebook": "^6.1.2",
-        "@refinitiv-ui/solar-theme": "^6.0.4",
-        "@refinitiv-ui/test-helpers": "^6.0.3",
-        "@refinitiv-ui/translate": "^6.0.4",
-        "@refinitiv-ui/utils": "^6.0.3",
+        "@refinitiv-ui/core": "^6.0.5",
+        "@refinitiv-ui/demo-block": "^6.0.6",
+        "@refinitiv-ui/halo-theme": "^6.1.4",
+        "@refinitiv-ui/i18n": "^6.0.4",
+        "@refinitiv-ui/phrasebook": "^6.1.3",
+        "@refinitiv-ui/solar-theme": "^6.0.5",
+        "@refinitiv-ui/test-helpers": "^6.0.4",
+        "@refinitiv-ui/translate": "^6.0.5",
+        "@refinitiv-ui/utils": "^6.0.4",
         "@types/chart.js": "^2.9.31",
         "@types/d3-interpolate": "^3.0.1",
         "chart.js": "~2.9.4",
         "d3-interpolate": "^3.0.1",
         "date-fns": "^2.22.1",
-        "lightweight-charts": "^3.3.0",
+        "lightweight-charts": "^3.8.0",
         "tslib": "^2.3.1"
       }
     },
     "@refinitiv-ui/halo-theme": {
       "version": "file:packages/halo-theme",
       "requires": {
-        "@refinitiv-ui/elemental-theme": "^6.0.4",
-        "@refinitiv-ui/theme-compiler": "^6.0.3"
+        "@refinitiv-ui/elemental-theme": "^6.0.5",
+        "@refinitiv-ui/theme-compiler": "^6.0.4"
       }
     },
     "@refinitiv-ui/i18n": {
@@ -25804,8 +25804,8 @@
       "requires": {
         "@formatjs/icu-messageformat-parser": "^2.0.15",
         "@formatjs/intl-utils": "^3.8.4",
-        "@refinitiv-ui/phrasebook": "^6.1.2",
-        "@refinitiv-ui/test-helpers": "^6.0.3",
+        "@refinitiv-ui/phrasebook": "^6.1.3",
+        "@refinitiv-ui/test-helpers": "^6.0.4",
         "intl-format-cache": "^4.3.1",
         "intl-messageformat": "^9.10.0",
         "tslib": "^2.3.1"
@@ -25835,8 +25835,8 @@
     "@refinitiv-ui/solar-theme": {
       "version": "file:packages/solar-theme",
       "requires": {
-        "@refinitiv-ui/elemental-theme": "^6.0.4",
-        "@refinitiv-ui/theme-compiler": "^6.0.3"
+        "@refinitiv-ui/elemental-theme": "^6.0.5",
+        "@refinitiv-ui/theme-compiler": "^6.0.4"
       }
     },
     "@refinitiv-ui/test-helpers": {
@@ -26199,10 +26199,10 @@
     "@refinitiv-ui/translate": {
       "version": "file:packages/translate",
       "requires": {
-        "@refinitiv-ui/core": "^6.0.4",
-        "@refinitiv-ui/i18n": "^6.0.3",
-        "@refinitiv-ui/phrasebook": "^6.1.2",
-        "@refinitiv-ui/test-helpers": "^6.0.3",
+        "@refinitiv-ui/core": "^6.0.5",
+        "@refinitiv-ui/i18n": "^6.0.4",
+        "@refinitiv-ui/phrasebook": "^6.1.3",
+        "@refinitiv-ui/test-helpers": "^6.0.4",
         "lit": "^2.2.7",
         "tslib": "^2.3.1"
       }
@@ -35423,7 +35423,7 @@
       }
     },
     "pandora-book": {
-      "version": "file:tools/pandora-book-3.0.0-66.tgz",
+      "version": "file:tools\\pandora-book-3.0.0-66.tgz",
       "integrity": "sha512-tx/8Zi0vopmfgBTvtKlDOjXRqkLkTf7r1+PWWm33p6E2jZUZe0pD8selzrWVoXUWNCfZDiNKF4V8AIiUfBADmA==",
       "dev": true,
       "requires": {

--- a/packages/elemental-theme/src/custom-elements/ef-interactive-chart.less
+++ b/packages/elemental-theme/src/custom-elements/ef-interactive-chart.less
@@ -32,7 +32,6 @@
 
     [part=legend] {
         position: absolute;
-        left: 15px;
         top: 15px;
         z-index: 1000;
         color: var(--text-color);
@@ -45,12 +44,6 @@
         }
         .ohlc {
             margin-right: 2px;
-        }
-        &.yaxis-left{
-            left: 70px;
-        }
-        &.yaxis-right{
-            left: 15px;
         }
         &.horizontal {
             display: flex;

--- a/packages/elemental-theme/src/custom-elements/ef-interactive-chart.less
+++ b/packages/elemental-theme/src/custom-elements/ef-interactive-chart.less
@@ -31,9 +31,7 @@
     --scale-times-border-color: fade(@grid-border-color, 50%);
 
     [part=legend] {
-        position: absolute;
         top: 15px;
-        z-index: 1000;
         color: var(--text-color);
         font-size: 90%;
         .row {

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -339,7 +339,7 @@
     "chart.js": "~2.9.4",
     "d3-interpolate": "^3.0.1",
     "date-fns": "^2.22.1",
-    "lightweight-charts": "^3.3.0",
+    "lightweight-charts": "^3.8.0",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
+++ b/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
@@ -887,5 +887,17 @@ describe('interactive-chart/InteractiveChart', () => {
       expect(legendStyle.position).to.equal('absolute');
       expect(legendLeftPosition).to.greaterThan(el.DEFAULT_LEGEND_LEFT_POSITION);
     });
+    it('Should has fixed left position in legend when the chart set y axis at right edge', async () => {
+      el.config = line;
+      await elementUpdated();
+      await nextFrame();
+
+      expect(el.chart).to.not.be.undefined;
+      expect(el.chart).to.not.be.null;
+      const legendStyle = getComputedStyle(el.shadowRoot.querySelector('[part=legend]'))
+      const legendLeftPosition = Number(legendStyle.left.substring(0,legendStyle.left.indexOf('px')))
+      expect(legendStyle.position).to.equal('absolute');
+      expect(legendLeftPosition).to.be(el.DEFAULT_LEGEND_LEFT_POSITION);
+    });
   });
 });

--- a/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
+++ b/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
@@ -669,30 +669,28 @@ describe('interactive-chart/InteractiveChart', () => {
 
     });
 
-    it('Set via attribute horizontal legend to vertical', async () => {
-
+    it('Legend should have horizontal style class when set legend-style="horizontal" via attribute', async () => {
       el = await fixture('<ef-interactive-chart legend-style="horizontal"></ef-interactive-chart>');
-
       el.config = line;
       await elementUpdated();
+      await nextFrame();
 
       expect(el.chart).to.not.be.undefined;
       expect(el.chart).to.not.be.null;
-
-      el.legendStyle = 'horizontal';
-      await nextFrame();
+      expect(el.shadowRoot.querySelector('[part=legend]').className).to.include('horizontal');
+    });
+    it('Legend should not have horizontal style class when set legend-style="vertical" via attribute', async () => {
+      el = await fixture('<ef-interactive-chart legend-style="vertical"></ef-interactive-chart>');
+      el.config = line;
       await elementUpdated();
-      expect(el.shadowRoot.querySelector('[part=legend]').className).to.include('yaxis-right');
-
-      el.legendStyle = 'vertical';
       await nextFrame();
-      await elementUpdated();
 
-      expect(el.shadowRoot.querySelector('[part=legend]').className).to.not.include('yaxis-left');
-
+      expect(el.chart).to.not.be.undefined;
+      expect(el.chart).to.not.be.null;
+      expect(el.shadowRoot.querySelector('[part=legend]').className).to.not.include('horizontal');
     });
 
-    it('Switch horizontal legend to vertical', async () => {
+    it('LegendStyle should able to switch between horizontal and vertical', async () => {
       el.config = line;
       await nextFrame();
       await elementUpdated();
@@ -703,14 +701,13 @@ describe('interactive-chart/InteractiveChart', () => {
       el.legendStyle = 'horizontal';
       await nextFrame();
       await elementUpdated();
-      expect(el.shadowRoot.querySelector('[part=legend]').className).to.include('yaxis-right');
+      expect(el.shadowRoot.querySelector('[part=legend]').className).to.include('horizontal');
 
       el.legendStyle = 'vertical';
       await nextFrame();
       await elementUpdated();
 
-      expect(el.shadowRoot.querySelector('[part=legend]').className).to.not.include('yaxis-left');
-
+      expect(el.shadowRoot.querySelector('[part=legend]').className).to.not.include('horizontal');
     });
 
     it('When toggle jump button in chart', async () => {
@@ -864,6 +861,31 @@ describe('interactive-chart/InteractiveChart', () => {
       await nextFrame();
       await elementUpdated();
       expect(el.shadowRoot.querySelector('[part=legend]').className).to.not.include('horizontal');
+    });
+
+    it('Should has dynamic left position in legend when the chart set y axis at left', async () => {
+      el.config = linePositionLeft;
+      await elementUpdated();
+      await nextFrame();
+
+      expect(el.chart).to.not.be.undefined;
+      expect(el.chart).to.not.be.null;
+      const legendStyle = getComputedStyle(el.shadowRoot.querySelector('[part=legend]'));
+      const legendLeftPosition = Number(legendStyle.left.substring(0,legendStyle.left.indexOf('px')))
+      expect(legendStyle.position).to.equal('absolute');
+      expect(legendLeftPosition).to.greaterThan(el.DEFAULT_LEGEND_LEFT_POSITION);
+    });
+    it('Should has dynamic left position in legend when the chart set y axis at both edge', async () => {
+      el.config = twoPriceScales;
+      await elementUpdated();
+      await nextFrame();
+
+      expect(el.chart).to.not.be.undefined;
+      expect(el.chart).to.not.be.null;
+      const legendStyle = getComputedStyle(el.shadowRoot.querySelector('[part=legend]'))
+      const legendLeftPosition = Number(legendStyle.left.substring(0,legendStyle.left.indexOf('px')))
+      expect(legendStyle.position).to.equal('absolute');
+      expect(legendLeftPosition).to.greaterThan(el.DEFAULT_LEGEND_LEFT_POSITION);
     });
   });
 });

--- a/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
+++ b/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
@@ -1,7 +1,7 @@
 import { fixture, fixtureSync, expect, elementUpdated, oneEvent, nextFrame, aTimeout } from '@refinitiv-ui/test-helpers';
 
 // import element and theme
-import '@refinitiv-ui/elements/interactive-chart';
+import { InteractiveChart } from '@refinitiv-ui/elements/interactive-chart';
 import '@refinitiv-ui/elemental-theme/light/ef-interactive-chart.js';
 let line = {
   series: [
@@ -841,7 +841,7 @@ describe('interactive-chart/InteractiveChart', () => {
     const legendStyle = getComputedStyle(el.shadowRoot.querySelector('[part=legend]'));
     const legendLeftPosition = Number(legendStyle.left.substring(0,legendStyle.left.indexOf('px')))
     expect(legendStyle.position).to.equal('absolute');
-    expect(legendLeftPosition).to.greaterThan(el.DEFAULT_LEGEND_LEFT_POSITION);
+    expect(legendLeftPosition).to.greaterThan(InteractiveChart.DEFAULT_LEGEND_LEFT_POSITION);
   });
 
   it('Should has dynamic left position in legend when the chart set y axis at both edge', async () => {
@@ -854,7 +854,7 @@ describe('interactive-chart/InteractiveChart', () => {
     const legendStyle = getComputedStyle(el.shadowRoot.querySelector('[part=legend]'))
     const legendLeftPosition = Number(legendStyle.left.substring(0,legendStyle.left.indexOf('px')))
     expect(legendStyle.position).to.equal('absolute');
-    expect(legendLeftPosition).to.greaterThan(el.DEFAULT_LEGEND_LEFT_POSITION);
+    expect(legendLeftPosition).to.greaterThan(InteractiveChart.DEFAULT_LEGEND_LEFT_POSITION);
   });
 
   it('Should has fixed left position in legend when the chart set y axis at right edge', async () => {
@@ -867,7 +867,7 @@ describe('interactive-chart/InteractiveChart', () => {
     const legendStyle = getComputedStyle(el.shadowRoot.querySelector('[part=legend]'))
     const legendLeftPosition = Number(legendStyle.left.substring(0,legendStyle.left.indexOf('px')))
     expect(legendStyle.position).to.equal('absolute');
-    expect(legendLeftPosition).to.equal(el.DEFAULT_LEGEND_LEFT_POSITION);
+    expect(legendLeftPosition).to.equal(InteractiveChart.DEFAULT_LEGEND_LEFT_POSITION);
   });
 
   describe('Test deprecated attribute', () => {

--- a/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
+++ b/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
@@ -831,6 +831,45 @@ describe('interactive-chart/InteractiveChart', () => {
     expect(legendText[3].innerText.indexOf('$')).to.equal(0); // close
   });
 
+  it('Should has dynamic left position in legend when the chart set y axis at left', async () => {
+    el.config = linePositionLeft;
+    await elementUpdated();
+    await nextFrame();
+
+    expect(el.chart).to.not.be.undefined;
+    expect(el.chart).to.not.be.null;
+    const legendStyle = getComputedStyle(el.shadowRoot.querySelector('[part=legend]'));
+    const legendLeftPosition = Number(legendStyle.left.substring(0,legendStyle.left.indexOf('px')))
+    expect(legendStyle.position).to.equal('absolute');
+    expect(legendLeftPosition).to.greaterThan(el.DEFAULT_LEGEND_LEFT_POSITION);
+  });
+
+  it('Should has dynamic left position in legend when the chart set y axis at both edge', async () => {
+    el.config = twoPriceScales;
+    await elementUpdated();
+    await nextFrame();
+
+    expect(el.chart).to.not.be.undefined;
+    expect(el.chart).to.not.be.null;
+    const legendStyle = getComputedStyle(el.shadowRoot.querySelector('[part=legend]'))
+    const legendLeftPosition = Number(legendStyle.left.substring(0,legendStyle.left.indexOf('px')))
+    expect(legendStyle.position).to.equal('absolute');
+    expect(legendLeftPosition).to.greaterThan(el.DEFAULT_LEGEND_LEFT_POSITION);
+  });
+
+  it('Should has fixed left position in legend when the chart set y axis at right edge', async () => {
+    el.config = line;
+    await elementUpdated();
+    await nextFrame();
+
+    expect(el.chart).to.not.be.undefined;
+    expect(el.chart).to.not.be.null;
+    const legendStyle = getComputedStyle(el.shadowRoot.querySelector('[part=legend]'))
+    const legendLeftPosition = Number(legendStyle.left.substring(0,legendStyle.left.indexOf('px')))
+    expect(legendStyle.position).to.equal('absolute');
+    expect(legendLeftPosition).to.equal(el.DEFAULT_LEGEND_LEFT_POSITION);
+  });
+
   describe('Test deprecated attribute', () => {
     it('Switch attribute legendstyle horizontal to vertical, it should display vertical style', async () => {
       el = await fixture('<ef-interactive-chart legendstyle="horizontal"></ef-interactive-chart>');
@@ -861,43 +900,6 @@ describe('interactive-chart/InteractiveChart', () => {
       await nextFrame();
       await elementUpdated();
       expect(el.shadowRoot.querySelector('[part=legend]').className).to.not.include('horizontal');
-    });
-
-    it('Should has dynamic left position in legend when the chart set y axis at left', async () => {
-      el.config = linePositionLeft;
-      await elementUpdated();
-      await nextFrame();
-
-      expect(el.chart).to.not.be.undefined;
-      expect(el.chart).to.not.be.null;
-      const legendStyle = getComputedStyle(el.shadowRoot.querySelector('[part=legend]'));
-      const legendLeftPosition = Number(legendStyle.left.substring(0,legendStyle.left.indexOf('px')))
-      expect(legendStyle.position).to.equal('absolute');
-      expect(legendLeftPosition).to.greaterThan(el.DEFAULT_LEGEND_LEFT_POSITION);
-    });
-    it('Should has dynamic left position in legend when the chart set y axis at both edge', async () => {
-      el.config = twoPriceScales;
-      await elementUpdated();
-      await nextFrame();
-
-      expect(el.chart).to.not.be.undefined;
-      expect(el.chart).to.not.be.null;
-      const legendStyle = getComputedStyle(el.shadowRoot.querySelector('[part=legend]'))
-      const legendLeftPosition = Number(legendStyle.left.substring(0,legendStyle.left.indexOf('px')))
-      expect(legendStyle.position).to.equal('absolute');
-      expect(legendLeftPosition).to.greaterThan(el.DEFAULT_LEGEND_LEFT_POSITION);
-    });
-    it('Should has fixed left position in legend when the chart set y axis at right edge', async () => {
-      el.config = line;
-      await elementUpdated();
-      await nextFrame();
-
-      expect(el.chart).to.not.be.undefined;
-      expect(el.chart).to.not.be.null;
-      const legendStyle = getComputedStyle(el.shadowRoot.querySelector('[part=legend]'))
-      const legendLeftPosition = Number(legendStyle.left.substring(0,legendStyle.left.indexOf('px')))
-      expect(legendStyle.position).to.equal('absolute');
-      expect(legendLeftPosition).to.be(el.DEFAULT_LEGEND_LEFT_POSITION);
     });
   });
 });

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -86,6 +86,7 @@ export class InteractiveChart extends ResponsiveElement {
     LARGE_DASHED: 3,
     SPARSE_DOTTED: 4
   };
+  private DEFAULT_LEGEND_LEFT_POSITION = 15;
 
   private _legendStyle?: LegendStyle;
 
@@ -162,7 +163,6 @@ export class InteractiveChart extends ResponsiveElement {
 
   private hasDataPoint = false;
 
-  private DEFAULT_LEGEND_LEFT_POSITION = 15;
 
   /**
    * @returns return config of property component
@@ -718,7 +718,11 @@ export class InteractiveChart extends ResponsiveElement {
     this.createRowLegend(this.rowLegend, param);
   };
 
-  protected onTimeScaleSizeChange = (): void => {
+  /**
+   * Callback uses for sizeChange event
+   * @returns {void}
+   */
+  private onTimeScaleSizeChange = (): void => {
     this.handleLegendLeftPosition();
   };
 
@@ -726,7 +730,7 @@ export class InteractiveChart extends ResponsiveElement {
    * Handle left position of legend
    * @returns {void}
    */
-  protected handleLegendLeftPosition (): void {
+  private handleLegendLeftPosition (): void {
     const position = this.getPriceScalePosition();
     if (position === 'left' || position === 'two-price') {
       const leftPriceScaleWidth = this.chart?.priceScale('left').width() || 0;

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -163,7 +163,6 @@ export class InteractiveChart extends ResponsiveElement {
 
   private hasDataPoint = false;
 
-
   /**
    * @returns return config of property component
    */

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -86,7 +86,7 @@ export class InteractiveChart extends ResponsiveElement {
     LARGE_DASHED: 3,
     SPARSE_DOTTED: 4
   };
-  private DEFAULT_LEGEND_LEFT_POSITION = 15;
+  private static readonly DEFAULT_LEGEND_LEFT_POSITION = 15;
 
   private _legendStyle?: LegendStyle;
 
@@ -211,11 +211,11 @@ export class InteractiveChart extends ResponsiveElement {
     }
 
     if (changedProperties.has('disabledLegend')) {
-      this.onLegendChange(this.disabledLegend);
+      this.onLegendChange();
     }
 
     if (changedProperties.has('disabledJumpButton')) {
-      this.onJumpButtonChange(this.disabledJumpButton);
+      this.onJumpButtonChange();
     }
 
     if (changedProperties.has('deprecatedLegendStyle') || changedProperties.has('legend-style')) {
@@ -248,11 +248,10 @@ export class InteractiveChart extends ResponsiveElement {
 
   /**
   * Legend value observer
-  * @param disabledLegend Legend value
   * @returns {void}
   */
-  private onLegendChange (disabledLegend: boolean): void {
-    if (!disabledLegend) {
+  private onLegendChange (): void {
+    if (!this.disabledLegend) {
       this.createLegend();
     }
     else {
@@ -280,11 +279,10 @@ export class InteractiveChart extends ResponsiveElement {
 
   /**
   * Jump last value observer
-  * @param value jump last value
   * @returns {void}
   */
-  private onJumpButtonChange (value: boolean): void {
-    if (!value) {
+  private onJumpButtonChange (): void {
+    if (!this.disabledJumpButton) {
       this.createJumpButton(this.width, this.height);
     }
     else {
@@ -343,7 +341,9 @@ export class InteractiveChart extends ResponsiveElement {
       this.mergeConfig(config);
       this.applyChartOptionSize(width, height);
 
-      this.onLegendChange(this.disabledLegend);
+      if (!this.disabledLegend) {
+        this.createLegend();
+      }
 
       if (this.legendStyle === 'horizontal') {
         this.legendContainer.classList.add(this.legendStyle);
@@ -730,8 +730,10 @@ export class InteractiveChart extends ResponsiveElement {
    * @returns {void}
    */
   private handleLegendLeftPosition (): void {
-    const leftPriceScaleWidth = this.chart?.priceScale('left').width() || 0;
-    this.legendContainer.style.left = `${leftPriceScaleWidth + this.DEFAULT_LEGEND_LEFT_POSITION}px`;
+    const leftPriceScaleWidth = this.chart?.priceScale('left')?.width() || 0;
+    if (this.legendContainer) {
+      this.legendContainer.style.left = `${leftPriceScaleWidth + InteractiveChart.DEFAULT_LEGEND_LEFT_POSITION}px`;
+    }
   }
 
   /**
@@ -1200,6 +1202,11 @@ export class InteractiveChart extends ResponsiveElement {
         position: relative;
         height: 300px;
         z-index: 0;
+      }
+
+      [part=legend] {
+        position: absolute;
+        z-index: 1000;
       }
     `;
   }

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -731,14 +731,8 @@ export class InteractiveChart extends ResponsiveElement {
    * @returns {void}
    */
   private handleLegendLeftPosition (): void {
-    const position = this.getPriceScalePosition();
-    if (position === 'left' || position === 'two-price') {
-      const leftPriceScaleWidth = this.chart?.priceScale('left').width() || 0;
-      this.legendContainer.style.left = `${leftPriceScaleWidth + this.DEFAULT_LEGEND_LEFT_POSITION}px`;
-    }
-    else {
-      this.legendContainer.style.left = '15px';
-    }
+    const leftPriceScaleWidth = this.chart?.priceScale('left').width() || 0;
+    this.legendContainer.style.left = `${leftPriceScaleWidth + this.DEFAULT_LEGEND_LEFT_POSITION}px`;
   }
 
   /**

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -745,7 +745,10 @@ export class InteractiveChart extends ResponsiveElement {
         this.rowLegend = this.shadowRoot.querySelectorAll('.row');
       }
       this.chart.subscribeCrosshairMove(this.handleCrosshairMoved);
-      // Legend relates to value of each series that relate to priceScale. But the axis is no event for now. So use x-axis instead.
+      /* Add a subscription to resizing time scale (x-axis). The event triggers after the chart rendered.
+       * So that we can know the priceScale (y-axis) width.
+       * Legend relates to priceScale directly. But the axis doesn't have event for now. So use x-axis instead.
+       */
       this.chart.timeScale().subscribeSizeChange(this.onTimeScaleSizeChange);
       this.legendInitialized = true;
     }


### PR DESCRIPTION
## Description
The legend is overlap the left y-axis when the width of y-axis is too large.
Here an error link: https://codepen.io/sirirats/pen/yLKYRQd?editors=1010

Fixes # ([ELF-1931](https://jira.refinitiv.com/browse/ELF-1931))

Solution:
Add callback to calculate Legend's left position when the chart has left y-axis. The callback is subscribed to sizeChange event that attached on x-axis. The sizeChange event called when width or height is changed and called after rendered. Actually, legend relate to Y-axis but lightweight-chart doesn't have event for y-axis, 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
