### PR TITLE
docs(tutorial): update framework webpack tutorial

### DIFF
--- a/documents/src/pages/build-app/framework-integration/angular.md
+++ b/documents/src/pages/build-app/framework-integration/angular.md
@@ -85,7 +85,7 @@ import '@refinitiv-ui/elements/panel/themes/halo/dark';
 import '@refinitiv-ui/elements/text-field/themes/halo/dark';
 import '@refinitiv-ui/elements/password-field/themes/halo/dark';
 ```
-If you're using webpack 4, you can setting alias `webpack.config.js` similar to [Vanilla](./tutorials/vanilla-js#webpack-4).
+If you're using webpack 4, you can set path aliases in `webpack.config.js` similar to [Vanilla](./tutorials/vanilla-js#webpack-4).
 
 At this stage EF elements should be ready to use!. You can use them like any other native HTML elements.
 

--- a/documents/src/pages/build-app/framework-integration/angular.md
+++ b/documents/src/pages/build-app/framework-integration/angular.md
@@ -85,6 +85,7 @@ import '@refinitiv-ui/elements/panel/themes/halo/dark';
 import '@refinitiv-ui/elements/text-field/themes/halo/dark';
 import '@refinitiv-ui/elements/password-field/themes/halo/dark';
 ```
+If you're using webpack 4, you can setting alias `webpack.config.js` similar to [Vanilla](./tutorials/vanilla-js#webpack-4).
 
 At this stage EF elements should be ready to use!. You can use them like any other native HTML elements.
 

--- a/documents/src/pages/build-app/framework-integration/angular.md
+++ b/documents/src/pages/build-app/framework-integration/angular.md
@@ -86,23 +86,6 @@ import '@refinitiv-ui/elements/text-field/themes/halo/dark';
 import '@refinitiv-ui/elements/password-field/themes/halo/dark';
 ```
 
-If you're using Angular 13++ or using Webpack 5, you can import module by using a shorter path.
-
-```javascript
-import '@refinitiv-ui/elements/loader';
-import '@refinitiv-ui/elements/button';
-import '@refinitiv-ui/elements/panel';
-import '@refinitiv-ui/elements/text-field';
-import '@refinitiv-ui/elements/password-field';
-
-import '@refinitiv-ui/halo-theme/dark/imports/native-elements';
-import '@refinitiv-ui/elements/loader/themes/halo/dark';
-import '@refinitiv-ui/elements/button/themes/halo/dark';
-import '@refinitiv-ui/elements/panel/themes/halo/dark';
-import '@refinitiv-ui/elements/text-field/themes/halo/dark';
-import '@refinitiv-ui/elements/password-field/themes/halo/dark';
-```
-
 At this stage EF elements should be ready to use!. You can use them like any other native HTML elements.
 
 ## Create a login page

--- a/documents/src/pages/build-app/framework-integration/vue.md
+++ b/documents/src/pages/build-app/framework-integration/vue.md
@@ -59,7 +59,7 @@ import '@refinitiv-ui/elements/panel/themes/halo/dark';
 import '@refinitiv-ui/elements/text-field/themes/halo/dark';
 import '@refinitiv-ui/elements/password-field/themes/halo/dark';
 ```
-If you're using webpack 4, you can setting alias `webpack.config.js` similar to [Vanilla](./tutorials/vanilla-js#webpack-4).
+If you're using webpack 4, you can set path aliases in `webpack.config.js` similar to [Vanilla](./tutorials/vanilla-js#webpack-4).
 
 Components can be used like any other native `HTMLElement`. Try replacing content in `src/App.vue` with the code below.
 

--- a/documents/src/pages/build-app/framework-integration/vue.md
+++ b/documents/src/pages/build-app/framework-integration/vue.md
@@ -59,6 +59,7 @@ import '@refinitiv-ui/elements/panel/themes/halo/dark';
 import '@refinitiv-ui/elements/text-field/themes/halo/dark';
 import '@refinitiv-ui/elements/password-field/themes/halo/dark';
 ```
+If you're using webpack 4, you can setting alias `webpack.config.js` similar to [Vanilla](./tutorials/vanilla-js#webpack-4).
 
 Components can be used like any other native `HTMLElement`. Try replacing content in `src/App.vue` with the code below.
 

--- a/documents/src/pages/build-app/framework-integration/vue.md
+++ b/documents/src/pages/build-app/framework-integration/vue.md
@@ -60,23 +60,6 @@ import '@refinitiv-ui/elements/text-field/themes/halo/dark';
 import '@refinitiv-ui/elements/password-field/themes/halo/dark';
 ```
 
-If you're already migrated or using Webpack 5, you can import module by using a shorter path.
-
-```javascript
-import '@refinitiv-ui/elements/loader';
-import '@refinitiv-ui/elements/button';
-import '@refinitiv-ui/elements/panel';
-import '@refinitiv-ui/elements/text-field';
-import '@refinitiv-ui/elements/password-field';
-
-import '@refinitiv-ui/halo-theme/dark/imports/native-elements';
-import '@refinitiv-ui/elements/loader/themes/halo/dark';
-import '@refinitiv-ui/elements/button/themes/halo/dark';
-import '@refinitiv-ui/elements/panel/themes/halo/dark';
-import '@refinitiv-ui/elements/text-field/themes/halo/dark';
-import '@refinitiv-ui/elements/password-field/themes/halo/dark';
-```
-
 Components can be used like any other native `HTMLElement`. Try replacing content in `src/App.vue` with the code below.
 
 ```html


### PR DESCRIPTION
## Description

Tutorials docs on Angular page and Vue page should refer to webpack 5 but have a little mention to help developers if they are still using Webpack4

https://ui.refinitiv.com/tutorials/angular#install-ef-elements
https://ui.refinitiv.com/tutorials/vue#install-elf-elements-and-themes


Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-2006
