### PR TITLE
fix(create-efx): add tslib as dependencies

### DIFF
--- a/packages/create-efx/package.json
+++ b/packages/create-efx/package.json
@@ -21,6 +21,9 @@
     "build:watch": "tsc --watch",
     "prepublishOnly": "npm run build"
   },
+  "dependencies": {
+    "tslib": "^2.4.0"
+  },
   "devDependencies": {
     "@types/chalk": "^2.2.0",
     "@types/fs-extra": "^9.0.13",


### PR DESCRIPTION
## Description
`tslib` module is required by typescript import helpers so we need to add it as dependencies.
