### PR TITLE
refactor: remove `await` on non-promise functions

### DIFF
--- a/packages/create-efx/template/scripts/jsx/jsxdts-generator.js
+++ b/packages/create-efx/template/scripts/jsx/jsxdts-generator.js
@@ -38,7 +38,7 @@ const handler = async () => {
     path.join(PACKAGE_ROOT, ELEMENT_DIST, JSX_TYPE_DECLARATION)
   );
 
-  const files = await getElementList(path.join(PACKAGE_ROOT, ELEMENT_DIST));
+  const files = getElementList(path.join(PACKAGE_ROOT, ELEMENT_DIST));
 
   for (const file of files) {
     const elementName = getElementTagName(file);

--- a/scripts/release/jsxdts-generator.js
+++ b/scripts/release/jsxdts-generator.js
@@ -35,7 +35,7 @@ const handler = async () => {
     path.join(PACKAGE_ROOT, ELEMENT_DIST, JSX_TYPE_DECLARATION)
   );
 
-  const files = await getElementList(path.join(PACKAGE_ROOT, ELEMENT_DIST));
+  const files = getElementList(path.join(PACKAGE_ROOT, ELEMENT_DIST));
 
   for (const file of files) {
     const elementName = getElementTagName(file);

--- a/scripts/release/theme-extractor.js
+++ b/scripts/release/theme-extractor.js
@@ -26,7 +26,7 @@ const THEMES_DIRECTORY = 'themes';
  * @returns {[{ dir: string, elements: string[], dependencies: string[]]} DependencyMap
  */
 const createDependencyMap = async () => {
-  const paths = await getElementList(path.join(process.cwd(), ELEMENT_DIST));
+  const paths = getElementList(path.join(process.cwd(), ELEMENT_DIST));
 
   const elements = paths.reduce((entries, path) => {
     const elementTagName = getElementTagName(path);
@@ -119,13 +119,13 @@ const getThemes = async (elements) => {
  * @returns {void}
  */
 const handler = async () => {
-  const dependencyMap = await createDependencyMap();
+  const dependencyMap = createDependencyMap();
 
   // DEBUG: This will log the dependency tree of all elements
   // console.log(dependencyMap);
 
   for (const { dir, elements, dependencies } of dependencyMap) {
-    const themes = await getThemes(elements);
+    const themes = getThemes(elements);
 
     for (const variant of themes) {
       /**


### PR DESCRIPTION
## Description

Removes `await` on non-promise functions reported by [sonarcloud](https://sonarcloud.io/project/issues?open=AYN4mjpMNvzb302CUHvY&id=refinitiv_refinitiv-ui)

## Type of change

Please delete options that are not relevant.

- [x] Refactor (improves code without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
