### PR TITLE
fix: remove unused imports

### DIFF
--- a/packages/elements/src/pagination/index.ts
+++ b/packages/elements/src/pagination/index.ts
@@ -16,7 +16,6 @@ import { VERSION } from '../version.js';
 import '../button/index.js';
 import '../button-bar/index.js';
 import '../layout/index.js';
-import '../text-field/index.js';
 
 import '@refinitiv-ui/phrasebook/locale/en/pagination.js';
 import { translate, Translate, TranslateDirectiveResult } from '@refinitiv-ui/translate';

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -16,7 +16,6 @@ import { CollectionComposer } from '@refinitiv-ui/utils/collection.js';
 import { TimeoutTaskRunner } from '@refinitiv-ui/utils/async.js';
 
 import '../icon/index.js';
-import '../text-field/index.js';
 import '../pill/index.js';
 import '../button/index.js';
 import '../checkbox/index.js';


### PR DESCRIPTION
## Description

`text-field` is not being used in both of the elements. Import is unnecessary. 

## Type of change

Please delete options that are not relevant.

- [ ] Refactor (improves code without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
