### PR TITLE
fix(chart): change chart property access modifier from private to public

### DIFF
--- a/packages/elements/src/chart/index.ts
+++ b/packages/elements/src/chart/index.ts
@@ -87,7 +87,7 @@ export class Chart extends BasicElement {
   /**
    * Chart.js object
    */
-  private chart: ChartJS | null = null;
+  public chart: ChartJS | null = null;
 
   /**
    * Chart configurations. Same configuration as ChartJS


### PR DESCRIPTION
## Description
`chart.js` instance can be access by `chart` property but current It defined as private property so we need to change It to public.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
