### PR TITLE
chore: upgrade typescript to 4.8.3 and update all formatjs dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
       "devDependencies": {
         "@commitlint/cli": "^17.0.2",
         "@commitlint/config-conventional": "^17.0.2",
-        "@formatjs/intl-getcanonicallocales": "^1.8.0",
-        "@formatjs/intl-locale": "^2.4.41",
-        "@formatjs/intl-numberformat": "^7.2.6",
-        "@formatjs/intl-pluralrules": "^4.1.6",
+        "@formatjs/intl-getcanonicallocales": "^2.0.4",
+        "@formatjs/intl-locale": "^3.0.6",
+        "@formatjs/intl-numberformat": "^8.1.3",
+        "@formatjs/intl-pluralrules": "^5.1.3",
         "@nrwl/cli": "latest",
         "@nrwl/tao": "latest",
         "@nrwl/workspace": "latest",
@@ -45,7 +45,7 @@
         "micromatch": "^4.0.4",
         "request": "^2.88.2",
         "sinon": "^9.2.4",
-        "typescript": "~4.6.4",
+        "typescript": "^4.8.3",
         "watch": "^1.0.2",
         "web-component-analyzer": "2.0.0-next.4",
         "yargs": "^17.0.1"
@@ -57,10 +57,10 @@
     },
     "documents": {
       "name": "@refinitiv-ui/docs",
-      "version": "6.1.1",
+      "version": "6.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@refinitiv-ui/elements": "^6.1.1",
+        "@refinitiv-ui/elements": "^6.2.0",
         "fast-glob": "^3.2.7",
         "fs-extra": "^10.0.0"
       },
@@ -2184,123 +2184,89 @@
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",
-      "integrity": "sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.12.0.tgz",
+      "integrity": "sha512-0/wm9b7brUD40kx7KSE0S532T8EfH06Zc41rGlinoNyYXnuusR6ull2x63iFJgVXgwahm42hAW7dcYdZ+llZzA==",
       "dependencies": {
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
+        "@formatjs/intl-localematcher": "0.2.31",
+        "tslib": "2.4.0"
       }
     },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
-      "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.6.tgz",
+      "integrity": "sha512-9CWZ3+wCkClKHX+i5j+NyoBVqGf0pIskTo6Xl6ihGokYM2yqSSS68JIgeo+99UIHc+7vi9L3/SDSz/dWI9SNlA==",
       "dependencies": {
-        "tslib": "^2.1.0"
+        "tslib": "2.4.0"
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.4.tgz",
-      "integrity": "sha512-3PqMvKWV1oyok0BuiXUAHIaotdhdTJw6OICqCZbfUgKT+ZRwRWO4IlCgvXJeCITaKS5p+PY0XXKjf/vUyIpWjQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.7.tgz",
+      "integrity": "sha512-KM4ikG5MloXMulqn39Js3ypuVzpPKq/DDplvl01PE2qD9rAzFO8YtaUCC9vr9j3sRXwdHPeTe8r3J/8IJgvYEQ==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.8",
-        "@formatjs/icu-skeleton-parser": "1.3.10",
-        "tslib": "2.4.0"
-      }
-    },
-    "node_modules/@formatjs/icu-messageformat-parser/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.11.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.8.tgz",
-      "integrity": "sha512-fgLqyWlwmTEuqV/TSLEL/t9JOmHNLFvCdgzXB0jc2w+WOItPCOJ1T0eyN6fQBQKRPfSqqNlu+kWj7ijcOVTVVQ==",
-      "dependencies": {
-        "@formatjs/intl-localematcher": "0.2.28",
-        "tslib": "2.4.0"
-      }
-    },
-    "node_modules/@formatjs/icu-messageformat-parser/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.28.tgz",
-      "integrity": "sha512-FLsc6Gifs1np/8HnCn/7Q+lHMmenrD5fuDhRT82yj0gi9O19kfaFwjQUw1gZsyILuRyT93GuzdifHj7TKRhBcw==",
-      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.12.0",
+        "@formatjs/icu-skeleton-parser": "1.3.13",
         "tslib": "2.4.0"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.10.tgz",
-      "integrity": "sha512-kXJmtLDqFF5aLTf8IxdJXnhrIX1Qb4Qp3a9jqRecGDYfzOa9hMhi9U0nKyhrJJ4cXxBzptcgb+LWkyeHL6nlBQ==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.13.tgz",
+      "integrity": "sha512-qb1kxnA4ep76rV+d9JICvZBThBpK5X+nh1dLmmIReX72QyglicsaOmKEcdcbp7/giCWfhVs6CXPVA2JJ5/ZvAw==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.8",
-        "tslib": "2.4.0"
-      }
-    },
-    "node_modules/@formatjs/icu-skeleton-parser/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.11.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.8.tgz",
-      "integrity": "sha512-fgLqyWlwmTEuqV/TSLEL/t9JOmHNLFvCdgzXB0jc2w+WOItPCOJ1T0eyN6fQBQKRPfSqqNlu+kWj7ijcOVTVVQ==",
-      "dependencies": {
-        "@formatjs/intl-localematcher": "0.2.28",
-        "tslib": "2.4.0"
-      }
-    },
-    "node_modules/@formatjs/icu-skeleton-parser/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.28.tgz",
-      "integrity": "sha512-FLsc6Gifs1np/8HnCn/7Q+lHMmenrD5fuDhRT82yj0gi9O19kfaFwjQUw1gZsyILuRyT93GuzdifHj7TKRhBcw==",
-      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.12.0",
         "tslib": "2.4.0"
       }
     },
     "node_modules/@formatjs/intl-getcanonicallocales": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.9.2.tgz",
-      "integrity": "sha512-69WTStIJI2ikErOU1Il4NQKLVV8f2x6awr7+/dZz0uihuI7uQRcZtI6k/BBt4EtYaEl6w65YjUF93VuE015C0w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-2.0.4.tgz",
+      "integrity": "sha512-+Sd9QcfnUQlo/hnBq8Czh3TyVgHWK1AW2fAlUABLCd6zVxJwFpHX20CATetH9lKKgbaG8fOP/ijn/7So6aa2fQ==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.1.0"
+        "tslib": "2.4.0"
       }
     },
     "node_modules/@formatjs/intl-locale": {
-      "version": "2.4.47",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.47.tgz",
-      "integrity": "sha512-yEpjx6RgVVG3pPsxb/jydhnq/A02KmjMste5U/wWxscRK0sny8LPIoBwgkOQycRoMRLNlLemJaQB7VbHZJ9OVg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-3.0.6.tgz",
+      "integrity": "sha512-vP3zSl74frX24UuiCXxUBjDmyg3tWaSN4Yep9m74fJF81VkxanQSUtQVQKKv8CzBmrwFPc1c5LF7co801zPp8Q==",
       "dev": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/intl-getcanonicallocales": "1.9.2",
-        "tslib": "^2.1.0"
+        "@formatjs/ecma402-abstract": "1.12.0",
+        "@formatjs/intl-getcanonicallocales": "2.0.4",
+        "tslib": "2.4.0"
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz",
-      "integrity": "sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==",
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.31.tgz",
+      "integrity": "sha512-9QTjdSBpQ7wHShZgsNzNig5qT3rCPvmZogS/wXZzKotns5skbXgs0I7J8cuN0PPqXyynvNVuN+iOKhNS2eb+ZA==",
       "dependencies": {
-        "tslib": "^2.1.0"
+        "tslib": "2.4.0"
       }
     },
     "node_modules/@formatjs/intl-numberformat": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-7.4.3.tgz",
-      "integrity": "sha512-oxhLCw00YO7brwMPqGD+ui5gdeWoMiRhqsRSqwsDSRd03aJ/N3/VZQDoxGIn3IM9bhlPM5W0ckXiXuOMFLszjw==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-8.1.3.tgz",
+      "integrity": "sha512-OLa6/k7rzLCPfNnoCYE1nStZAU6dswFYrTNCyWpDt0uP5UOR6bgpYpLg0ZcnJX9MhV2ZEtcc69bvhL6pULxwDw==",
       "dev": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
+        "@formatjs/ecma402-abstract": "1.12.0",
+        "@formatjs/intl-localematcher": "0.2.31",
+        "tslib": "2.4.0"
       }
     },
     "node_modules/@formatjs/intl-pluralrules": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-4.3.3.tgz",
-      "integrity": "sha512-NLZN8gf2qLpCuc0m565IbKLNUarEGOzk0mkdTkE4XTuNCofzoQTurW6lL3fmDlneAoYl2FiTdHa5q4o2vZF50g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-5.1.3.tgz",
+      "integrity": "sha512-jNEDAXhwpxO1IjOY+UNk7l5SLHX6QCIvJHd40q/HXyThLZULbweayam2rMMhoa/et5dW7K574qYwk2JIeiyxPA==",
       "dev": true,
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
+        "@formatjs/ecma402-abstract": "1.12.0",
+        "@formatjs/intl-localematcher": "0.2.31",
+        "tslib": "2.4.0"
       }
     },
     "node_modules/@formatjs/intl-utils": {
@@ -12121,33 +12087,14 @@
       "integrity": "sha512-OEUYNA7D06agqPOYhbTkl0T8HA3QKSuwWh1HiClEnpd9vw7N+3XsQt5iZ0GUEchp5CW1fQk/tary+NsbF3yQ1Q=="
     },
     "node_modules/intl-messageformat": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.13.0.tgz",
-      "integrity": "sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.1.4.tgz",
+      "integrity": "sha512-tXCmWCXhbeHOF28aIf5b9ce3kwdwGyIiiSXVZsyDwksMiGn5Tp0MrMvyeuHuz4uN1UL+NfGOztHmE+6aLFp1wQ==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/fast-memoize": "1.2.1",
-        "@formatjs/icu-messageformat-parser": "2.1.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/intl-messageformat/node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.0.tgz",
-      "integrity": "sha512-Qxv/lmCN6hKpBSss2uQ8IROVnta2r9jd3ymUEIjm2UyIkUCHVcbUVRGL/KS/wv7876edvsPe+hjHVJ4z8YuVaw==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/icu-skeleton-parser": "1.3.6",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/intl-messageformat/node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.6.tgz",
-      "integrity": "sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "tslib": "^2.1.0"
+        "@formatjs/ecma402-abstract": "1.12.0",
+        "@formatjs/fast-memoize": "1.2.6",
+        "@formatjs/icu-messageformat-parser": "2.1.7",
+        "tslib": "2.4.0"
       }
     },
     "node_modules/ip": {
@@ -19956,9 +19903,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21143,12 +21090,12 @@
         "eslint": "^8.18.0",
         "eslint-plugin-html": "^6.2.0",
         "eslint-plugin-import": "^2.26.0",
-        "typescript": "~4.6.4"
+        "typescript": "^4.8.3"
       }
     },
     "packages/core": {
       "name": "@refinitiv-ui/core",
-      "version": "6.0.5",
+      "version": "6.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@juggle/resize-observer": "^3.3.1",
@@ -21157,33 +21104,33 @@
       },
       "devDependencies": {
         "@refinitiv-ui/test-helpers": "^6.0.4",
-        "@refinitiv-ui/utils": "^6.0.4"
+        "@refinitiv-ui/utils": "^6.1.0"
       },
       "peerDependencies": {
-        "@refinitiv-ui/utils": "^6.0.4"
+        "@refinitiv-ui/utils": "^6.1.0"
       }
     },
     "packages/demo-block": {
       "name": "@refinitiv-ui/demo-block",
-      "version": "6.0.6",
+      "version": "6.0.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@refinitiv-ui/elemental-theme": "^6.0.5",
-        "@refinitiv-ui/halo-theme": "^6.1.4",
-        "@refinitiv-ui/solar-theme": "^6.0.5",
+        "@refinitiv-ui/elemental-theme": "^6.1.0",
+        "@refinitiv-ui/halo-theme": "^6.2.0",
+        "@refinitiv-ui/solar-theme": "^6.1.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@refinitiv-ui/core": "^6.0.5",
+        "@refinitiv-ui/core": "^6.0.6",
         "@refinitiv-ui/test-helpers": "^6.0.4"
       },
       "peerDependencies": {
-        "@refinitiv-ui/core": "^6.0.5"
+        "@refinitiv-ui/core": "^6.0.6"
       }
     },
     "packages/elemental-theme": {
       "name": "@refinitiv-ui/elemental-theme",
-      "version": "6.0.5",
+      "version": "6.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@refinitiv-ui/theme-compiler": "^6.0.4"
@@ -21191,12 +21138,12 @@
     },
     "packages/elements": {
       "name": "@refinitiv-ui/elements",
-      "version": "6.1.1",
+      "version": "6.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@refinitiv-ui/browser-sparkline": "1.1.8",
-        "@refinitiv-ui/halo-theme": "^6.1.4",
-        "@refinitiv-ui/solar-theme": "^6.0.5",
+        "@refinitiv-ui/halo-theme": "^6.2.0",
+        "@refinitiv-ui/solar-theme": "^6.1.0",
         "@types/chart.js": "^2.9.31",
         "chart.js": "~2.9.4",
         "d3-interpolate": "^3.0.1",
@@ -21205,29 +21152,29 @@
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@refinitiv-ui/core": "^6.0.5",
-        "@refinitiv-ui/demo-block": "^6.0.6",
-        "@refinitiv-ui/i18n": "^6.0.4",
-        "@refinitiv-ui/phrasebook": "^6.1.3",
+        "@refinitiv-ui/core": "^6.0.6",
+        "@refinitiv-ui/demo-block": "^6.0.7",
+        "@refinitiv-ui/i18n": "^6.0.5",
+        "@refinitiv-ui/phrasebook": "^6.2.0",
         "@refinitiv-ui/test-helpers": "^6.0.4",
-        "@refinitiv-ui/translate": "^6.0.5",
-        "@refinitiv-ui/utils": "^6.0.4",
+        "@refinitiv-ui/translate": "^6.0.6",
+        "@refinitiv-ui/utils": "^6.1.0",
         "@types/d3-interpolate": "^3.0.1"
       },
       "peerDependencies": {
-        "@refinitiv-ui/core": "^6.0.5",
-        "@refinitiv-ui/i18n": "^6.0.4",
-        "@refinitiv-ui/phrasebook": "^6.1.3",
-        "@refinitiv-ui/translate": "^6.0.5",
-        "@refinitiv-ui/utils": "^6.0.4"
+        "@refinitiv-ui/core": "^6.0.6",
+        "@refinitiv-ui/i18n": "^6.0.5",
+        "@refinitiv-ui/phrasebook": "^6.2.0",
+        "@refinitiv-ui/translate": "^6.0.6",
+        "@refinitiv-ui/utils": "^6.1.0"
       }
     },
     "packages/halo-theme": {
       "name": "@refinitiv-ui/halo-theme",
-      "version": "6.1.4",
+      "version": "6.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@refinitiv-ui/elemental-theme": "^6.0.5"
+        "@refinitiv-ui/elemental-theme": "^6.1.0"
       },
       "devDependencies": {
         "@refinitiv-ui/theme-compiler": "^6.0.4"
@@ -21235,26 +21182,26 @@
     },
     "packages/i18n": {
       "name": "@refinitiv-ui/i18n",
-      "version": "6.0.4",
+      "version": "6.0.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@formatjs/icu-messageformat-parser": "^2.0.15",
+        "@formatjs/icu-messageformat-parser": "^2.1.7",
         "@formatjs/intl-utils": "^3.8.4",
         "intl-format-cache": "^4.3.1",
-        "intl-messageformat": "^9.10.0",
+        "intl-messageformat": "^10.1.4",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@refinitiv-ui/phrasebook": "^6.1.3",
+        "@refinitiv-ui/phrasebook": "^6.2.0",
         "@refinitiv-ui/test-helpers": "^6.0.4"
       },
       "peerDependencies": {
-        "@refinitiv-ui/phrasebook": "^6.1.3"
+        "@refinitiv-ui/phrasebook": "^6.2.0"
       }
     },
     "packages/phrasebook": {
       "name": "@refinitiv-ui/phrasebook",
-      "version": "6.1.3",
+      "version": "6.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -21281,10 +21228,10 @@
     },
     "packages/solar-theme": {
       "name": "@refinitiv-ui/solar-theme",
-      "version": "6.0.5",
+      "version": "6.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@refinitiv-ui/elemental-theme": "^6.0.5"
+        "@refinitiv-ui/elemental-theme": "^6.1.0"
       },
       "devDependencies": {
         "@refinitiv-ui/theme-compiler": "^6.0.4"
@@ -21842,26 +21789,26 @@
     },
     "packages/translate": {
       "name": "@refinitiv-ui/translate",
-      "version": "6.0.5",
+      "version": "6.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "lit": "^2.2.7",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
-        "@refinitiv-ui/core": "^6.0.5",
-        "@refinitiv-ui/i18n": "^6.0.4",
-        "@refinitiv-ui/phrasebook": "^6.1.3",
+        "@refinitiv-ui/core": "^6.0.6",
+        "@refinitiv-ui/i18n": "^6.0.5",
+        "@refinitiv-ui/phrasebook": "^6.2.0",
         "@refinitiv-ui/test-helpers": "^6.0.4"
       },
       "peerDependencies": {
-        "@refinitiv-ui/i18n": "^6.0.4",
-        "@refinitiv-ui/phrasebook": "^6.1.3"
+        "@refinitiv-ui/i18n": "^6.0.5",
+        "@refinitiv-ui/phrasebook": "^6.2.0"
       }
     },
     "packages/utils": {
       "name": "@refinitiv-ui/utils",
-      "version": "6.0.4",
+      "version": "6.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/d3-color": "^3.0.2",
@@ -23385,127 +23332,89 @@
       }
     },
     "@formatjs/ecma402-abstract": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",
-      "integrity": "sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.12.0.tgz",
+      "integrity": "sha512-0/wm9b7brUD40kx7KSE0S532T8EfH06Zc41rGlinoNyYXnuusR6ull2x63iFJgVXgwahm42hAW7dcYdZ+llZzA==",
       "requires": {
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
+        "@formatjs/intl-localematcher": "0.2.31",
+        "tslib": "2.4.0"
       }
     },
     "@formatjs/fast-memoize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
-      "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.6.tgz",
+      "integrity": "sha512-9CWZ3+wCkClKHX+i5j+NyoBVqGf0pIskTo6Xl6ihGokYM2yqSSS68JIgeo+99UIHc+7vi9L3/SDSz/dWI9SNlA==",
       "requires": {
-        "tslib": "^2.1.0"
+        "tslib": "2.4.0"
       }
     },
     "@formatjs/icu-messageformat-parser": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.4.tgz",
-      "integrity": "sha512-3PqMvKWV1oyok0BuiXUAHIaotdhdTJw6OICqCZbfUgKT+ZRwRWO4IlCgvXJeCITaKS5p+PY0XXKjf/vUyIpWjQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.7.tgz",
+      "integrity": "sha512-KM4ikG5MloXMulqn39Js3ypuVzpPKq/DDplvl01PE2qD9rAzFO8YtaUCC9vr9j3sRXwdHPeTe8r3J/8IJgvYEQ==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.8",
-        "@formatjs/icu-skeleton-parser": "1.3.10",
+        "@formatjs/ecma402-abstract": "1.12.0",
+        "@formatjs/icu-skeleton-parser": "1.3.13",
         "tslib": "2.4.0"
-      },
-      "dependencies": {
-        "@formatjs/ecma402-abstract": {
-          "version": "1.11.8",
-          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.8.tgz",
-          "integrity": "sha512-fgLqyWlwmTEuqV/TSLEL/t9JOmHNLFvCdgzXB0jc2w+WOItPCOJ1T0eyN6fQBQKRPfSqqNlu+kWj7ijcOVTVVQ==",
-          "requires": {
-            "@formatjs/intl-localematcher": "0.2.28",
-            "tslib": "2.4.0"
-          }
-        },
-        "@formatjs/intl-localematcher": {
-          "version": "0.2.28",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.28.tgz",
-          "integrity": "sha512-FLsc6Gifs1np/8HnCn/7Q+lHMmenrD5fuDhRT82yj0gi9O19kfaFwjQUw1gZsyILuRyT93GuzdifHj7TKRhBcw==",
-          "requires": {
-            "tslib": "2.4.0"
-          }
-        }
       }
     },
     "@formatjs/icu-skeleton-parser": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.10.tgz",
-      "integrity": "sha512-kXJmtLDqFF5aLTf8IxdJXnhrIX1Qb4Qp3a9jqRecGDYfzOa9hMhi9U0nKyhrJJ4cXxBzptcgb+LWkyeHL6nlBQ==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.13.tgz",
+      "integrity": "sha512-qb1kxnA4ep76rV+d9JICvZBThBpK5X+nh1dLmmIReX72QyglicsaOmKEcdcbp7/giCWfhVs6CXPVA2JJ5/ZvAw==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.8",
+        "@formatjs/ecma402-abstract": "1.12.0",
         "tslib": "2.4.0"
-      },
-      "dependencies": {
-        "@formatjs/ecma402-abstract": {
-          "version": "1.11.8",
-          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.8.tgz",
-          "integrity": "sha512-fgLqyWlwmTEuqV/TSLEL/t9JOmHNLFvCdgzXB0jc2w+WOItPCOJ1T0eyN6fQBQKRPfSqqNlu+kWj7ijcOVTVVQ==",
-          "requires": {
-            "@formatjs/intl-localematcher": "0.2.28",
-            "tslib": "2.4.0"
-          }
-        },
-        "@formatjs/intl-localematcher": {
-          "version": "0.2.28",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.28.tgz",
-          "integrity": "sha512-FLsc6Gifs1np/8HnCn/7Q+lHMmenrD5fuDhRT82yj0gi9O19kfaFwjQUw1gZsyILuRyT93GuzdifHj7TKRhBcw==",
-          "requires": {
-            "tslib": "2.4.0"
-          }
-        }
       }
     },
     "@formatjs/intl-getcanonicallocales": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.9.2.tgz",
-      "integrity": "sha512-69WTStIJI2ikErOU1Il4NQKLVV8f2x6awr7+/dZz0uihuI7uQRcZtI6k/BBt4EtYaEl6w65YjUF93VuE015C0w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-2.0.4.tgz",
+      "integrity": "sha512-+Sd9QcfnUQlo/hnBq8Czh3TyVgHWK1AW2fAlUABLCd6zVxJwFpHX20CATetH9lKKgbaG8fOP/ijn/7So6aa2fQ==",
       "dev": true,
       "requires": {
-        "tslib": "^2.1.0"
+        "tslib": "2.4.0"
       }
     },
     "@formatjs/intl-locale": {
-      "version": "2.4.47",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.47.tgz",
-      "integrity": "sha512-yEpjx6RgVVG3pPsxb/jydhnq/A02KmjMste5U/wWxscRK0sny8LPIoBwgkOQycRoMRLNlLemJaQB7VbHZJ9OVg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-3.0.6.tgz",
+      "integrity": "sha512-vP3zSl74frX24UuiCXxUBjDmyg3tWaSN4Yep9m74fJF81VkxanQSUtQVQKKv8CzBmrwFPc1c5LF7co801zPp8Q==",
       "dev": true,
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/intl-getcanonicallocales": "1.9.2",
-        "tslib": "^2.1.0"
+        "@formatjs/ecma402-abstract": "1.12.0",
+        "@formatjs/intl-getcanonicallocales": "2.0.4",
+        "tslib": "2.4.0"
       }
     },
     "@formatjs/intl-localematcher": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz",
-      "integrity": "sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==",
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.31.tgz",
+      "integrity": "sha512-9QTjdSBpQ7wHShZgsNzNig5qT3rCPvmZogS/wXZzKotns5skbXgs0I7J8cuN0PPqXyynvNVuN+iOKhNS2eb+ZA==",
       "requires": {
-        "tslib": "^2.1.0"
+        "tslib": "2.4.0"
       }
     },
     "@formatjs/intl-numberformat": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-7.4.3.tgz",
-      "integrity": "sha512-oxhLCw00YO7brwMPqGD+ui5gdeWoMiRhqsRSqwsDSRd03aJ/N3/VZQDoxGIn3IM9bhlPM5W0ckXiXuOMFLszjw==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-8.1.3.tgz",
+      "integrity": "sha512-OLa6/k7rzLCPfNnoCYE1nStZAU6dswFYrTNCyWpDt0uP5UOR6bgpYpLg0ZcnJX9MhV2ZEtcc69bvhL6pULxwDw==",
       "dev": true,
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
+        "@formatjs/ecma402-abstract": "1.12.0",
+        "@formatjs/intl-localematcher": "0.2.31",
+        "tslib": "2.4.0"
       }
     },
     "@formatjs/intl-pluralrules": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-4.3.3.tgz",
-      "integrity": "sha512-NLZN8gf2qLpCuc0m565IbKLNUarEGOzk0mkdTkE4XTuNCofzoQTurW6lL3fmDlneAoYl2FiTdHa5q4o2vZF50g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-5.1.3.tgz",
+      "integrity": "sha512-jNEDAXhwpxO1IjOY+UNk7l5SLHX6QCIvJHd40q/HXyThLZULbweayam2rMMhoa/et5dW7K574qYwk2JIeiyxPA==",
       "dev": true,
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
+        "@formatjs/ecma402-abstract": "1.12.0",
+        "@formatjs/intl-localematcher": "0.2.31",
+        "tslib": "2.4.0"
       }
     },
     "@formatjs/intl-utils": {
@@ -25736,7 +25645,7 @@
       "requires": {
         "@juggle/resize-observer": "^3.3.1",
         "@refinitiv-ui/test-helpers": "^6.0.4",
-        "@refinitiv-ui/utils": "^6.0.4",
+        "@refinitiv-ui/utils": "^6.1.0",
         "lit": "^2.2.7",
         "tslib": "^2.3.1"
       }
@@ -25744,10 +25653,10 @@
     "@refinitiv-ui/demo-block": {
       "version": "file:packages/demo-block",
       "requires": {
-        "@refinitiv-ui/core": "^6.0.5",
-        "@refinitiv-ui/elemental-theme": "^6.0.5",
-        "@refinitiv-ui/halo-theme": "^6.1.4",
-        "@refinitiv-ui/solar-theme": "^6.0.5",
+        "@refinitiv-ui/core": "^6.0.6",
+        "@refinitiv-ui/elemental-theme": "^6.1.0",
+        "@refinitiv-ui/halo-theme": "^6.2.0",
+        "@refinitiv-ui/solar-theme": "^6.1.0",
         "@refinitiv-ui/test-helpers": "^6.0.4",
         "tslib": "^2.3.1"
       }
@@ -25755,7 +25664,7 @@
     "@refinitiv-ui/docs": {
       "version": "file:documents",
       "requires": {
-        "@refinitiv-ui/elements": "^6.1.1",
+        "@refinitiv-ui/elements": "^6.2.0",
         "chalk": "^4.1.2",
         "concurrently": "^6.4.0",
         "fast-glob": "^3.2.7",
@@ -25774,15 +25683,15 @@
       "version": "file:packages/elements",
       "requires": {
         "@refinitiv-ui/browser-sparkline": "1.1.8",
-        "@refinitiv-ui/core": "^6.0.5",
-        "@refinitiv-ui/demo-block": "^6.0.6",
-        "@refinitiv-ui/halo-theme": "^6.1.4",
-        "@refinitiv-ui/i18n": "^6.0.4",
-        "@refinitiv-ui/phrasebook": "^6.1.3",
-        "@refinitiv-ui/solar-theme": "^6.0.5",
+        "@refinitiv-ui/core": "^6.0.6",
+        "@refinitiv-ui/demo-block": "^6.0.7",
+        "@refinitiv-ui/halo-theme": "^6.2.0",
+        "@refinitiv-ui/i18n": "^6.0.5",
+        "@refinitiv-ui/phrasebook": "^6.2.0",
+        "@refinitiv-ui/solar-theme": "^6.1.0",
         "@refinitiv-ui/test-helpers": "^6.0.4",
-        "@refinitiv-ui/translate": "^6.0.5",
-        "@refinitiv-ui/utils": "^6.0.4",
+        "@refinitiv-ui/translate": "^6.0.6",
+        "@refinitiv-ui/utils": "^6.1.0",
         "@types/chart.js": "^2.9.31",
         "@types/d3-interpolate": "^3.0.1",
         "chart.js": "~2.9.4",
@@ -25795,19 +25704,19 @@
     "@refinitiv-ui/halo-theme": {
       "version": "file:packages/halo-theme",
       "requires": {
-        "@refinitiv-ui/elemental-theme": "^6.0.5",
+        "@refinitiv-ui/elemental-theme": "^6.1.0",
         "@refinitiv-ui/theme-compiler": "^6.0.4"
       }
     },
     "@refinitiv-ui/i18n": {
       "version": "file:packages/i18n",
       "requires": {
-        "@formatjs/icu-messageformat-parser": "^2.0.15",
+        "@formatjs/icu-messageformat-parser": "^2.1.7",
         "@formatjs/intl-utils": "^3.8.4",
-        "@refinitiv-ui/phrasebook": "^6.1.3",
+        "@refinitiv-ui/phrasebook": "^6.2.0",
         "@refinitiv-ui/test-helpers": "^6.0.4",
         "intl-format-cache": "^4.3.1",
-        "intl-messageformat": "^9.10.0",
+        "intl-messageformat": "^10.1.4",
         "tslib": "^2.3.1"
       }
     },
@@ -25835,7 +25744,7 @@
     "@refinitiv-ui/solar-theme": {
       "version": "file:packages/solar-theme",
       "requires": {
-        "@refinitiv-ui/elemental-theme": "^6.0.5",
+        "@refinitiv-ui/elemental-theme": "^6.1.0",
         "@refinitiv-ui/theme-compiler": "^6.0.4"
       }
     },
@@ -26199,9 +26108,9 @@
     "@refinitiv-ui/translate": {
       "version": "file:packages/translate",
       "requires": {
-        "@refinitiv-ui/core": "^6.0.5",
-        "@refinitiv-ui/i18n": "^6.0.4",
-        "@refinitiv-ui/phrasebook": "^6.1.3",
+        "@refinitiv-ui/core": "^6.0.6",
+        "@refinitiv-ui/i18n": "^6.0.5",
+        "@refinitiv-ui/phrasebook": "^6.2.0",
         "@refinitiv-ui/test-helpers": "^6.0.4",
         "lit": "^2.2.7",
         "tslib": "^2.3.1"
@@ -31752,35 +31661,14 @@
       "integrity": "sha512-OEUYNA7D06agqPOYhbTkl0T8HA3QKSuwWh1HiClEnpd9vw7N+3XsQt5iZ0GUEchp5CW1fQk/tary+NsbF3yQ1Q=="
     },
     "intl-messageformat": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.13.0.tgz",
-      "integrity": "sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.1.4.tgz",
+      "integrity": "sha512-tXCmWCXhbeHOF28aIf5b9ce3kwdwGyIiiSXVZsyDwksMiGn5Tp0MrMvyeuHuz4uN1UL+NfGOztHmE+6aLFp1wQ==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/fast-memoize": "1.2.1",
-        "@formatjs/icu-messageformat-parser": "2.1.0",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@formatjs/icu-messageformat-parser": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.0.tgz",
-          "integrity": "sha512-Qxv/lmCN6hKpBSss2uQ8IROVnta2r9jd3ymUEIjm2UyIkUCHVcbUVRGL/KS/wv7876edvsPe+hjHVJ4z8YuVaw==",
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.11.4",
-            "@formatjs/icu-skeleton-parser": "1.3.6",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@formatjs/icu-skeleton-parser": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.6.tgz",
-          "integrity": "sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==",
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.11.4",
-            "tslib": "^2.1.0"
-          }
-        }
+        "@formatjs/ecma402-abstract": "1.12.0",
+        "@formatjs/fast-memoize": "1.2.6",
+        "@formatjs/icu-messageformat-parser": "2.1.7",
+        "tslib": "2.4.0"
       }
     },
     "ip": {
@@ -37817,9 +37705,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=="
     },
     "typical": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5677,14 +5677,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz",
-      "integrity": "sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.37.0.tgz",
+      "integrity": "sha512-Fde6W0IafXktz1UlnhGkrrmnnGpAo1kyX7dnyHHVrmwJOn72Oqm3eYtddrpOwwel2W8PAK9F3pIL5S+lfoM0og==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.32.0",
-        "@typescript-eslint/type-utils": "5.32.0",
-        "@typescript-eslint/utils": "5.32.0",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/type-utils": "5.37.0",
+        "@typescript-eslint/utils": "5.37.0",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -5710,14 +5710,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.32.0.tgz",
-      "integrity": "sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.37.0.tgz",
+      "integrity": "sha512-01VzI/ipYKuaG5PkE5+qyJ6m02fVALmMPY3Qq5BHflDx3y4VobbLdHQkSMg9VPRS4KdNt4oYTMaomFoHonBGAw==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.32.0",
-        "@typescript-eslint/types": "5.32.0",
-        "@typescript-eslint/typescript-estree": "5.32.0",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.37.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -5737,13 +5737,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz",
-      "integrity": "sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
+      "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.32.0",
-        "@typescript-eslint/visitor-keys": "5.32.0"
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5754,12 +5754,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz",
-      "integrity": "sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.37.0.tgz",
+      "integrity": "sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.32.0",
+        "@typescript-eslint/typescript-estree": "5.37.0",
+        "@typescript-eslint/utils": "5.37.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -5780,9 +5781,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.32.0.tgz",
-      "integrity": "sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
+      "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5793,13 +5794,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz",
-      "integrity": "sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
+      "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.32.0",
-        "@typescript-eslint/visitor-keys": "5.32.0",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -5820,15 +5821,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.32.0.tgz",
-      "integrity": "sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
+      "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
       "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.32.0",
-        "@typescript-eslint/types": "5.32.0",
-        "@typescript-eslint/typescript-estree": "5.32.0",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.37.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -5844,12 +5845,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz",
-      "integrity": "sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
+      "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.32.0",
+        "@typescript-eslint/types": "5.37.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -21085,8 +21086,8 @@
       "version": "6.0.4",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.29.0",
-        "@typescript-eslint/parser": "^5.29.0",
+        "@typescript-eslint/eslint-plugin": "^5.37.0",
+        "@typescript-eslint/parser": "^5.37.0",
         "eslint": "^8.18.0",
         "eslint-plugin-html": "^6.2.0",
         "eslint-plugin-import": "^2.26.0",
@@ -26739,14 +26740,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz",
-      "integrity": "sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.37.0.tgz",
+      "integrity": "sha512-Fde6W0IafXktz1UlnhGkrrmnnGpAo1kyX7dnyHHVrmwJOn72Oqm3eYtddrpOwwel2W8PAK9F3pIL5S+lfoM0og==",
       "peer": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.32.0",
-        "@typescript-eslint/type-utils": "5.32.0",
-        "@typescript-eslint/utils": "5.32.0",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/type-utils": "5.37.0",
+        "@typescript-eslint/utils": "5.37.0",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -26756,52 +26757,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.32.0.tgz",
-      "integrity": "sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.37.0.tgz",
+      "integrity": "sha512-01VzI/ipYKuaG5PkE5+qyJ6m02fVALmMPY3Qq5BHflDx3y4VobbLdHQkSMg9VPRS4KdNt4oYTMaomFoHonBGAw==",
       "peer": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.32.0",
-        "@typescript-eslint/types": "5.32.0",
-        "@typescript-eslint/typescript-estree": "5.32.0",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.37.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz",
-      "integrity": "sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
+      "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
       "peer": true,
       "requires": {
-        "@typescript-eslint/types": "5.32.0",
-        "@typescript-eslint/visitor-keys": "5.32.0"
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz",
-      "integrity": "sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.37.0.tgz",
+      "integrity": "sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==",
       "peer": true,
       "requires": {
-        "@typescript-eslint/utils": "5.32.0",
+        "@typescript-eslint/typescript-estree": "5.37.0",
+        "@typescript-eslint/utils": "5.37.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.32.0.tgz",
-      "integrity": "sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
+      "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
       "peer": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz",
-      "integrity": "sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
+      "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
       "peer": true,
       "requires": {
-        "@typescript-eslint/types": "5.32.0",
-        "@typescript-eslint/visitor-keys": "5.32.0",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/visitor-keys": "5.37.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -26810,26 +26812,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.32.0.tgz",
-      "integrity": "sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
+      "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
       "peer": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.32.0",
-        "@typescript-eslint/types": "5.32.0",
-        "@typescript-eslint/typescript-estree": "5.32.0",
+        "@typescript-eslint/scope-manager": "5.37.0",
+        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.37.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz",
-      "integrity": "sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==",
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
+      "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
       "peer": true,
       "requires": {
-        "@typescript-eslint/types": "5.32.0",
+        "@typescript-eslint/types": "5.37.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   "devDependencies": {
     "@commitlint/cli": "^17.0.2",
     "@commitlint/config-conventional": "^17.0.2",
-    "@formatjs/intl-getcanonicallocales": "^1.8.0",
-    "@formatjs/intl-locale": "^2.4.41",
-    "@formatjs/intl-numberformat": "^7.2.6",
-    "@formatjs/intl-pluralrules": "^4.1.6",
+    "@formatjs/intl-getcanonicallocales": "^2.0.4",
+    "@formatjs/intl-locale": "^3.0.6",
+    "@formatjs/intl-numberformat": "^8.1.3",
+    "@formatjs/intl-pluralrules": "^5.1.3",
     "@nrwl/cli": "latest",
     "@nrwl/tao": "latest",
     "@nrwl/workspace": "latest",
@@ -64,7 +64,7 @@
     "micromatch": "^4.0.4",
     "request": "^2.88.2",
     "sinon": "^9.2.4",
-    "typescript": "~4.6.4",
+    "typescript": "^4.8.3",
     "watch": "^1.0.2",
     "web-component-analyzer": "2.0.0-next.4",
     "yargs": "^17.0.1"

--- a/packages/configurations/package.json
+++ b/packages/configurations/package.json
@@ -27,7 +27,7 @@
     "eslint": "^8.18.0",
     "eslint-plugin-html": "^6.2.0",
     "eslint-plugin-import": "^2.26.0",
-    "typescript": "~4.6.4"
+    "typescript": "^4.8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/configurations/package.json
+++ b/packages/configurations/package.json
@@ -22,8 +22,8 @@
   "author": "Refinitiv",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.29.0",
-    "@typescript-eslint/parser": "^5.29.0",
+    "@typescript-eslint/eslint-plugin": "^5.37.0",
+    "@typescript-eslint/parser": "^5.37.0",
     "eslint": "^8.18.0",
     "eslint-plugin-html": "^6.2.0",
     "eslint-plugin-import": "^2.26.0",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -24,10 +24,10 @@
   "author": "Refinitiv",
   "license": "Apache-2.0",
   "dependencies": {
-    "@formatjs/icu-messageformat-parser": "^2.0.15",
+    "@formatjs/icu-messageformat-parser": "^2.1.7",
     "@formatjs/intl-utils": "^3.8.4",
     "intl-format-cache": "^4.3.1",
-    "intl-messageformat": "^9.10.0",
+    "intl-messageformat": "^10.1.4",
     "tslib": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
Update typescript to latest version to 4.8.3. It need to update dependencies to support those version.
Here is a list that effected after upgrade typescript.
1. Build fail from @formatjs/ecma402-abstract that fixed in 1.11.8
Here is a effected dependency list.
root@
├─┬ @formatjs/intl-locale
├─┬ @formatjs/intl-numberformat
├─┬ @formatjs/intl-pluralrules
└─┬ @refinitiv-ui/i18n
  ├─┬ @formatjs/icu-messageformat-parser
  └─┬ intl-messageformat

2. Lint fail from @typescript-eslint/typescript-eslint that fixed in 5.36.1
Fixes # ([ELF-1844](https://jira.refinitiv.com/browse/ELF-1844))
Here is a effected dependency list.
root@
└─┬ @refinitiv-ui/configurations
  ├─┬ @typescript-eslint/eslint-plugin
  └─┬ @typescript-eslint/parser@5.37.0


## Type of change

- [x] Refactor (improves code without changing its functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
