### PR TITLE
fix: add minimum npm version (v7) to package.json

### DIFF
--- a/packages/create-efx/template/package.json.template
+++ b/packages/create-efx/template/package.json.template
@@ -9,6 +9,9 @@
   "repository": "",
   "author": "Refinitiv",
   "license": "Apache-2.0",
+  "engines": {
+    "npm": "^7.0.0"
+  },
   "scripts": {
     "start": "vite --open --base=/demo/",
     "build": "npm run build:themes && tsc --sourceMap --declarationMap",

--- a/packages/create-efx/template/src/efx-element.ts
+++ b/packages/create-efx/template/src/efx-element.ts
@@ -64,9 +64,11 @@ export class EfxElement extends BasicElement {
   protected render (): TemplateResult {
     return html`
     <ef-panel part="container">
-      <a href="https://lit.dev" target="_blank">
-        <img src="https://lit.dev/images/logo.svg" part="logo" class="logo lit" alt="Lit logo" />
-      </a>
+      <div part="logo-container">
+        <a href="https://lit.dev" target="_blank">
+          <img src="https://lit.dev/images/logo.svg" part="logo" class="logo lit" alt="Lit logo" />
+        </a>
+      </div>
       <slot></slot>
       <ef-button part="button" @tap="${this.onTap}">
         count is ${this.count}

--- a/packages/create-efx/template/test/efx-element.test.js
+++ b/packages/create-efx/template/test/efx-element.test.js
@@ -4,7 +4,7 @@ import { fixture, expect } from '@refinitiv-ui/test-helpers';
 
 // import element and theme
 import '../src/efx-element.ts';
-import '../themes/halo-theme/dark';
+import '../themes/halo/dark';
 
 describe('EfxElementTest', () => {
   it('Label and DOM structure is correct', async () => {

--- a/packages/create-efx/template/themes/halo/dark/efx-element.js
+++ b/packages/create-efx/template/themes/halo/dark/efx-element.js
@@ -1,4 +1,4 @@
 import './imports/native-elements.js';
 
 
-elf.customStyles.define('efx-element', ':host{max-width:500px}:host [part=container]{padding:20px}:host [part=logo]{height:6em;padding:1.5em;will-change:filter}:host [part=logo]:hover{filter:drop-shadow(0 0 2em #334bff)}:host [part=sub-title]{color:#6678ff}');
+elf.customStyles.define('efx-element', ':host{max-width:500px}:host [part=container]{padding:20px}:host [part=logo-container]{background-color:#fff;padding:10px;margin-bottom:20px}:host [part=logo]{height:6em;padding:1.5em;will-change:filter}:host [part=logo]:hover{filter:drop-shadow(0 0 2em #334bff)}:host [part=sub-title]{color:#6678ff}');

--- a/packages/create-efx/template/themes/halo/dark/es5/all-elements.js
+++ b/packages/create-efx/template/themes/halo/dark/es5/all-elements.js
@@ -1,2 +1,2 @@
-elf.customStyles.define('efx-element', ':host{max-width:500px}:host [part=container]{padding:20px}:host [part=logo]{height:6em;padding:1.5em;will-change:filter}:host [part=logo]:hover{filter:drop-shadow(0 0 2em #334bff)}:host [part=sub-title]{color:#6678ff}');
+elf.customStyles.define('efx-element', ':host{max-width:500px}:host [part=container]{padding:20px}:host [part=logo-container]{background-color:#fff;padding:10px;margin-bottom:20px}:host [part=logo]{height:6em;padding:1.5em;will-change:filter}:host [part=logo]:hover{filter:drop-shadow(0 0 2em #334bff)}:host [part=sub-title]{color:#6678ff}');
 

--- a/packages/create-efx/template/themes/halo/efx-element.less
+++ b/packages/create-efx/template/themes/halo/efx-element.less
@@ -12,6 +12,12 @@ INSTRUCTIONS
   [part=container] {
     padding: 20px;
   }
+  
+  [part=logo-container] {
+    background-color: white;
+    padding: 10px;
+    margin-bottom: 20px;
+  }
 
   [part=logo] {
     height: 6em;

--- a/packages/create-efx/template/themes/halo/light/efx-element.js
+++ b/packages/create-efx/template/themes/halo/light/efx-element.js
@@ -1,4 +1,4 @@
 import './imports/native-elements.js';
 
 
-elf.customStyles.define('efx-element', ':host{max-width:500px}:host [part=container]{padding:20px}:host [part=logo]{height:6em;padding:1.5em;will-change:filter}:host [part=logo]:hover{filter:drop-shadow(0 0 2em #334bff)}:host [part=sub-title]{color:#6678ff}');
+elf.customStyles.define('efx-element', ':host{max-width:500px}:host [part=container]{padding:20px}:host [part=logo-container]{background-color:#fff;padding:10px;margin-bottom:20px}:host [part=logo]{height:6em;padding:1.5em;will-change:filter}:host [part=logo]:hover{filter:drop-shadow(0 0 2em #334bff)}:host [part=sub-title]{color:#6678ff}');

--- a/packages/create-efx/template/themes/halo/light/es5/all-elements.js
+++ b/packages/create-efx/template/themes/halo/light/es5/all-elements.js
@@ -1,2 +1,2 @@
-elf.customStyles.define('efx-element', ':host{max-width:500px}:host [part=container]{padding:20px}:host [part=logo]{height:6em;padding:1.5em;will-change:filter}:host [part=logo]:hover{filter:drop-shadow(0 0 2em #334bff)}:host [part=sub-title]{color:#6678ff}');
+elf.customStyles.define('efx-element', ':host{max-width:500px}:host [part=container]{padding:20px}:host [part=logo-container]{background-color:#fff;padding:10px;margin-bottom:20px}:host [part=logo]{height:6em;padding:1.5em;will-change:filter}:host [part=logo]:hover{filter:drop-shadow(0 0 2em #334bff)}:host [part=sub-title]{color:#6678ff}');
 


### PR DESCRIPTION
Because peerDependencies will require npm > v7 to auto install, it might be better to set minimum version inside package.json.

Also, a cosmetic improvement on demo page to make it looks nicer in both light and dark theme.

![image](https://user-images.githubusercontent.com/81604092/195248476-4838325c-4abe-4601-8123-3692ab56ae63.png)
