### PR TITLE
docs(elements): fix incorrect style in select grouping demo section

### DIFF
--- a/documents/src/pages/elements/select.md
+++ b/documents/src/pages/elements/select.md
@@ -110,6 +110,7 @@ section {
 }
 ```
 ```html
+<section>
   <ef-select>
   <ef-item type="header">Drinks</ef-item>
   <ef-item value="1">Cola</ef-item>


### PR DESCRIPTION
`<section>` tag is missing so it causes demo block has incorrect height.