### PR TITLE
fix(card): Card can not expand nested overlay-menu in touch devices

### DIFF
--- a/packages/elements/src/card/__test__/card.test.js
+++ b/packages/elements/src/card/__test__/card.test.js
@@ -10,7 +10,7 @@ import '@formatjs/intl-pluralrules/locale-data/en';
 import '@refinitiv-ui/elements/card';
 import '@refinitiv-ui/elemental-theme/light/ef-card';
 
-const menuData = [{ label: 'Spain', value: 'Spain'  }, { label: 'France',value: 'France', disabled: true }, { label: 'Italy', value: 'Italy' }];
+const menuData = [{ label: 'Spain', value: 'Spain'  }, { label: 'France',value: 'France', disabled: true }, { label: 'Italy', value: 'Italy' }, { label: 'Other', items: [{ label: 'Thailand', value: 'Thailand' }] }];
 
 describe('card/Card', () => {
   describe('DOM structure', () => {
@@ -81,6 +81,36 @@ describe('card/Card', () => {
 
       await oneEvent(el, 'item-trigger');
       expect(menu.opened).to.equal(false, 'Menu should close when item is selected');
+    });
+    it('Should open menu and not close when clicked on non value item', async () => {
+      const el = await fixture('<ef-card lang="en-gb">Card</ef-card>');
+      el.config = {
+        menu: {
+          data: menuData
+        }
+      };
+      await elementUpdated(el);
+
+      const openMenu = el.openMenuElement;
+      const menu = el.menuElement;
+
+      expect(openMenu, 'Open menu button element does not exist').to.exist;
+      expect(menu, 'Menu element does not exist').to.exist;
+
+      openMenu.click();
+
+      await elementUpdated(el);
+      expect(menu.opened).to.equal(true, 'Menu should open on button click');
+
+      const item = menu.shadowRoot.querySelectorAll('ef-item')[3];
+      
+      expect(item, 'Menu config is not passed correctly').to.exist;
+
+      setTimeout(() => {
+        item.click();
+      });
+      await oneEvent(el, 'item-trigger');
+      expect(menu.opened).to.equal(true, 'Menu should still open');
     });
   });
 

--- a/packages/elements/src/card/__test__/card.test.js
+++ b/packages/elements/src/card/__test__/card.test.js
@@ -82,7 +82,7 @@ describe('card/Card', () => {
       await oneEvent(el, 'item-trigger');
       expect(menu.opened).to.equal(false, 'Menu should close when item is selected');
     });
-    it('Should open menu and not close when clicked on non value item', async () => {
+    it('Should open menu and not close when clicked on non value item', async function () {
       const el = await fixture('<ef-card lang="en-gb">Card</ef-card>');
       el.config = {
         menu: {

--- a/packages/elements/src/card/index.ts
+++ b/packages/elements/src/card/index.ts
@@ -155,7 +155,7 @@ export class Card extends BasicElement {
 
   /**
    * Close menu
-   * @param event Custom event
+   * @param event ItemTriggerEvent
    * @returns {void}
    */
   private closeMenu (event: ItemTriggerEvent): void {

--- a/packages/elements/src/card/index.ts
+++ b/packages/elements/src/card/index.ts
@@ -15,7 +15,7 @@ import { isSlotEmpty } from '@refinitiv-ui/utils/is-slot-empty.js';
 import type { Button } from '../button';
 import type { OverlayMenu, OverlayMenuData } from '../overlay-menu';
 import type { CardConfig } from './helpers/types';
-import type { OpenedChangedEvent } from '../events';
+import type { OpenedChangedEvent, ItemTriggerEvent } from '../events';
 import '../label/index.js';
 import '../button/index.js';
 import '../overlay-menu/index.js';
@@ -155,10 +155,11 @@ export class Card extends BasicElement {
 
   /**
    * Close menu
+   * @param event Custom event
    * @returns {void}
    */
-  private closeMenu (): void {
-    if (this.menuElement?.opened) {
+  private closeMenu (event: ItemTriggerEvent): void {
+    if (this.menuElement?.opened && event.detail.value) {
       this.menuElement.opened = false;
       this.menuOpened = false;
     }
@@ -225,8 +226,7 @@ export class Card extends BasicElement {
    */
   protected firstUpdated (changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
-
-    this.addEventListener('item-trigger', this.closeMenu); // Here to cover nested menus
+    this.addEventListener('item-trigger', (event) => this.closeMenu(event as ItemTriggerEvent)); // Here to cover nested menus
   }
 
   /**

--- a/packages/elements/src/overlay-menu/index.ts
+++ b/packages/elements/src/overlay-menu/index.ts
@@ -1029,7 +1029,7 @@ export class OverlayMenu extends Overlay {
       .label=${label}
       .subLabel=${subLabel}
       .icon=${icon}
-      .value=${ifDefined(value)}
+      value=${ifDefined(value || undefined)}
       .for=${ifDefined(forMenu || undefined)}>
     </ef-item>`;
   }

--- a/packages/elements/src/overlay-menu/index.ts
+++ b/packages/elements/src/overlay-menu/index.ts
@@ -1029,7 +1029,7 @@ export class OverlayMenu extends Overlay {
       .label=${label}
       .subLabel=${subLabel}
       .icon=${icon}
-      value=${ifDefined(value || undefined)}
+      .value=${ifDefined(value || undefined)}
       .for=${ifDefined(forMenu || undefined)}>
     </ef-item>`;
   }

--- a/packages/elements/src/overlay-menu/index.ts
+++ b/packages/elements/src/overlay-menu/index.ts
@@ -1029,7 +1029,7 @@ export class OverlayMenu extends Overlay {
       .label=${label}
       .subLabel=${subLabel}
       .icon=${icon}
-      .value=${value}
+      .value=${ifDefined(value)}
       .for=${ifDefined(forMenu || undefined)}>
     </ef-item>`;
   }


### PR DESCRIPTION
## Description
Card can't expand nested overlay-menu in touch devices.
In mouse devices it work fine when hover the parent item to expand sub items.
But not for touch devices, it should tap the parent item to expand the sub items.

Root cause:
- Card always close the overlay-menu when trigger item

Solution: 
- Add condition to close the overlay-menu only when trigger an item with value (That mean parent item shouldn't have a value)

Fixes # (issue)
https://jira.refinitiv.com/browse/STG-241

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
