### PR TITLE
fix(autosuggest): fix invalid label when disabled suggestion item

### DIFF
--- a/packages/elements/src/autosuggest/__test__/autosuggest-functional.test.js
+++ b/packages/elements/src/autosuggest/__test__/autosuggest-functional.test.js
@@ -786,7 +786,7 @@ describe('autosuggest/Functional', () => {
       expect(document.activeElement).to.equal(input);
     });
 
-    it('Item should display as item.label when item is disabled', async function () {
+    it('Item should use item.label when it is disabled', async function () {
       if (isIE()) {
         this.skip();
       }

--- a/packages/elements/src/autosuggest/__test__/autosuggest-functional.test.js
+++ b/packages/elements/src/autosuggest/__test__/autosuggest-functional.test.js
@@ -785,5 +785,61 @@ describe('autosuggest/Functional', () => {
 
       expect(document.activeElement).to.equal(input);
     });
+
+    it('Item should display as item.label when item is disabled', async function () {
+      if (isIE()) {
+        this.skip();
+      }
+      const input = await createInputElement();
+      const autoSuggest = await createFixture('navigation');
+      const suggestLabel = 'Cornelius';
+
+      const modifiedData = [...data];
+      modifiedData[0].disabled = true;
+
+      autoSuggest.suggestions = modifiedData;
+      await elementUpdated(autoSuggest);
+
+      await focusAction(input);
+      input.value = suggestLabel;
+      await inputAction(input);
+
+      setTimeout(() => pressKey(input, 'Enter'));
+
+      await oneEvent(autoSuggest, 'opened-changed');
+      expect(autoSuggest.opened).to.equal(true);
+
+      expect(autoSuggest.querySelector('ef-item').label).to.equal(modifiedData[0].label);
+      expect(autoSuggest.querySelector('ef-item').disabled).to.equal(modifiedData[0].disabled);
+    });
+
+    it('Item should display as item.value when item is disabled and has no label', async function () {
+      if (isIE()) {
+        this.skip();
+      }
+      const input = await createInputElement();
+      const autoSuggest = await createFixture('navigation');
+      const suggestLabel = 'Cornelius';
+
+      const modifiedData = [...data];
+      modifiedData[0].disabled = true;
+      modifiedData[0].label = undefined;
+      modifiedData[0].value = 'Cornelius';
+
+      autoSuggest.suggestions = modifiedData;
+      await elementUpdated(autoSuggest);
+
+      await focusAction(input);
+      input.value = suggestLabel;
+      await inputAction(input);
+
+      setTimeout(() => pressKey(input, 'Enter'));
+
+      await oneEvent(autoSuggest, 'opened-changed');
+      expect(autoSuggest.opened).to.equal(true);
+
+      expect(autoSuggest.querySelector('ef-item').label).to.equal(modifiedData[0].value);
+      expect(autoSuggest.querySelector('ef-item').disabled).to.equal(modifiedData[0].disabled);
+    });
   });
 });

--- a/packages/elements/src/autosuggest/__test__/autosuggest-functional.test.js
+++ b/packages/elements/src/autosuggest/__test__/autosuggest-functional.test.js
@@ -813,7 +813,7 @@ describe('autosuggest/Functional', () => {
       expect(autoSuggest.querySelector('ef-item').disabled).to.equal(modifiedData[0].disabled);
     });
 
-    it('Item should display as item.value when item is disabled and has no label', async function () {
+    it('Item should use item.value as display text when it is disabled and has no label', async function () {
       if (isIE()) {
         this.skip();
       }

--- a/packages/elements/src/autosuggest/helpers/utils.ts
+++ b/packages/elements/src/autosuggest/helpers/utils.ts
@@ -52,6 +52,6 @@ export const updateElementContent = (el: Item, query: string, label: string, val
     el.innerHTML = queryWordSelect(label, query);
   }
   else {
-    el.label = label;
+    el.label = label || `${value}`;
   }
 };

--- a/packages/elements/src/autosuggest/helpers/utils.ts
+++ b/packages/elements/src/autosuggest/helpers/utils.ts
@@ -52,6 +52,6 @@ export const updateElementContent = (el: Item, query: string, label: string, val
     el.innerHTML = queryWordSelect(label, query);
   }
   else {
-    el.label = `${value}`;
+    el.label = label;
   }
 };


### PR DESCRIPTION
## Description
When autosuggest item has a value and has been disabled, autosuggest item will show value text instead of showing label text.

Steps to Reproduce:
1. Open demo link
2. Type "e" to text field

https://codepen.io/iamatomath/pen/RwywGRe

Expected Results:
Autosuggest first item show text "Cornelius Martin"

Actual Results:
Autosuggest first item show text "1"

Fixes # ([ELF-1982](https://jira.refinitiv.com/browse/ELF-1982))


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
