### PR TITLE
fix: change rem unit to px

### DIFF
--- a/packages/elemental-theme/src/custom-elements/ef-chart.less
+++ b/packages/elemental-theme/src/custom-elements/ef-chart.less
@@ -2,9 +2,7 @@
 @import 'element:ef-layout';
 
 :host {
-
-  font-size: 15rem;
-
+  font-size: @global-text-size;
   --grid-line-color: fade(@grid-border-color, 50%);
   --zero-line-color: fade(@grid-border-color, 50%);
   --animation-duration: 1000;
@@ -30,5 +28,4 @@
   --chart-color-6: @dataviz-color-6;
   --chart-color-7: @dataviz-color-7;
   --chart-color-8: @dataviz-color-8;
-
 }

--- a/packages/elemental-theme/src/custom-elements/ef-tornado-chart.less
+++ b/packages/elemental-theme/src/custom-elements/ef-tornado-chart.less
@@ -6,7 +6,7 @@
   --secondary-color: @dataviz-color-secondary;
   --responsive-width: 450;
 
-  font-size: 15rem;
+  font-size: @global-text-size;
 
   [part=legend] {
     display: flex;

--- a/packages/elemental-theme/src/native-elements/h1.less
+++ b/packages/elemental-theme/src/native-elements/h1.less
@@ -2,13 +2,13 @@
 
 h1 {
   font-weight: 300;
-  font-size: 70rem;
+  font-size: 48px;
   margin: (60px * @airiness) 0 (25px * @airiness) 0;
   .heading-defaults;
 
   @media (max-width: 450px) {
     & {
-      font-size: 48rem;
+      font-size: 48px;
     }
   }
 }

--- a/packages/elemental-theme/src/native-elements/h2.less
+++ b/packages/elemental-theme/src/native-elements/h2.less
@@ -2,7 +2,7 @@
 
 h2 {
   font-weight: 300;
-  font-size: 38rem;
+  font-size: 38px;
   margin: (55px * @airiness) 0 (20px * @airiness) 0;
   .heading-defaults;
 }

--- a/packages/elemental-theme/src/native-elements/h3.less
+++ b/packages/elemental-theme/src/native-elements/h3.less
@@ -2,7 +2,7 @@
 
 h3 {
   font-weight: 300;
-  font-size: 28rem;
+  font-size: 28px;
   margin: (48px * @airiness) 0 (20px * @airiness) 0;
   .heading-defaults;
 }

--- a/packages/elemental-theme/src/native-elements/h4.less
+++ b/packages/elemental-theme/src/native-elements/h4.less
@@ -2,7 +2,7 @@
 
 h4 {
   font-weight: 400;
-  font-size: 20rem;
+  font-size: 20px;
   margin: (40px * @airiness) 0 (25px * @airiness) 0;
   .heading-defaults;
 }

--- a/packages/elemental-theme/src/native-elements/h5.less
+++ b/packages/elemental-theme/src/native-elements/h5.less
@@ -2,7 +2,7 @@
 
 h5 {
   font-weight: 500;
-  font-size: 14rem;
+  font-size: 14px;
   margin: (36px * @airiness) 0 (20px * @airiness) 0;
   text-transform: uppercase;
   .heading-defaults;

--- a/packages/elemental-theme/src/native-elements/h6.less
+++ b/packages/elemental-theme/src/native-elements/h6.less
@@ -2,7 +2,7 @@
 
 h6 {
   font-weight: 700;
-  font-size: 11rem;
+  font-size: 11px;
   margin: (30px * @airiness) 0 (-1px + 1 * @airiness) 0;
   text-transform: uppercase;
   .heading-defaults;

--- a/packages/elemental-theme/src/native-elements/html.less
+++ b/packages/elemental-theme/src/native-elements/html.less
@@ -1,7 +1,6 @@
 @import '../shared-styles/scrollbar';
 
 html {
-  font-size: calc(unit((0.625 * @scale), em) / 10);
   height: 100%;
   touch-action: manipulation; // Improve tap speed on mobile browsers
   -webkit-tap-highlight-color: rgba(0,0,0,0);

--- a/packages/elemental-theme/src/variables.less
+++ b/packages/elemental-theme/src/variables.less
@@ -44,7 +44,7 @@ Rules:
 @scheme-color-info                       : @color-dataviz-cyan;
 
 // Globals
-@global-text-size                        : 15rem; // Equivalent to 15px
+@global-text-size                        : 15px;
 @global-text-color                       : @color-slate;
 @global-background-color                 : @color-white;
 @global-text-selection-color             : inherit;

--- a/packages/halo-theme/src/custom-elements/ef-chart.less
+++ b/packages/halo-theme/src/custom-elements/ef-chart.less
@@ -1,7 +1,6 @@
 @import '@refinitiv-ui/elemental-theme/src/custom-elements/ef-chart';
 
 :host {
-   font-size: @global-text-size;;
   --tooltip-background-color: @tooltip-background-color;
   --tooltip-title-color: @tooltip-text-color;
   --tooltip-body-color: @tooltip-text-color;

--- a/packages/halo-theme/src/custom-elements/ef-counter.less
+++ b/packages/halo-theme/src/custom-elements/ef-counter.less
@@ -9,7 +9,7 @@
   line-height: @size;
   color: @counter-text-color;
   background-color: @counter-background-color;
-  font-size: 10rem;
+  font-size: 10px;
   padding: 0px 3px;
   &:hover {
     background-color: @button-hover-background-color;

--- a/packages/halo-theme/src/custom-elements/ef-tornado-chart.less
+++ b/packages/halo-theme/src/custom-elements/ef-tornado-chart.less
@@ -3,5 +3,4 @@
 :host {
   --primary-color: @dataviz-color-1;
   --secondary-color: @dataviz-color-2;
-  font-size: @global-text-size;
 }

--- a/packages/halo-theme/src/native-elements/h1.less
+++ b/packages/halo-theme/src/native-elements/h1.less
@@ -1,7 +1,7 @@
 @import '@refinitiv-ui/elemental-theme/src/native-elements/h1';
 
 h1 {
-  font-size: 44rem;
+  font-size: 44px;
   margin-bottom: 15px;
   font-weight: normal;
   line-height: calc(50/44);

--- a/packages/halo-theme/src/native-elements/h2.less
+++ b/packages/halo-theme/src/native-elements/h2.less
@@ -1,7 +1,7 @@
 @import '@refinitiv-ui/elemental-theme/src/native-elements/h2';
 
 h2 {
-  font-size: 36rem;
+  font-size: 36px;
   margin-bottom: 15px;
   font-weight: normal;
   line-height: calc(42/36);

--- a/packages/halo-theme/src/native-elements/h3.less
+++ b/packages/halo-theme/src/native-elements/h3.less
@@ -1,7 +1,7 @@
 @import '@refinitiv-ui/elemental-theme/src/native-elements/h3';
 
 h3 {
-  font-size: 28rem;
+  font-size: 28px;
   margin-bottom: 15px;
   font-weight: normal;
   line-height: calc(34/28);

--- a/packages/halo-theme/src/native-elements/h4.less
+++ b/packages/halo-theme/src/native-elements/h4.less
@@ -1,7 +1,7 @@
 @import '@refinitiv-ui/elemental-theme/src/native-elements/h4';
 
 h4 {
-  font-size: 24rem;
+  font-size: 24px;
   margin-bottom: 10px;
   text-transform: uppercase;
   font-weight: bold;

--- a/packages/halo-theme/src/native-elements/h5.less
+++ b/packages/halo-theme/src/native-elements/h5.less
@@ -1,7 +1,7 @@
 @import '@refinitiv-ui/elemental-theme/src/native-elements/h5';
 
 h5 {
-  font-size: 18rem;
+  font-size: 18px;
   margin-bottom: 10px;
   text-transform: uppercase;
   font-weight: bold;

--- a/packages/halo-theme/src/native-elements/h6.less
+++ b/packages/halo-theme/src/native-elements/h6.less
@@ -1,7 +1,7 @@
 @import '@refinitiv-ui/elemental-theme/src/native-elements/h6';
 
 h6 {
-  font-size: 16rem;
+  font-size: 16px;
   margin-bottom: 10px;
   text-transform: uppercase;
   font-weight: bold;

--- a/packages/halo-theme/src/variants/dark/overrides.less
+++ b/packages/halo-theme/src/variants/dark/overrides.less
@@ -31,7 +31,7 @@ Rules:
 @shadowing                                : 0;
 
 // Globals
-@global-text-size                         : 12rem;
+@global-text-size                         : 12px;
 @global-background-color                  : @color-lights-out;
 @global-text-color                        : @color-silver;
 @global-text-mark-color                   : @color-white;

--- a/packages/solar-theme/src/custom-elements/ef-chart.less
+++ b/packages/solar-theme/src/custom-elements/ef-chart.less
@@ -1,7 +1,6 @@
 @import '@refinitiv-ui/elemental-theme/src/custom-elements/ef-chart';
 
 :host {
-  font-size: 12rem;
   color: fade(@global-text-color, 80%);
   --legend-key-box-width: 12;
   --grid-line-color: fade(@global-text-color, 10%);

--- a/packages/solar-theme/src/custom-elements/ef-tornado-chart.less
+++ b/packages/solar-theme/src/custom-elements/ef-tornado-chart.less
@@ -2,5 +2,4 @@
 
 :host {
   --secondary-color: @dataviz-color-tertiary;
-  font-size: @global-text-size;
 }

--- a/packages/solar-theme/src/native-elements/h1.less
+++ b/packages/solar-theme/src/native-elements/h1.less
@@ -2,7 +2,7 @@
 
 h1 {
   color: @heading-color-1;
-  font-size: 44rem;
+  font-size: 44px;
   margin-bottom: 15px;
   font-weight: normal;
 }

--- a/packages/solar-theme/src/native-elements/h2.less
+++ b/packages/solar-theme/src/native-elements/h2.less
@@ -2,7 +2,7 @@
 
 h2 {
   color: @heading-color-2;
-  font-size: 37rem;
+  font-size: 37px;
   margin-bottom: 15px;
   font-weight: normal;
 }

--- a/packages/solar-theme/src/native-elements/h3.less
+++ b/packages/solar-theme/src/native-elements/h3.less
@@ -2,7 +2,7 @@
 
 h3 {
   color: @heading-color-3;
-  font-size: 30rem;
+  font-size: 30px;
   margin-bottom: 15px;
   font-weight: normal;
 }

--- a/packages/solar-theme/src/native-elements/h4.less
+++ b/packages/solar-theme/src/native-elements/h4.less
@@ -2,7 +2,7 @@
 
 h4 {
   color: @heading-color-4;
-  font-size: 23rem;
+  font-size: 23px;
   margin-bottom: 10px;
   text-transform: uppercase;
   font-weight: bold;

--- a/packages/solar-theme/src/native-elements/h5.less
+++ b/packages/solar-theme/src/native-elements/h5.less
@@ -2,7 +2,7 @@
 
 h5 {
   color: @heading-color-5;
-  font-size: 15rem;
+  font-size: 15px;
   margin-bottom: 10px;
   text-transform: uppercase;
   font-weight: bold;

--- a/packages/solar-theme/src/native-elements/h6.less
+++ b/packages/solar-theme/src/native-elements/h6.less
@@ -2,7 +2,7 @@
 
 h6 {
   color: @heading-color-6;
-  font-size: 13rem;
+  font-size: 13px;
   margin-bottom: 10px;
   text-transform: uppercase;
   font-weight: bold;

--- a/packages/solar-theme/src/variants/charcoal/overrides.less
+++ b/packages/solar-theme/src/variants/charcoal/overrides.less
@@ -20,7 +20,7 @@ This file overrides variables from Elemental.
 @scheme-color-warning                     : @color-orange-neon-carrot;
 
 // Globals
-@global-text-size                         : 14rem;
+@global-text-size                         : 14px;
 @global-icon-size                         : 15px;
 @global-text-color                        : @color-grey-silver;
 @global-background-color                  : @color-grey-woodsmoke;
@@ -98,7 +98,7 @@ This file overrides variables from Elemental.
 
 // Controls
 @control-height                           : 23px;
-@control-font-size                        : 13rem;
+@control-font-size                        : 13px;
 @control-border-color                     : @color-grey-abbey;
 @control-text-color                       : @color-grey-mercury;
 // Buttons


### PR DESCRIPTION
## Description

Currently, font-size is set at `html` tag with `1px` and all elements are using `rem` unit.

Often, application want to override font size to their preferred unit at `html` e.g. `15px`. Consequently, this screw up the font in all ELF elements. 

We need to change all rem unit to px.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
