### PR TITLE
fix(create-efx): run build script before publish to NPM

### DIFF
--- a/packages/create-efx/package.json
+++ b/packages/create-efx/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "build:watch": "tsc --watch"
+    "build:watch": "tsc --watch",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@types/chalk": "^2.2.0",


### PR DESCRIPTION
## Description
`create-efx` package has been published without `lib` folder so we need to run build script before publish to NPM by adding prepublishonly script in package.json

