### PR TITLE
docs: update sandbox redirect

### DIFF
--- a/documents/src/_redirects
+++ b/documents/src/_redirects
@@ -1,1 +1,1 @@
-/sandbox https://codepen.io/element-framework/pen/GRxveeP
+/sandbox https://codesandbox.io/s/ef-debugging-template-q11i0v


### PR DESCRIPTION
## Description

- Create Vanilla TypeScript sample in CodeSandbox to replace the current sandbox in CodePen
- Move https://ui.refinitiv.com/sandbox from CodePen to CodeSandbox (Vanilla Typescript).

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-1997