### PR TITLE
refactor(overlay): remove first resize done attr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16846,11 +16846,6 @@
         "tslib": "^2.3.0"
       }
     },
-    "@nrwl/nx-darwin-x64": {
-      "version": "15.7.2",
-      "dev": true,
-      "optional": true
-    },
     "@nrwl/tao": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-15.7.2.tgz",
@@ -21012,7 +21007,9 @@
       }
     },
     "idb": {
-      "version": "7.1.1"
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
     },
     "ieee754": {
       "version": "1.2.1",

--- a/packages/elements/src/combo-box/__test__/__snapshots__/combo-box.async.test.snap.js
+++ b/packages/elements/src/combo-box/__test__/__snapshots__/combo-box.async.test.snap.js
@@ -28,7 +28,6 @@ snapshots["combo-box/AsyncFilter Setting Data Asynchronously Should be possible 
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""

--- a/packages/elements/src/combo-box/__test__/__snapshots__/combo-box.filter.test.snap.js
+++ b/packages/elements/src/combo-box/__test__/__snapshots__/combo-box.filter.test.snap.js
@@ -28,7 +28,6 @@ snapshots["combo-box/Filter Can Filter Data Default filter filters data"] =
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""
@@ -94,7 +93,6 @@ snapshots["combo-box/Filter Can Filter Data Default filter filters data: changed
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""

--- a/packages/elements/src/combo-box/__test__/__snapshots__/combo-box.selected.test.snap.js
+++ b/packages/elements/src/combo-box/__test__/__snapshots__/combo-box.selected.test.snap.js
@@ -28,7 +28,6 @@ snapshots["combo-box/Selected Selection By Selected Property Data Selected: Afgh
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""
@@ -101,7 +100,6 @@ snapshots["combo-box/Selected Selection By Selected Property Data Selected: chan
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""
@@ -174,7 +172,6 @@ snapshots["combo-box/Selected Selection By Selected Property Data Selected: unse
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""
@@ -252,7 +249,6 @@ snapshots["combo-box/Selected Selection By Selected Property Multiple. Data Sele
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""
@@ -330,7 +326,6 @@ snapshots["combo-box/Selected Selection By Selected Property Multiple. Data Sele
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""
@@ -407,7 +402,6 @@ snapshots["combo-box/Selected Selection By Selected Property Multiple. Data Sele
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""

--- a/packages/elements/src/combo-box/__test__/__snapshots__/combo-box.template.test.snap.js
+++ b/packages/elements/src/combo-box/__test__/__snapshots__/combo-box.template.test.snap.js
@@ -54,7 +54,6 @@ snapshots["combo-box/Template Template Parts Lazy Render: data"] =
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""
@@ -126,7 +125,6 @@ snapshots["combo-box/Template Template Parts Data is reflected to render"] =
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""
@@ -198,7 +196,6 @@ snapshots["combo-box/Template Template Parts Data is reflected to render: revers
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""
@@ -264,7 +261,6 @@ snapshots["combo-box/Template Template Parts Data is reflected to render: empty"
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""

--- a/packages/elements/src/combo-box/__test__/__snapshots__/combo-box.value.test.snap.js
+++ b/packages/elements/src/combo-box/__test__/__snapshots__/combo-box.value.test.snap.js
@@ -28,7 +28,6 @@ snapshots["combo-box/Value Selection by Value Attribute Data Selected: Afghanist
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""
@@ -101,7 +100,6 @@ snapshots["combo-box/Value Selection by Value Attribute Value attribute is selec
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""
@@ -180,7 +178,6 @@ snapshots["combo-box/Value Selection by Value Attribute Multiple. Data Selected:
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-focus-management=""
   no-overlap=""

--- a/packages/elements/src/datetime-picker/__test__/__snapshots__/datetime-picker.snapshot.test.snap.js
+++ b/packages/elements/src/datetime-picker/__test__/__snapshots__/datetime-picker.snapshot.test.snap.js
@@ -46,7 +46,6 @@ snapshots["datetime-picker/DOMStructure DOM Structure DOM structure is correct w
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-cancel-on-esc-key=""
   opened=""
@@ -107,7 +106,6 @@ snapshots["datetime-picker/DOMStructure DOM Structure DOM structure is correct w
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-cancel-on-esc-key=""
   opened=""
@@ -167,7 +165,6 @@ snapshots["datetime-picker/DOMStructure DOM Structure DOM structure is correct w
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-cancel-on-esc-key=""
   opened=""
@@ -245,7 +242,6 @@ snapshots["datetime-picker/DOMStructure DOM Structure DOM structure is correct w
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-cancel-on-esc-key=""
   opened=""
@@ -324,7 +320,6 @@ snapshots["datetime-picker/DOMStructure DOM Structure DOM structure is correct w
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-cancel-on-esc-key=""
   opened=""
@@ -392,7 +387,6 @@ snapshots["datetime-picker/DOMStructure DOM Structure DOM structure is correct w
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   no-autofocus=""
   no-cancel-on-esc-key=""
   opened=""

--- a/packages/elements/src/overlay/elements/overlay.ts
+++ b/packages/elements/src/overlay/elements/overlay.ts
@@ -138,11 +138,6 @@ export class Overlay extends ResponsiveElement {
         display: none !important;
       }
 
-      :host(:not([first-resize-done])) {
-        pointer-events: none !important; /* needs for Mobile to prevent tap while overlay is not yet on the screen */
-        opacity: 0;
-      }
-
       :host(:not([animation-ready])) {
         animation: none  !important;
         transition: none !important;
@@ -653,23 +648,6 @@ export class Overlay extends ResponsiveElement {
     toggleAttribute(this, 'animation-position', animationPosition);
   }
 
-  private _firstResizeDone = false;
-  /**
-   * Used to set attribute after the initial callback has been fired
-   * A function is here to sort IE11 flickering problem
-   * @param firstResizeDone True if the initial resize has happened
-   */
-  private set firstResizeDone (firstResizeDone: boolean) {
-    if (this._firstResizeDone !== firstResizeDone) {
-      this._firstResizeDone = firstResizeDone;
-      /* Toggling the attribute first-resize-done on the element. */
-      toggleAttribute(this, 'first-resize-done', firstResizeDone);
-    }
-  }
-  private get firstResizeDone (): boolean {
-    return this._firstResizeDone;
-  }
-
   /**
    * Used internally to keep calculated positions
    */
@@ -885,7 +863,6 @@ export class Overlay extends ResponsiveElement {
    * @returns {void}
    */
   private onFullyClosed (): void {
-    this.firstResizeDone = false;
     applyLock();
     this.resetSizingInfo();
     this.clearCached();
@@ -1642,8 +1619,7 @@ export class Overlay extends ResponsiveElement {
       this.setResizeSizingInfo();
       this.fitNonThrottled();
 
-      if (this.opened && this.firstResizeDone === false) {
-        this.firstResizeDone = true;
+      if (this.opened) {
         if (this._fullyOpened === OpenedState.CLOSED) { /* cannot set to opening if the overlay has not been fully closed */
           this._fullyOpened = OpenedState.OPENING;
         }

--- a/packages/elements/src/select/__test__/__snapshots__/select.selected.test.snap.js
+++ b/packages/elements/src/select/__test__/__snapshots__/select.selected.test.snap.js
@@ -19,7 +19,6 @@ snapshots["select/Selection Selection by Selected Property Options Selected: Afg
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   focused=""
   id="menu"
   lock-position-target=""
@@ -53,7 +52,6 @@ snapshots["select/Selection Selection by Selected Property Data Selected: Afghan
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   focused=""
   id="menu"
   lock-position-target=""
@@ -124,7 +122,6 @@ snapshots["select/Selection Selection by Selected Property Data Selected change"
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   focused=""
   id="menu"
   lock-position-target=""
@@ -195,7 +192,6 @@ snapshots["select/Selection Selection by Selected Property Data Unselected"] =
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   focused=""
   id="menu"
   lock-position-target=""

--- a/packages/elements/src/select/__test__/__snapshots__/select.template.test.snap.js
+++ b/packages/elements/src/select/__test__/__snapshots__/select.template.test.snap.js
@@ -82,7 +82,6 @@ snapshots["select/Template Template Parts Lazy Render: options opened"] =
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   focused=""
   id="menu"
   lock-position-target=""
@@ -136,7 +135,6 @@ snapshots["select/Template Template Parts Lazy Render: data opened"] =
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   focused=""
   id="menu"
   lock-position-target=""
@@ -204,7 +202,6 @@ snapshots["select/Template Template Parts Data is reflected to render"] =
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   focused=""
   id="menu"
   lock-position-target=""

--- a/packages/elements/src/select/__test__/__snapshots__/select.value.test.snap.js
+++ b/packages/elements/src/select/__test__/__snapshots__/select.value.test.snap.js
@@ -19,7 +19,6 @@ snapshots["select/Value Selection by Value Attribute Options Selected: Afghanist
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   focused=""
   id="menu"
   lock-position-target=""
@@ -53,7 +52,6 @@ snapshots["select/Value Selection by Value Attribute Data Selected: Afghanistan"
 <ef-overlay-viewport>
 </ef-overlay-viewport>
 <ef-overlay
-  first-resize-done=""
   focused=""
   id="menu"
   lock-position-target=""


### PR DESCRIPTION
## Description
Remove first-resize-done attr hack for IE11 flickering problem.