### PR TITLE
Revert "fix: use Map to save key instead of plain object to prevent it from being replaced when a new element is created."

### DIFF
--- a/packages/translate/src/translate.ts
+++ b/packages/translate/src/translate.ts
@@ -154,19 +154,18 @@ const translate = function (options?: string | DecoratorOptions): TranslateFunct
     // Cannot use an element itself as a key.
     // Element may have multiple translate directives with different scope
     // Therefore we need a truly unique key
-    const keys = new Map<BasicElement, ObserverKey>();
+    let key: ObserverKey;
     const connectedCallback = prototype.connectedCallback;
 
     prototype.connectedCallback = function (): void {
       connectedCallback.call(this);
-      keys.set(this, observeTranslations.call(this, scope));
+      key = observeTranslations.call(this, scope);
     };
 
     const disconnectedCallback = prototype.disconnectedCallback;
     prototype.disconnectedCallback = function (): void {
       disconnectedCallback.call(this);
-      disconnectTranslations.call(this, keys.get(this) || '');
-      keys.delete(this);
+      disconnectTranslations.call(this, key);
     };
 
     const descriptor = mode === 'promise'


### PR DESCRIPTION
Reverts Refinitiv/refinitiv-ui#574