### PR TITLE
docs(collapse): add missing imports to "custom header" code example

### DIFF
--- a/documents/src/pages/elements/collapse.md
+++ b/documents/src/pages/elements/collapse.md
@@ -128,6 +128,10 @@ The header can contain simple text or components such as checkbox, button. These
 ::
 ```javascript
 ::collapse::
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements/checkbox?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+halo('checkbox');
+halo('button');
 ```
 ```css
 ef-collapse {


### PR DESCRIPTION
## Description

* add missing imports of checkbox and icon to "custom header" code example of collapse element

Fixes # (issue)

## Type of change

* documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
