### PR TITLE
refactor(calendar): remove ie11 BC year workaround

### DIFF
--- a/packages/elements/src/calendar/index.ts
+++ b/packages/elements/src/calendar/index.ts
@@ -749,19 +749,15 @@ export class Calendar extends ControlElement implements MultiValue {
           break;
         }
         return;
-      case 'Up': // IE11
       case 'ArrowUp':
         void this.onNavigation('ArrowUp');
         break;
-      case 'Down':
       case 'ArrowDown':
         void this.onNavigation('ArrowDown');
         break;
-      case 'Left':
       case 'ArrowLeft':
         void this.onNavigation('ArrowLeft');
         break;
-      case 'Right':
       case 'ArrowRight':
         void this.onNavigation('ArrowRight');
         break;
@@ -1368,7 +1364,7 @@ export class Calendar extends ControlElement implements MultiValue {
       ?range-to=${cell.rangeTo}>
         <div role="${ifDefined(cell.value ? 'button' : undefined)}"
              tabindex=${ifDefined(isSelectable ? (cell.active ? 0 : -1) : undefined)}
-             aria-label="${ifDefined(isSelectable ? this.t(this.getCellLabelKey(cell), { /* IE11 has significant performance hit, disable */
+             aria-label="${ifDefined(isSelectable ? this.t(this.getCellLabelKey(cell), {
                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                value: parse(cell.value!),
                view: this.renderView
@@ -1440,7 +1436,7 @@ export class Calendar extends ControlElement implements MultiValue {
    * @returns template result
    */
   private get selectionTemplate (): TemplateResult | undefined {
-    if (!this.announceValues) { /* IE11 has significant performance complications */
+    if (!this.announceValues) {
       return;
     }
     return html`<div

--- a/packages/elements/src/calendar/index.ts
+++ b/packages/elements/src/calendar/index.ts
@@ -1025,10 +1025,10 @@ export class Calendar extends ControlElement implements MultiValue {
    */
   private viewFormattedDate (segment: DateSegment, includeMonth = false): TemplateResult {
     const year = segment.year;
-    const includeEra = year <= 0;
+    const isBC = year <= 0;
     const date = utcParse(segment);
 
-    return html`${this.dateT('VIEW_FORMAT', { date, includeMonth, includeEra }, ViewFormatTranslateParams)}`;
+    return html`${this.dateT('VIEW_FORMAT', { date, includeMonth, includeEra: isBC }, ViewFormatTranslateParams)}`;
   }
 
   /**

--- a/packages/elements/src/calendar/index.ts
+++ b/packages/elements/src/calendar/index.ts
@@ -16,7 +16,6 @@ import { cache } from '@refinitiv-ui/core/directives/cache.js';
 import { guard } from '@refinitiv-ui/core/directives/guard.js';
 import { ref, createRef, Ref } from '@refinitiv-ui/core/directives/ref.js';
 import { VERSION } from '../version.js';
-import { isIE } from '@refinitiv-ui/utils/browser.js';
 import {
   DateSegment,
   DateFormat,
@@ -1030,15 +1029,8 @@ export class Calendar extends ControlElement implements MultiValue {
    */
   private viewFormattedDate (segment: DateSegment, includeMonth = false): TemplateResult {
     const year = segment.year;
-    const isBC = year <= 0;
-    const includeEra = isBC;
+    const includeEra = year <= 0;
     const date = utcParse(segment);
-
-    // Unfortunately IE11 does not support date formatting for year <= 0
-    // Do manual conversion instead
-    if (isIE && isBC) {
-      return html`${formatLocaleDate(date, getLocale(this), includeMonth, includeEra)}`;
-    }
 
     return html`${this.dateT('VIEW_FORMAT', { date, includeMonth, includeEra }, ViewFormatTranslateParams)}`;
   }
@@ -1376,7 +1368,7 @@ export class Calendar extends ControlElement implements MultiValue {
       ?range-to=${cell.rangeTo}>
         <div role="${ifDefined(cell.value ? 'button' : undefined)}"
              tabindex=${ifDefined(isSelectable ? (cell.active ? 0 : -1) : undefined)}
-             aria-label="${ifDefined(isSelectable && !isIE ? this.t(this.getCellLabelKey(cell), { /* IE11 has significant performance hit, disable */
+             aria-label="${ifDefined(isSelectable ? this.t(this.getCellLabelKey(cell), { /* IE11 has significant performance hit, disable */
                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                value: parse(cell.value!),
                view: this.renderView
@@ -1448,7 +1440,7 @@ export class Calendar extends ControlElement implements MultiValue {
    * @returns template result
    */
   private get selectionTemplate (): TemplateResult | undefined {
-    if (isIE || !this.announceValues) { /* IE11 has significant performance complications */
+    if (!this.announceValues) { /* IE11 has significant performance complications */
       return;
     }
     return html`<div

--- a/packages/elements/src/calendar/index.ts
+++ b/packages/elements/src/calendar/index.ts
@@ -741,7 +741,6 @@ export class Calendar extends ControlElement implements MultiValue {
     }
 
     switch (event.key) {
-      case 'Esc':
       case 'Escape':
         if (this.renderView === RenderView.YEAR || this.renderView === RenderView.MONTH) {
           this.renderView = RenderView.DAY;

--- a/packages/elements/src/calendar/index.ts
+++ b/packages/elements/src/calendar/index.ts
@@ -51,7 +51,6 @@ import {
   monthInfo,
   weekdaysNames,
   monthsNames,
-  formatLocaleDate,
   ViewFormatTranslateParams
 } from './utils.js';
 import {

--- a/packages/elements/src/calendar/utils.ts
+++ b/packages/elements/src/calendar/utils.ts
@@ -108,31 +108,6 @@ const monthsNames = (locale: string, width: Intl.DateTimeFormatOptions['month'] 
 };
 
 /**
- * @deprecated
- * Some old browsers (as IE11) do not support formatting of old dates before BC
- * Instead simply convert the date manually to match Translate function
- * @param date Date
- * @param locale locale
- * @param [includeMonth=false] true to include month
- * @param [includeEra=false] tru to include era descriptor
- * @returns formatted dates
- */
-const formatLocaleDate = (date: Date, locale: string, includeMonth = false, includeEra = false): string => {
-  locale = getLocale(locale);
-
-  const monthNames = monthsNames(locale, 'long');
-  const year = date.getUTCFullYear();
-  const month = date.getUTCMonth();
-
-  // BC flags are not supported. Always use English
-  return `${
-    includeMonth ? `${monthNames[month]} ` : ''
-  } ${
-    year > 0 ? year : year === 0 ? '1' : Math.abs(year - 1)
-  }${includeEra ? year <= 0 ? ' BC' : ' AD' : ''}`;
-};
-
-/**
  * Used to format views
  */
 const ViewFormatTranslateParams: TranslateParams = {
@@ -150,6 +125,5 @@ export {
   monthInfo,
   weekdaysNames,
   monthsNames,
-  formatLocaleDate,
   ViewFormatTranslateParams
 };

--- a/packages/elements/src/calendar/utils.ts
+++ b/packages/elements/src/calendar/utils.ts
@@ -114,7 +114,7 @@ const ViewFormatTranslateParams: TranslateParams = {
   unicodeExtensions: {
     // while latest Chrome, FF and Intl.DateTimeFormat polyfill support
     // calendar option to format date,
-    // older browsers as Safari and IE11 need this to be provided as
+    // older browsers as Safari version < 14.1 need this to be provided as
     // unicode extension, e.g. lang="th-u-ca-gregory"
     ca: 'gregory'
   },


### PR DESCRIPTION
## Description
IE11 series: remove specific IE11 code from `ef-calendar`

Fixes # (issue)
https://jira.refinitiv.com/browse/STG-33

## Type of change

- [x] Refactor (improves code without changing its functionality)
