### PR TITLE
fix(number-field): fix step error when becomes 6 decimal points

### DIFF
--- a/packages/elements/src/number-field/__test__/number-field.step.test.js
+++ b/packages/elements/src/number-field/__test__/number-field.step.test.js
@@ -79,6 +79,14 @@ describe('number-field/Step', () => {
       const el = await fixture('<ef-number-field step="0.3"></ef-number-field>');
       await expectValues(el, [-0.3, -0.6, -0.9, -1.2, -1.5], DOWN);
     });
+    it('step = 0.0000001, Step Up', async () => {
+      const el = await fixture('<ef-number-field step="0.0000001"></ef-number-field>');
+      await expectValues(el, [0.0000001, 0.0000002, 0.0000003], UP);
+    });
+    it('step = 0.0000001, Step Down', async () => {
+      const el = await fixture('<ef-number-field step="0.0000001"></ef-number-field>');
+      await expectValues(el, [-0.0000001, -0.0000002, -0.0000003], DOWN);
+    });
     it('step = 0.3, value (property) = 0.5, Step Up', async () => {
       const el = await fixture('<ef-number-field step="0.3"></ef-number-field>');
       el.value = '0.5';

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -240,7 +240,7 @@ export class NumberField extends FormFieldElement {
     if (Math.floor(value) === value || isNaN(value) || !isFinite(value)) {
       return 0;
     }
-    return value.toString().split('.')[1].length || 0;
+    return new Intl.NumberFormat('en', { minimumSignificantDigits: 1 }).format(value).split('.')[1].length || 0;
   }
 
   /**


### PR DESCRIPTION
## Description

The number-field will error when step up/down number becomes after 6 decimal points.

Solution
- use `Intl.NumberFormat` that suggested by Trem in [ELF-1811](https://jira.refinitiv.com/browse/ELF-1811)


Fixes # (issue)

https://jira.refinitiv.com/browse/ELF-1811
https://jira.refinitiv.com/browse/ELF-2090

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
