### PR TITLE
chore: run SonarCloud coverage on every PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,3 +65,19 @@ jobs:
           browserstack: $USE_BROWSERSTACK
           username: $BROWSERSTACK_USERNAME
           access-key: $BROWSERSTACK_ACCESS_KEY
+
+  sonarcloud:
+    needs: test
+    name: TestCoverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,7 +1,6 @@
 name: "Test Coverage" # To be able to access test coverage of the repository on SonarCloud
-on:
-  push:
-    branches: [v6]
+
+on: [push, pull_request]
 env:
   USE_BROWSERSTACK: ${{ secrets.USE_BROWSERSTACK }}
   BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,7 +1,5 @@
 name: "Test Coverage" # To be able to access test coverage of the repository on SonarCloud
 on:
-  pull_request:
-    branches: [v6]
   push:
     branches: [v6]
 env:

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,6 +1,9 @@
 name: "Test Coverage" # To be able to access test coverage of the repository on SonarCloud
-
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [v6]
+  push:
+    branches: [v6]
 env:
   USE_BROWSERSTACK: ${{ secrets.USE_BROWSERSTACK }}
   BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=refinitiv_refinitiv-ui
 sonar.organization=refinitiv
 sonar.exclusions=documents/**, samples/**, packages/*-theme/**, packages/configurations/**, *.config.js, cli.js, packages/elements/scripts/**, packages/*/*.config.js, **/__snapshots__/**, **/__demo__/**, **/__test__/**
 sonar.javascript.lcov.reportPaths=**/coverage/lcov.info
-sonar.coverage.exclusions=scripts/**, packages/phrasebook/**, packages/utils/**, packages/polyfills/**, packages/theme-compiler/**
+sonar.coverage.exclusions=scripts/**, packages/phrasebook/**, packages/utils/**, packages/polyfills/**, packages/theme-compiler/**, packages/create-efx/**, packages/demo-block/**
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=dtanp-rft_refinitiv-ui


### PR DESCRIPTION
Objective : Run SonarCloud coverage on every PRs.

Because we don't want to run test when we push to V6 so we still need to keep test_coverage.yml, just for this..
If we agree to run test as well on V6, we can remove test_coverage.yml and change to trigger test.yml workflow to run on V6 too.

