### PR TITLE
chore(create-efx): change package version to alpha

### DIFF
--- a/packages/create-efx/package.json
+++ b/packages/create-efx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-efx",
-  "version": "6.0.0",
+  "version": "6.0.0-alpha.0",
   "description": "Initializer to create new EFX element",
   "main": "lib/index",
   "bin": {


### PR DESCRIPTION
## Description
Change package version to 6.0.0-alpha.0 so Lerna can graduate version to 6.0.0 on published.
