### PR TITLE
fix(color-dialog): can not change value between default color and black color

### DIFF
--- a/packages/elements/src/color-dialog/__test__/color-dialog.test.js
+++ b/packages/elements/src/color-dialog/__test__/color-dialog.test.js
@@ -224,6 +224,12 @@ describe('color-dialog/ColorDialog', () => {
       await elementUpdated();
       expect(confirmBtn.disabled).to.equal(false);
     });
+    it('should enabled confirmed button when change from default color to black color', async () => {
+      hexInput.value = '000000';
+      hexInput.dispatchEvent(new Event('value-changed'));
+      await elementUpdated();
+      expect(confirmBtn.disabled).to.equal(false);
+    });
     it('should enabled confirmed button when r,g,b is valid', async () => {
       redInput.value = '255';
       greenInput.value = '200';

--- a/packages/elements/src/color-dialog/helpers/value-model.ts
+++ b/packages/elements/src/color-dialog/helpers/value-model.ts
@@ -63,7 +63,9 @@ class ValueModel {
    * @returns true if different
    */
   public hasChanged (): boolean {
-    return rgb(this.initialValue).formatHex() !== rgb(this.value).formatHex();
+    // Avoid the same hex color format of empty string and black color
+    return ((this.initialValue !== this.value) && ((!!this.initialValue && !!this.value) === false))
+            || rgb(this.initialValue).formatHex() !== rgb(this.value).formatHex();
   }
 
   /**


### PR DESCRIPTION
## Description

Color dialog can not pick color from default color to black color and  black color to default value either.
- Default color is `''`
- Black color is `'#000000'`

Root cause:
- It returns an incorrect value when try to compare hex format between two values in `hasChanged` method
- Both of default color and black color in hex format are return `'#000000'`

Solution: 
- Add condition to check when pick color between default value and another value

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-1974

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
