### PR TITLE
fix(list): error custom renderer requires key

### DIFF
--- a/packages/elements/src/list/elements/list.ts
+++ b/packages/elements/src/list/elements/list.ts
@@ -14,7 +14,6 @@ import { VERSION } from '../../version.js';
 import { CollectionComposer, DataItem } from '@refinitiv-ui/utils/collection.js';
 import type { ItemData } from '../../item';
 import type { ListData } from '../helpers/types';
-import { getItemId } from '../helpers/item-id.js';
 import { ListRenderer } from '../helpers/renderer.js';
 import './list-item.js';
 
@@ -357,12 +356,10 @@ export class List<T extends DataItem = ItemData> extends ControlElement {
     if (item) {
       this.clearHighlighted();
       this.composer.setItemPropertyValue(item, 'highlighted', true);
-
-      if (this.tabIndex >= 0) {
-        const id = getItemId(this.renderer.key, item.value);
-        this.setAttribute('aria-activedescendant', id);
+      const element = this.elementFromItem(item);
+      if (this.tabIndex >= 0 && element) {
+        this.setAttribute('aria-activedescendant', element.id);
       }
-
       scrollToItem && this.scrollToItem(item);
     }
   }

--- a/packages/elements/src/list/helpers/renderer.ts
+++ b/packages/elements/src/list/helpers/renderer.ts
@@ -16,12 +16,13 @@ type Context = {
  * This is the default renderer for lists.
  */
 export class ListRenderer extends Renderer {
-  /**
-   * Renderer key prefix, used in combination with item value to give unique id to each item
-   */
-  public key: string = uuid();
-
+  
   constructor (context?: unknown) {
+    /**
+     * Renderer key prefix, used in combination with item value to give unique id to each item
+     */
+    const key: string = uuid();
+
     /**
      * Create and return render function
      */
@@ -38,7 +39,7 @@ export class ListRenderer extends Renderer {
       el.label = composer.getItemPropertyValue(item, 'label') as string;
       el.subLabel = composer.getItemPropertyValue(item, 'subLabel') as string;
       el.value = composer.getItemPropertyValue(item, 'value') as string;
-      el.id = getItemId(this.key, el.value);
+      el.id = getItemId(key, el.value);
       el.icon = composer.getItemPropertyValue(item, 'icon') as string;
       el.highlighted = composer.getItemPropertyValue(item, 'highlighted') === true;
       el.selected = composer.getItemPropertyValue(item, 'selected') === true;

--- a/packages/elements/src/tree/__demo__/index.html
+++ b/packages/elements/src/tree/__demo__/index.html
@@ -115,7 +115,6 @@
         }
         return element;
       };
-      custom.renderer.key = renderer.key; // used in aria-activedescendant to indicate current highlight item
     </script>
 
     <demo-block header="Default" layout="normal" tags="default">

--- a/packages/elements/src/tree/helpers/renderer.ts
+++ b/packages/elements/src/tree/helpers/renderer.ts
@@ -12,12 +12,11 @@ type RendererScope = {
 
 export class TreeRenderer extends Renderer {
 
-  /**
-   * Renderer key prefix, used in combination with item value to give unique id to each item
-   */
-  public key: string = uuid();
-
   constructor (scope?: unknown) {
+    /**
+     * Renderer key prefix, used in combination with item value to give unique id to each item
+     */
+    const key: string = uuid();
 
     let manager: TreeManager<TreeDataItem>;
     let currentMode: TreeManagerMode;
@@ -36,7 +35,7 @@ export class TreeRenderer extends Renderer {
 
       element.multiple = multiple;
       element.item = item;
-      element.id = getItemId(this.key, item.value);
+      element.id = getItemId(key, item.value);
       element.depth = composer.getItemDepth(item);
       element.parent = composer.getItemChildren(item).length > 0;
       element.expanded = manager.isItemExpanded(item);


### PR DESCRIPTION
## Description
Type mismatched issue from https://lseg.stackenterprise.co/questions/3803
Typescript always throwing an error when trying to setting a tree renderer to a new custom renderer
Typescript does not allow to set a new custom renderer function because a type is mismatched.

Root cause: 
- Renderer class needs to be provided a key when creating to use when highlight item for accessibility reason

Solution: 
- Move renderer key property from class to constructor and get id from element instead when highlight item

Fixes # (issue)
https://jira.refinitiv.com/browse/STG-178

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
