### PR TITLE
Fix/create efx move template dependencies to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Getting started and usage guide are available from this [documentation](https://
 | [@refinitiv-ui/theme-compiler](https://github.com/Refinitiv/refinitiv-ui/tree/v6/packages/theme-compiler)  | [![npm version](https://badgen.net/npm/v/@refinitiv-ui/theme-compiler)](https://www.npmjs.com/package/@refinitiv-ui/theme-compiler)   | [![change log](https://badgen.net/badge/icon/changelog/grey?icon=git&label)](https://github.com/Refinitiv/refinitiv-ui/blob/v6/packages/theme-compiler/CHANGELOG.md)  |
 | [@refinitiv-ui/translate](https://github.com/Refinitiv/refinitiv-ui/tree/v6/packages/translate)       | [![npm version](https://badgen.net/npm/v/@refinitiv-ui/translate)](https://www.npmjs.com/package/@refinitiv-ui/translate)             | [![change log](https://badgen.net/badge/icon/changelog/grey?icon=git&label)](https://github.com/Refinitiv/refinitiv-ui/blob/v6/packages/translate/CHANGELOG.md)       |
 | [@refinitiv-ui/utils](https://github.com/Refinitiv/refinitiv-ui/tree/v6/packages/utils)           | [![npm version](https://badgen.net/npm/v/@refinitiv-ui/utils)](https://www.npmjs.com/package/@refinitiv-ui/utils)                     | [![change log](https://badgen.net/badge/icon/changelog/grey?icon=git&label)](https://github.com/Refinitiv/refinitiv-ui/blob/v6/packages/utils/CHANGELOG.md)           |
+| [create-efx](https://github.com/Refinitiv/refinitiv-ui/tree/v6/packages/create-efx)           | [![npm version](https://badgen.net/npm/v/create-efx)](https://www.npmjs.com/package/create-efx)                     | [![change log](https://badgen.net/badge/icon/changelog/grey?icon=git&label)](https://github.com/Refinitiv/refinitiv-ui/blob/v6/packages/create-efx/CHANGELOG.md)           |
 
 
 # License Information
@@ -64,6 +65,7 @@ Element Framework is using monorepo. This repository has elements, supporting mo
 
 * `packages/configurations` - Configuration file for element development e.g. eslint, typescript
 * `packages/core` - Core module of element e.g. base classes, element registration
+* `packages/create-efx` - Initializer for creating a new EFX elements
 * `packages/demo-block` - Use in demo page of each element to demonstrate element's features
 * `packages/elemental-theme` - Base theme to extend to design system theme e.g. Halo Theme
 * `packages/elements` - All elements in Element Framework

--- a/packages/create-efx/template/package.json.template
+++ b/packages/create-efx/template/package.json.template
@@ -24,15 +24,11 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "tslib": "^2.4.0",
-    "@refinitiv-ui/core": "^6.0.5",
-    "@refinitiv-ui/elements": "^6.1.1"
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@refinitiv-ui/configurations": "^6.0.4",
-    "@refinitiv-ui/demo-block": "^6.0.6",
     "@refinitiv-ui/halo-theme": "^6.1.4",
-    "@refinitiv-ui/solar-theme": "^6.0.5",
     "@refinitiv-ui/test-helpers": "^6.0.4",
     "@refinitiv-ui/theme-compiler": "^6.0.4",
     "@web/dev-server-esbuild": "^0.3.2",
@@ -41,5 +37,9 @@
     "fast-glob": "^3.2.12",
     "typescript": "^4.8.3",
     "vite": "^3.1.0"
+  },
+  "peerDependencies": {
+    "@refinitiv-ui/core": "^6.0.7",
+    "@refinitiv-ui/elements": "^6.1.1"
   }
 }

--- a/packages/create-efx/template/package.json.template
+++ b/packages/create-efx/template/package.json.template
@@ -21,7 +21,7 @@
     "test:watch": "wtr --node-resolve --watch",
     "test:snapshots": "wtr --node-resolve --update-snapshots",
     "generate:jsx": "node ./scripts/jsx/jsxdts-generator.js",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build && npm run generate:jsx"
   },
   "dependencies": {
     "tslib": "^2.4.0"


### PR DESCRIPTION
## Description
@refinitiv-ui/core in template should be in peer dependencies to resolve multiple versions of core issues.

This PR also

1. Add create-efx package to package section in README.
2. Add generate:jsx script to prepublish command so when published the element can be use in React.
3. Remove @refinitiv-ui/demo-block and solar theme from template dependencies.

