### PR TITLE
fix(tree): update parent item in values setter

### DIFF
--- a/packages/elements/src/list/elements/list.ts
+++ b/packages/elements/src/list/elements/list.ts
@@ -162,7 +162,6 @@ export class List<T extends DataItem = ItemData> extends ControlElement {
    * selected item values
    * @type {string[]}
    * @default []
-   * @readonly
    */
   @property({ type: Array, attribute: false })
   public get values (): string[] {

--- a/packages/elements/src/list/elements/list.ts
+++ b/packages/elements/src/list/elements/list.ts
@@ -26,7 +26,7 @@ enum Direction {
   DOWN = 1
 }
 
-const valueFormatWarning = new WarningNotice('The specified \'values\' format does not conform to the required format.');
+export const valueFormatWarning = new WarningNotice('The specified \'values\' format does not conform to the required format.');
 
 /**
  * Provides listing and immutable selection

--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -396,6 +396,20 @@ describe('tree/Tree', () => {
       expect(el.value).to.equal('1.1');
       expect(el.values).to.deep.equal(['1.1', '1.2']);
     });
+
+    it('Update the parent selected state correctly', async () => {
+      const el = await fixture('<ef-tree multiple></ef-tree>');
+      el.data = nestedData;
+      await elementUpdated(el);
+      const item = el.children[0];
+      expect(item.checkedState).to.equal(-1); // Indeterminate
+      el.values = [];
+      await elementUpdated(el);
+      expect(item.checkedState).to.equal(0); // Unchecked
+      el.values = ['1.1'];
+      await elementUpdated(el);
+      expect(item.checkedState).to.equal(-1); // Indeterminate
+    });
   });
 
   describe('Filter Tests', () => {

--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -410,6 +410,15 @@ describe('tree/Tree', () => {
       await elementUpdated(el);
       expect(item.checkedState).to.equal(-1); // Indeterminate
     });
+
+    it('Should set values to empty array when set invalid values', async () => {
+      const el = await fixture('<ef-tree multiple></ef-tree>');
+      el.data = nestedData;
+      await elementUpdated(el);
+      el.values = '1.1';
+      await elementUpdated(el);
+      expect(el.values).to.deep.equal([]);
+    });
   });
 
   describe('Filter Tests', () => {

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -7,7 +7,7 @@ import { property } from '@refinitiv-ui/core/decorators/property.js';
 import { VERSION } from '../../version.js';
 import { CollectionComposer } from '@refinitiv-ui/utils/collection.js';
 
-import { List } from '../../list/index.js';
+import { List, valueFormatWarning } from '../../list/index.js';
 import { TreeRenderer } from '../helpers/renderer.js';
 import { defaultFilter } from '../helpers/filter.js';
 import type { TreeData, TreeDataItem, TreeFilter } from '../helpers/types';
@@ -425,8 +425,34 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
       return this.composer.getItemPropertyValue(item, 'value') as string || '';
     });
   }
-  public set values (value: string[]) {
-    super.values = value;
+  public set values (values: string[]) {
+    if (!Array.isArray(values)) {
+      valueFormatWarning.show();
+      this.values = [];
+    }
+    else {
+      // Clone value arrays
+      const newValue = values.slice();
+      const oldValue = this.values.slice();
+
+      newValue.sort();
+      oldValue.sort();
+
+      // Create comparison strings to check for differences
+      const newComparison = newValue.toString();
+      const oldComparison = oldValue.toString();
+
+      if (newComparison !== oldComparison) {
+        this.manager.uncheckAllItems();
+        values.some((value) => {
+          this.queryItemsByPropertyValue('value', value).forEach((item) => {
+            this.manager.checkItem(item);
+          });
+          return !this.multiple; // Only set the fist value if multiple is not enabled
+        });
+        this.requestUpdate('values', oldValue);
+      }
+    }
   }
 
   /**

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -432,17 +432,10 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
     }
     else {
       // Clone value arrays
-      const newValue = values.slice();
-      const oldValue = this.values.slice();
+      const newValue = [...values].sort().toString();
+      const oldValue = [...this.values].sort().toString();
 
-      newValue.sort();
-      oldValue.sort();
-
-      // Create comparison strings to check for differences
-      const newComparison = newValue.toString();
-      const oldComparison = oldValue.toString();
-
-      if (newComparison !== oldComparison) {
+      if (newValue !== oldValue) {
         this.manager.uncheckAllItems();
         values.some((value) => {
           this.queryItemsByPropertyValue('value', value).forEach((item) => {
@@ -450,7 +443,7 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
           });
           return !this.multiple; // Only set the fist value if multiple is not enabled
         });
-        this.requestUpdate('values', oldValue);
+        this.requestUpdate('values', this.values);
       }
     }
   }


### PR DESCRIPTION
## Description
When set tree values via `values`, parent node doesn't show correct selected state because tree using setter from List that doesn't updating the parent node.

## Fixes # (issue)
Parent node displays wrong state when set values programmatically ELF-2020 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
