### PR TITLE
Docs: update capital letter format

### DIFF
--- a/documents/src/navigation.md
+++ b/documents/src/navigation.md
@@ -93,7 +93,7 @@ type: nav
   * [Introduction](./creating-custom-elements)
   * [Tutorial](./tutorials/element)
   * [Element Types](./element-types)
-  * [Configuration and States](./configuration-and-states)
+  * [Configuration & States](./configuration-and-states)
   * [Events](./events)
   * [Localisation](./localisation)
   * [Reporting Issues](./reporting-issues)

--- a/documents/src/pages/build-app/framework-integration/react.md
+++ b/documents/src/pages/build-app/framework-integration/react.md
@@ -186,7 +186,7 @@ Finally, starting your app and it should automatically open `http://localhost:30
 npm start
 ```
 
-## Testing With Jest
+## Testing with Jest
 
 If you use [Create React App](https://create-react-app.dev/), Jest is already included out of the box with useful defaults.
 

--- a/documents/src/pages/build-app/internationalization.md
+++ b/documents/src/pages/build-app/internationalization.md
@@ -88,7 +88,7 @@ App.Settings.Language.read(value => {
 });
 ```
 
-### From The Server
+### URL Import
 
 You can store translations as JSON on the app server or CDN. In this case you may want to extract JSON content to upload to the server.
 

--- a/documents/src/pages/build-element/configuration-and-states.md
+++ b/documents/src/pages/build-element/configuration-and-states.md
@@ -7,7 +7,7 @@ layout: default
 
 
 
-# Configuration and States
+# Configuration & States
 When building your custom element, you need to choose how the element should be configured and managed the state. A different approach of configuration would require to implement state management differently.
 
 ## Element configuration

--- a/documents/src/pages/start/styling.md
+++ b/documents/src/pages/start/styling.md
@@ -12,7 +12,7 @@ Applications in Refinitiv Workspace should use the Halo Design System theme to b
 ## Halo Theme
 The Halo Design System theme is provided with two variants; light and dark. An application can use only one variant while the app is running. See [Theme Switching](/guides/theme-switching) to learn how to toggle between light and dark themes in your application.
 
-### Native Styles
+### Native styles
 
 The application is required to import native styles so that the correct typography and Element Frameworks global CSS variables are applied in an application.
 


### PR DESCRIPTION
- Rename page from “Configuration and States” to “Configuration & States”
- Rename i18n page h3 from “From The Server” to “URL Import”
- Change some h2&h3 capital letter