### PR TITLE
uncheckAllItems method not update checked state of parent node

### DIFF
--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -408,36 +408,6 @@ describe('tree/Tree', () => {
       expect(itemChild.checkedState).to.equal(0);
     });
 
-    it('Can uncheck all item with disabled parent', async () => {
-      const el = await fixture('<ef-tree multiple></ef-tree>');
-      el.data = [
-        {
-          label: 'Item 1',
-          value: '1',
-          disabled: true,
-          expanded: true,
-          items: [
-            {
-              label: 'Item 1.1',
-              value: '1.1'
-            },
-            {
-              label: 'Item 1.2',
-              value: '1.2'
-            }
-          ]
-        }
-      ];
-      await elementUpdated(el);
-      const item = el.children[0];
-      const itemChild = el.children[1];
-      itemChild.click();
-      await elementUpdated(el);
-      el.uncheckAll();
-      await elementUpdated(el);
-      expect(item.checkedState).to.equal(0);
-    })
-
     it('Can set values programmatically', async () => {
       const el = await fixture('<ef-tree multiple></ef-tree>');
       el.data = nestedData;

--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -384,6 +384,60 @@ describe('tree/Tree', () => {
       expect(el.values).to.deep.equal(['1.1', '1.2', '4']);
     });
 
+    it('Uncheck all items correctly with deep nested data', async () => {
+      const el = await fixture('<ef-tree multiple></ef-tree>');
+      el.data = deepNestedData;
+      await elementUpdated(el);
+      el.uncheckAll();
+      el.expandAll();
+      await elementUpdated(el);
+      const item = el.children[3];
+      const itemChild = el.children[4];
+      itemChild.click();
+      await elementUpdated(el);
+      el.uncheckAll();
+      await elementUpdated(el);
+      expect(item.checkedState).to.equal(0);
+      el.uncheckAll();
+      await elementUpdated(el);
+      el.values = ['1.3.1.1'];
+      await elementUpdated(el);
+      el.uncheckAll();
+      await elementUpdated(el);
+      expect(item.checkedState).to.equal(0);
+      expect(itemChild.checkedState).to.equal(0);
+    });
+
+    it('Can uncheck all item with disabled parent', async () => {
+      const el = await fixture('<ef-tree multiple></ef-tree>');
+      el.data = [
+        {
+          label: 'Item 1',
+          value: '1',
+          disabled: true,
+          expanded: true,
+          items: [
+            {
+              label: 'Item 1.1',
+              value: '1.1'
+            },
+            {
+              label: 'Item 1.2',
+              value: '1.2'
+            }
+          ]
+        }
+      ];
+      await elementUpdated(el);
+      const item = el.children[0];
+      const itemChild = el.children[1];
+      itemChild.click();
+      await elementUpdated(el);
+      el.uncheckAll();
+      await elementUpdated(el);
+      expect(item.checkedState).to.equal(0);
+    })
+
     it('Can set values programmatically', async () => {
       const el = await fixture('<ef-tree multiple></ef-tree>');
       el.data = nestedData;

--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -408,6 +408,26 @@ describe('tree/Tree', () => {
       expect(itemChild.checkedState).to.equal(0);
     });
 
+    it('check/uncheck all items correctly in no-relation with deep nested data', async () => {
+      const el = await fixture('<ef-tree multiple no-relation></ef-tree>');
+      el.data = deepNestedData;
+      await elementUpdated(el);
+      el.uncheckAll();
+      el.expandAll();
+      await elementUpdated(el);
+      const item = el.children[3];
+      const itemChild = el.children[4];
+      itemChild.click();
+      await elementUpdated(el);
+      el.uncheckAll();
+      await elementUpdated(el);
+      expect(item.checkedState).to.equal(0);
+      el.checkAll();
+      await elementUpdated(el);
+      expect(item.checkedState).to.equal(1);
+      expect(itemChild.checkedState).to.equal(1);
+    });
+
     it('Can set values programmatically', async () => {
       const el = await fixture('<ef-tree multiple></ef-tree>');
       el.data = nestedData;

--- a/packages/elements/src/tree/managers/tree-manager.ts
+++ b/packages/elements/src/tree/managers/tree-manager.ts
@@ -437,6 +437,12 @@ export class TreeManager<T extends TreeDataItem> {
    * @returns {void}
    */
   public uncheckAllItems (): void {
-    this.editableItems.forEach(item => this.uncheckItem(item));
+    this.items.forEach(item => {
+      if (this.canUncheckItem(item)) {
+        this.composer.setItemPropertyValue(item, 'selected', false);
+      }
+    });
+    // Force update of all visible parent items, making sure any indeterminate states are remove.
+    this.parentItems.forEach(item => this.updateItem(item));
   }
 }

--- a/packages/elements/src/tree/managers/tree-manager.ts
+++ b/packages/elements/src/tree/managers/tree-manager.ts
@@ -438,7 +438,7 @@ export class TreeManager<T extends TreeDataItem> {
    * @returns {void}
    */
   public uncheckAllItems (): void {
-    // uncheck items from top levels when manage relationships to avoid redundant call to force re-render item
+    // uncheck items from top levels when manage relationships to avoid redundant re-renders
     const items = this.manageRelationships ? this.composer.queryItems(() => true, 0) : this.checkedItems;
     items.forEach(item => this.uncheckItem(item));
   }

--- a/packages/elements/src/tree/managers/tree-manager.ts
+++ b/packages/elements/src/tree/managers/tree-manager.ts
@@ -410,6 +410,7 @@ export class TreeManager<T extends TreeDataItem> {
         this.forceUpdateOnPath(item);
         this.getItemDescendants(item).forEach(descendant => this._uncheckItem(descendant, false));
       }
+      this.updateItem(item);
       return true;
     }
     return false;
@@ -437,10 +438,8 @@ export class TreeManager<T extends TreeDataItem> {
    * @returns {void}
    */
   public uncheckAllItems (): void {
-    this.editableItems.forEach(item => {
-      this.composer.setItemPropertyValue(item, 'selected', false);
-    });
-    // Force update of all visible parent items, making sure any indeterminate states are remove.
-    this.parentItems.forEach(item => this.updateItem(item));
+    // uncheck items from top levels when manage relationships to avoid redundant call to force re-render item
+    const items = this.manageRelationships ? this.composer.queryItems(() => true, 0) : this.checkedItems;
+    items.forEach(item => this.uncheckItem(item));
   }
 }

--- a/packages/elements/src/tree/managers/tree-manager.ts
+++ b/packages/elements/src/tree/managers/tree-manager.ts
@@ -437,10 +437,8 @@ export class TreeManager<T extends TreeDataItem> {
    * @returns {void}
    */
   public uncheckAllItems (): void {
-    this.items.forEach(item => {
-      if (this.canUncheckItem(item)) {
-        this.composer.setItemPropertyValue(item, 'selected', false);
-      }
+    this.editableItems.forEach(item => {
+      this.composer.setItemPropertyValue(item, 'selected', false);
     });
     // Force update of all visible parent items, making sure any indeterminate states are remove.
     this.parentItems.forEach(item => this.updateItem(item));


### PR DESCRIPTION
## Description
`uncheckAllItems` method inside `tree-manager` call `uncheckItem` method recursively and inside this method has condition to prevent update timestamp of descendent items so some parent of checked items will not be re-render.

Live Demo:

https://codepen.io/mosmaall/pen/MWXpwRW?editors=1010

Steps to Reproduce:
1. Open Codepen and click `Uncheck All By Public Method` button.
2. Click ADF item
3. Click `Uncheck All By Public Method` or `Uncheck All By Set Empty values` button.

Expected Results:
Parent Item of `ADF` should not in indeterminate state.

Actual Results:
Parent Item of `ADF` is in indeterminate state.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
