### PR TITLE
feat(theme-compiler): support Browserslist config

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,6 @@
+# Browsers that we support
+
+last 3 versions
+> 0.5%
+Firefox ESR
+not dead # no browsers without security updates

--- a/package-lock.json
+++ b/package-lock.json
@@ -4262,6 +4262,8 @@
     },
     "node_modules/browserslist": {
       "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "funding": [
         {
           "type": "opencollective",
@@ -4272,7 +4274,6 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "caniuse-lite": "^1.0.30001449",
         "electron-to-chromium": "^1.4.284",
@@ -15167,6 +15168,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "autoprefixer": "^10.4.2",
+        "browserslist": "^4.21.5",
         "chalk": "^4.1.1",
         "clean-css": "^4.2.1",
         "css-select": "^5.1.0",
@@ -17188,6 +17190,7 @@
       "version": "file:packages/theme-compiler",
       "requires": {
         "autoprefixer": "^10.4.2",
+        "browserslist": "*",
         "chalk": "^4.1.1",
         "clean-css": "^4.2.1",
         "css-select": "^5.1.0",
@@ -18404,6 +18407,8 @@
     },
     "browserslist": {
       "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "requires": {
         "caniuse-lite": "^1.0.30001449",
         "electron-to-chromium": "^1.4.284",

--- a/packages/theme-compiler/README.md
+++ b/packages/theme-compiler/README.md
@@ -47,3 +47,7 @@ Example:
 ```
 
 Then you can run `npm run watch`.
+
+## Browsers
+
+Theme Compiler uses the [Browserslist](https://github.com/browserslist/browserslist) to Autoprefixing CSS, you can create `.browserslistrc` in your project to specify the target browsers. See [Browserlist](https://github.com/browserslist/browserslist) for more information.

--- a/packages/theme-compiler/package.json
+++ b/packages/theme-compiler/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "autoprefixer": "^10.4.2",
+    "browserslist": "^4.21.5",
     "chalk": "^4.1.1",
     "clean-css": "^4.2.1",
     "css-select": "^5.1.0",


### PR DESCRIPTION
## Description

Add Theme Compiler to support Browserslist config for adding Autoprefixing CSS on supported browsers

## Type of change

- [x] feat(theme-compiler): support Browserslist config

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
