### PR TITLE
refactor(combo-box, overlay): using resize helper from core

### DIFF
--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -8,7 +8,8 @@ import {
   TemplateResult,
   WarningNotice,
   FocusedPropertyKey,
-  StyleMap
+  StyleMap,
+  triggerResize
 } from '@refinitiv-ui/core';
 import { customElement } from '@refinitiv-ui/core/decorators/custom-element.js';
 import { property } from '@refinitiv-ui/core/decorators/property.js';
@@ -625,7 +626,7 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
     // If data is set asynchronously while popup is opened
     // list might not trigger popup update
     if (changedProperties.has('data') && this.opened) {
-      this.forcePopupLayout();
+      triggerResize();
     }
 
     super.update(changedProperties);
@@ -849,7 +850,7 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
       });
     }
 
-    this.forcePopupLayout();
+    triggerResize();
   }
 
   /**
@@ -893,18 +894,6 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
     }
 
     return canHighlight;
-  }
-
-  /**
-   * https://github.com/juggle/resize-observer/issues/42
-   *
-   * This event ensures that ResizeObserver picks up resize events
-   * when popup is deeply nested inside shadow root.
-   * TODO: remove this workaround once ResizeObserver handles shadow root scenario
-   * @returns {void}
-  */
-  protected forcePopupLayout (): void {
-    window.dispatchEvent(new Event('animationiteration'));
   }
 
   /**

--- a/packages/elements/src/overlay/elements/overlay.ts
+++ b/packages/elements/src/overlay/elements/overlay.ts
@@ -5,7 +5,8 @@ import {
   TemplateResult,
   CSSResultGroup,
   PropertyValues,
-  ElementSize
+  ElementSize,
+  triggerResize
 } from '@refinitiv-ui/core';
 import { customElement } from '@refinitiv-ui/core/decorators/custom-element.js';
 import { property } from '@refinitiv-ui/core/decorators/property.js';
@@ -770,14 +771,7 @@ export class Overlay extends ResponsiveElement {
       this.redrawThrottler.schedule(() => this.updateVariable('--redraw', `${Date.now()}`));
     }
 
-    /*
-    https://github.com/juggle/resize-observer/issues/42
-
-    This event ensures that ResizeObserver picks up resize events
-    when overlay is deeply nested inside shadow root.
-    TODO: remove this workaround once ResizeObserver handles shadow root scenario
-    */
-    window.dispatchEvent(new Event('animationiteration'));
+    triggerResize();
   }
 
   /**

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -2,7 +2,8 @@ import {
   html,
   TemplateResult,
   CSSResultGroup,
-  css
+  css,
+  triggerResize
 } from '@refinitiv-ui/core';
 import { customElement } from '@refinitiv-ui/core/decorators/custom-element.js';
 import { property } from '@refinitiv-ui/core/decorators/property.js';
@@ -624,7 +625,7 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
       // unlike CCB, we do not close EMS when there is no matches for filter
     }
 
-    this.forcePopupLayout();
+    triggerResize();
   }
 
   /**


### PR DESCRIPTION
## Description
Replace forcePopupLayout with resize helper from core.

## Type of change
- [x] Refactor (improves code without changing its functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
