### PR TITLE
chore: remove conventional graduate flag from release workflow

### DIFF
--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -33,13 +33,13 @@ jobs:
 
       - name: Bump all package versions and create GitHub release
         if: ${{ inputs.force }}
-        run: lerna version --create-release github --conventional-commits --conventional-graduate --force-publish --yes
+        run: lerna version --create-release github --conventional-commits --force-publish --yes
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Bump modified package versions and create GitHub release
         if: ${{ !inputs.force }}
-        run: lerna version --create-release github --conventional-commits --conventional-graduate --yes
+        run: lerna version --create-release github --conventional-commits --yes
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 


### PR DESCRIPTION
## Description
According to https://github.com/Refinitiv/refinitiv-ui/pull/463 we add temporary conventional graduate flag to publish `create-efx` package version 6.0.0 to NPM. We need to remove it to prevent the package with beta/alpha version be graduated to latest version.

