### PR TITLE
fix(configurations): move import extension eslint rule to local env

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,10 +5,13 @@
     "project": "./tsconfig.json"
   },
   "rules": {
-    "@typescript-eslint/no-namespace": 0
+    "@typescript-eslint/no-namespace": 0,
+    "import/extensions": ["error", "always"]
   },
   "ignorePatterns": [
     "packages/**/lib",
+    "packages/**/scripts",
+    "*.config.js",
     "__test__",
     "*.md"
   ] // .eslintignore resolves relative to working dir, this is needed to ignore files in workspaces

--- a/packages/configurations/typescript.eslint-config.js
+++ b/packages/configurations/typescript.eslint-config.js
@@ -15,7 +15,6 @@ module.exports = {
         extraFileExtensions: ['.html'],
       },
       rules: {
-        'import/extensions': ['error', 'always'],
         '@typescript-eslint/unbound-method': 0,
         'valid-jsdoc': [
           2,

--- a/packages/elements/.eslintrc
+++ b/packages/elements/.eslintrc
@@ -3,6 +3,7 @@
     "project": "./tsconfig.json"
   },
   "ignorePatterns": [
+    "cli.js",
     "./**/__demo__",
     "./**/__test__/**",
     "./**/__snapshots__/**"


### PR DESCRIPTION
## Description
"import/extensions" rule in "eslint" file of configurations packages should be use only in local environment because other user might be extends this configure.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
