### PR TITLE
docs(tutorials): update example import part for webpackv4

### DIFF
--- a/documents/src/pages/build-app/framework-integration/angular.md
+++ b/documents/src/pages/build-app/framework-integration/angular.md
@@ -72,18 +72,18 @@ npm install @refinitiv-ui/halo-theme
 Import the elements and themes into your app, `src/app/app.component.ts`
 
 ```javascript
-import '@refinitiv-ui/elements/loader';
-import '@refinitiv-ui/elements/button';
-import '@refinitiv-ui/elements/panel';
-import '@refinitiv-ui/elements/text-field';
-import '@refinitiv-ui/elements/password-field';
+import '@refinitiv-ui/elements/lib/loader';
+import '@refinitiv-ui/elements/lib/button';
+import '@refinitiv-ui/elements/lib/panel';
+import '@refinitiv-ui/elements/lib/text-field';
+import '@refinitiv-ui/elements/lib/password-field';
 
 import '@refinitiv-ui/halo-theme/dark/imports/native-elements';
-import '@refinitiv-ui/elements/loader/themes/halo/dark';
-import '@refinitiv-ui/elements/button/themes/halo/dark';
-import '@refinitiv-ui/elements/panel/themes/halo/dark';
-import '@refinitiv-ui/elements/text-field/themes/halo/dark';
-import '@refinitiv-ui/elements/password-field/themes/halo/dark';
+import '@refinitiv-ui/elements/lib/loader/themes/halo/dark';
+import '@refinitiv-ui/elements/lib/button/themes/halo/dark';
+import '@refinitiv-ui/elements/lib/panel/themes/halo/dark';
+import '@refinitiv-ui/elements/lib/text-field/themes/halo/dark';
+import '@refinitiv-ui/elements/lib/password-field/themes/halo/dark';
 ```
 
 If you're using Angular 13++ or using Webpack 5, you can import module by using a shorter path.

--- a/documents/src/pages/build-app/framework-integration/vue.md
+++ b/documents/src/pages/build-app/framework-integration/vue.md
@@ -46,11 +46,11 @@ npm install @refinitiv-ui/halo-theme
 Import elements that you want to use and themes in `src/main.js`.
 
 ```javascript
-import '@refinitiv-ui/elements/loader';
-import '@refinitiv-ui/elements/button';
-import '@refinitiv-ui/elements/panel';
-import '@refinitiv-ui/elements/text-field';
-import '@refinitiv-ui/elements/password-field';
+import '@refinitiv-ui/elements/lib/loader';
+import '@refinitiv-ui/elements/lib/button';
+import '@refinitiv-ui/elements/lib/panel';
+import '@refinitiv-ui/elements/lib/text-field';
+import '@refinitiv-ui/elements/lib/password-field';
 
 import '@refinitiv-ui/halo-theme/dark/imports/native-elements';
 import '@refinitiv-ui/elements/loader/themes/halo/dark';


### PR DESCRIPTION
Update documentation import element part for webpack v4 on Vue and Angular