### PR TITLE
fix: remove parallel=1 out of test:all because wrong test behavior

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,7 +1,7 @@
 name: "Test Coverage" # To be able to access test coverage of the repository on SonarCloud
 on:
   push:
-    branches: [fix/test-coverage-action]
+    branches: [v6]
 env:
   USE_BROWSERSTACK: ${{ secrets.USE_BROWSERSTACK }}
   BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -1,7 +1,7 @@
 name: "Test Coverage" # To be able to access test coverage of the repository on SonarCloud
 on:
   push:
-    branches: [v6]
+    branches: [fix/test-coverage-action]
 env:
   USE_BROWSERSTACK: ${{ secrets.USE_BROWSERSTACK }}
   BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,11 @@ Run the unit test in specific element or package:
 npm run test button -- <options>
 ```
 Run the unit test on all packages:
+
+> add options `--parallel=1` to prevent port crash on local
+
 ```bash
-npm run test:all
+npm run test:all --parallel=1
 ```
 Run linting tools in specific a element or package:
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:docs": "nx run @refinitiv-ui/docs:start",
     "test": "node cli test",
     "test:affected": "nx affected:test",
-    "test:all": "nx affected:test --parallel=1 --all",
+    "test:all": "nx affected:test --all",
     "lint": "node cli lint",
     "lint:affected": "nx affected:lint --parallel",
     "lint:all": "nx affected:lint --parallel --all",


### PR DESCRIPTION
Duplicate options `--parallel=1` causes Test coverage action run passed without test.

Example pipeline that run pass without test. https://github.com/Refinitiv/refinitiv-ui/actions/runs/3590385905/jobs/6043763189