### PR TITLE
Fix/memory leak translate directive removing wrong observer key

### DIFF
--- a/packages/translate/src/translate.ts
+++ b/packages/translate/src/translate.ts
@@ -132,11 +132,9 @@ const observeTranslations = function (this: BasicElement, scope = this.localName
  * @param key Observe key from the `observeTranslations` function
  * @returns {void}
  */
-const disconnectTranslations = function (this: BasicElement, key: ObserverKey | undefined): void {
+const disconnectTranslations = function (this: BasicElement, key: ObserverKey): void {
   LangAttributeObserver.disconnect(this);
-  if (key) {
-    Phrasebook.disconnect(key);
-  }
+  Phrasebook.disconnect(key);
 };
 
 /**
@@ -167,7 +165,7 @@ const translate = function (options?: string | DecoratorOptions): TranslateFunct
     const disconnectedCallback = prototype.disconnectedCallback;
     prototype.disconnectedCallback = function (): void {
       disconnectedCallback.call(this);
-      disconnectTranslations.call(this, keys.get(this));
+      disconnectTranslations.call(this, keys.get(this) || '');
       keys.delete(this);
     };
 

--- a/packages/translate/src/translate.ts
+++ b/packages/translate/src/translate.ts
@@ -132,9 +132,11 @@ const observeTranslations = function (this: BasicElement, scope = this.localName
  * @param key Observe key from the `observeTranslations` function
  * @returns {void}
  */
-const disconnectTranslations = function (this: BasicElement, key: ObserverKey): void {
+const disconnectTranslations = function (this: BasicElement, key: ObserverKey | undefined): void {
   LangAttributeObserver.disconnect(this);
-  Phrasebook.disconnect(key);
+  if (key) {
+    Phrasebook.disconnect(key);
+  }
 };
 
 /**
@@ -154,18 +156,19 @@ const translate = function (options?: string | DecoratorOptions): TranslateFunct
     // Cannot use an element itself as a key.
     // Element may have multiple translate directives with different scope
     // Therefore we need a truly unique key
-    let key: ObserverKey;
+    const keys = new WeakMap<HTMLElement, ObserverKey>();
     const connectedCallback = prototype.connectedCallback;
 
     prototype.connectedCallback = function (): void {
       connectedCallback.call(this);
-      key = observeTranslations.call(this, scope);
+      keys.set(this, observeTranslations.call(this, scope));
     };
 
     const disconnectedCallback = prototype.disconnectedCallback;
     prototype.disconnectedCallback = function (): void {
       disconnectedCallback.call(this);
-      disconnectTranslations.call(this, key);
+      disconnectTranslations.call(this, keys.get(this));
+      keys.delete(this);
     };
 
     const descriptor = mode === 'promise'

--- a/packages/translate/src/translate.ts
+++ b/packages/translate/src/translate.ts
@@ -156,7 +156,7 @@ const translate = function (options?: string | DecoratorOptions): TranslateFunct
     // Cannot use an element itself as a key.
     // Element may have multiple translate directives with different scope
     // Therefore we need a truly unique key
-    const keys = new WeakMap<HTMLElement, ObserverKey>();
+    const keys = new WeakMap<BasicElement, ObserverKey>();
     const connectedCallback = prototype.connectedCallback;
 
     prototype.connectedCallback = function (): void {

--- a/packages/translate/src/translate.ts
+++ b/packages/translate/src/translate.ts
@@ -156,7 +156,7 @@ const translate = function (options?: string | DecoratorOptions): TranslateFunct
     // Cannot use an element itself as a key.
     // Element may have multiple translate directives with different scope
     // Therefore we need a truly unique key
-    const keys = new WeakMap<BasicElement, ObserverKey>();
+    const keys = new Map<BasicElement, ObserverKey>();
     const connectedCallback = prototype.connectedCallback;
 
     prototype.connectedCallback = function (): void {


### PR DESCRIPTION
Description
When an element using the translate directive is created, it will retrieve the key from the Phrasebook and store it in the key variable within the translate scope.

However, the translate directive is only called once, unless a new element with the same name is created.
As a result, the key variable will be replaced each time, leading to a memory leak since the Phrasebook will only remove the most recent element reference.

Type of change
- [x]  Bug fix (non-breaking change which fixes an issue)