### PR TITLE
docs(chart): update demo page to chartjs v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6417,6 +6417,15 @@
         "pnpm": "^7.0.0"
       }
     },
+    "node_modules/chartjs-adapter-date-fns": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz",
+      "integrity": "sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==",
+      "peerDependencies": {
+        "chart.js": ">=2.8.0",
+        "date-fns": ">=2.0.0"
+      }
+    },
     "node_modules/check-error": {
       "version": "1.0.2",
       "dev": true,
@@ -18122,8 +18131,9 @@
         "@refinitiv-ui/halo-theme": "^7.0.0-next.0",
         "@refinitiv-ui/solar-theme": "^7.0.0-next.0",
         "chart.js": "^4.2.1",
+        "chartjs-adapter-date-fns": "^3.0.0",
         "d3-interpolate": "^3.0.1",
-        "date-fns": "^2.22.1",
+        "date-fns": "^2.29.3",
         "lightweight-charts": "^3.8.0",
         "tslib": "^2.3.1"
       },
@@ -21623,8 +21633,9 @@
         "@refinitiv-ui/utils": "^7.0.0-next.0",
         "@types/d3-interpolate": "^3.0.1",
         "chart.js": "^4.2.1",
+        "chartjs-adapter-date-fns": "^3.0.0",
         "d3-interpolate": "^3.0.1",
-        "date-fns": "^2.22.1",
+        "date-fns": "^2.29.3",
         "lightweight-charts": "^3.8.0",
         "tslib": "^2.3.1"
       }
@@ -23561,6 +23572,12 @@
       "requires": {
         "@kurkle/color": "^0.3.0"
       }
+    },
+    "chartjs-adapter-date-fns": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz",
+      "integrity": "sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==",
+      "requires": {}
     },
     "check-error": {
       "version": "1.0.2",
@@ -28708,7 +28725,7 @@
       }
     },
     "pandora-book": {
-      "version": "file:tools/pandora-book-3.0.0-68.tgz",
+      "version": "file:tools\\pandora-book-3.0.0-68.tgz",
       "integrity": "sha512-Kl2TMMiIpW/sbGc/z2MyYa5K36OLJspIexoTD+Bn9yepqCM7lBH4IT4p4q038zYOqNG1fGLwKpCpQTAYZsiWGw==",
       "dev": true,
       "requires": {

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -340,8 +340,9 @@
     "@refinitiv-ui/halo-theme": "^7.0.0-next.0",
     "@refinitiv-ui/solar-theme": "^7.0.0-next.0",
     "chart.js": "^4.2.1",
+    "chartjs-adapter-date-fns": "^3.0.0",
     "d3-interpolate": "^3.0.1",
-    "date-fns": "^2.22.1",
+    "date-fns": "^2.29.3",
     "lightweight-charts": "^3.8.0",
     "tslib": "^2.3.1"
   },

--- a/packages/elements/src/chart/__demo__/index.html
+++ b/packages/elements/src/chart/__demo__/index.html
@@ -255,7 +255,7 @@
                 title: (tooltipItems) => {
                   return tooltipItems[0].chart.data.datasets[tooltipItems[0].datasetIndex].label;
                 },
-                label: function (tooltipItem) {
+                label: (tooltipItem) => {
                   const year = tooltipItem.label;
                   let rev = tooltipItem.raw;
                   rev = rev.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
@@ -381,10 +381,10 @@
   <demo-block layout="normal" header="Pie Chart">
     <ef-chart id="pie"></ef-chart>
     <script>
-      var pieDatasets = [{
-        data: [36, 22, 16, 8.2, 5.7, 12]
+      const pieDatasets = [{
+        data: [100, 22, 16, 8.2, 5.7, 12]
       }];
-      var pie = document.getElementById('pie');
+      const pie = document.getElementById('pie');
       pie.config = {
         type: 'pie',
         data: {
@@ -398,6 +398,7 @@
             },
             tooltip: {
               callbacks: {
+                title: () => null,
                 label: (tooltipItem) => {
                   const title = tooltipItem.label;
                   const result = tooltipItem.raw;
@@ -411,13 +412,13 @@
     </script>
   </demo-block>
 
-  <!-- <demo-block layout="normal" header="Doughnut Chart">
+  <demo-block layout="normal" header="Doughnut Chart">
     <ef-chart id="doughnut"></ef-chart>
     <script>
-      var doughnutDataSets = [{
+      const doughnutDataSets = [{
         data: [36, 22, 16, 8.2, 5.7, 12]
       }];
-      var doughnut = document.getElementById('doughnut');
+      const doughnut = document.getElementById('doughnut');
       doughnut.config = {
         type: 'doughnut',
         data: {
@@ -425,15 +426,18 @@
           datasets: doughnutDataSets
         },
         options: {
-          title: {
-            text: 'Operating Segments of AAPL.O in 2014'
-          },
-          tooltips: {
-            callbacks: {
-              label: function (tooltipItem, data) {
-                var title = data.labels[tooltipItem.index];
-                var result = data.datasets[0].data[tooltipItem.index];
-                return title + ': ' + result + '%';
+          plugins: {
+            title: {
+              text: 'Operating Segments of AAPL.O in 2014'
+            },
+            tooltip: {
+              callbacks: {
+                title: () => null,
+                label: (tooltipItem) => {
+                  const title = tooltipItem.label;
+                  const result = tooltipItem.raw;
+                  return title + ': ' + result + '%';
+                }
               }
             }
           }
@@ -445,24 +449,30 @@
   <demo-block layout="normal" header="Donut Chart - Center Label">
     <ef-chart id="doughnut-center-label"></ef-chart>
     <script>
-      var doughnutDataSets = [{
+      const doughnutCenterLabelDataSets = [{
         data: [36, 22, 16, 8.2, 5.7, 12]
       }];
-      var doughnut = document.getElementById('doughnut-center-label');
-      doughnut.config = {
+      const doughnutCenterLabel = document.getElementById('doughnut-center-label');
+      doughnutCenterLabel.config = {
         type: 'doughnut',
         data: {
           labels: ['Americas', 'Europe', 'Greater China', 'Japan', 'Asia Pacific', 'Retail'],
-          datasets: doughnutDataSets
+          datasets: doughnutCenterLabelDataSets
         },
         options: {
-          onHover: function (chart, chartItem) {
-            console.log('hover: ', chartItem); // eslint-disable-line
+          onHover: (event, elements, chart) => {
+            console.log('hover: ', event, elements, chart); // eslint-disable-line
           },
-          onClick: function (chart, chartItem) {
-            console.log('click: ', chartItem); // eslint-disable-line
+          onClick: (event, elements, chart) => {
+            console.log('click: ', event, elements, chart); // eslint-disable-line
           },
           plugins: {
+            title: {
+              text: 'Operating Segments of AAPL.O in 2014'
+            },
+            tooltip: {
+              enabled: true
+            },
             centerLabel: {
               defaultText: [
                 {
@@ -477,9 +487,9 @@
                 if (chartItems.length) {
                   const chartItem = chartItems[0];
                   const data = chart.data;
-                  const title = data.labels[chartItem._index];
-                  const value = data.datasets[chartItem._datasetIndex].data[chartItem._index];
-                  const total = data.datasets[chartItem._datasetIndex].data.reduce((total, num) => total + num);
+                  const title = data.labels[chartItem.index];
+                  const value = data.datasets[chartItem.datasetIndex].data[chartItem.index];
+                  const total = data.datasets[chartItem.datasetIndex].data.reduce((total, num) => total + num);
                   const percent = parseFloat(parseFloat(value) / parseFloat(total)).toFixed(2);
 
                   return [{
@@ -494,12 +504,6 @@
                 }
               }
             }
-          },
-          title: {
-            text: 'Operating Segments of AAPL.O in 2014'
-          },
-          tooltips: {
-            enabled: true
           }
         }
       };
@@ -510,7 +514,7 @@
   <demo-block layout="normal" header="Donut Chart - Center Label - Multiple Dataset">
     <ef-chart id="doughnut-multiple-dataset"></ef-chart>
     <script>
-      var doughnutDataSets = [
+      const doughnutCenterLabelMultiDataSets = [
         {
           label: '2020',
           data: [36, 22, 16, 8.2, 5.7, 12]
@@ -524,16 +528,22 @@
           data: [12, 5.7, 8.2, 16, 22, 36]
         }
       ];
-      var doughnut = document.getElementById('doughnut-multiple-dataset');
-      doughnut.config = {
+      const doughnutCenterLabelMulti = document.getElementById('doughnut-multiple-dataset');
+      doughnutCenterLabelMulti.config = {
         type: 'doughnut',
         data: {
           labels: ['Americas', 'Europe', 'Greater China', 'Japan', 'Asia Pacific', 'Retail'],
-          datasets: doughnutDataSets
+          datasets: doughnutCenterLabelMultiDataSets
         },
         options: {
           hover: { animationDuration: 0 },
           plugins: {
+            title: {
+              text: 'Operating Segments of AAPL.O in 2020'
+            },
+            tooltip: {
+              enabled: true
+            },
             centerLabel: {
               defaultText: [
                 {
@@ -549,21 +559,21 @@
                 if (chartItems.length) {
                   const chartItem = chartItems[0];
                   const data = chart.data;
-                  const title = data.labels[chartItem._index];
-                  const value = data.datasets[chartItem._datasetIndex].data[chartItem._index];
-                  const total = data.datasets[chartItem._datasetIndex].data.reduce((total, num) => total + num);
+                  const title = data.labels[chartItem.index];
+                  const value = data.datasets[chartItem.datasetIndex].data[chartItem.index];
+                  const total = data.datasets[chartItem.datasetIndex].data.reduce((total, num) => total + num);
                   const percent = parseFloat(parseFloat(value) / parseFloat(total)).toFixed(2);
                   let labels = [{ label: title, bold: true }];
 
                   if (data.datasets.length > 1) {
-                    const datasetLebel = data.datasets[chartItem._datasetIndex].label;
+                    const datasetLebel = data.datasets[chartItem.datasetIndex].label;
                     if (datasetLebel) {
                       labels.push({ label: datasetLebel });
                     }
                   }
 
                   labels.push({
-                    label: value
+                    label: 'value: ' + value
                   }, {
                     label: percent + ' %'
                   });
@@ -572,12 +582,6 @@
                 }
               }
             }
-          },
-          title: {
-            text: 'Operating Segments of AAPL.O in 2020'
-          },
-          tooltips: {
-            enabled: true
           }
         }
       };
@@ -587,12 +591,12 @@
   <demo-block layout="normal" header="Pie Chart - Custom Colors">
     <ef-chart id="customize-color"></ef-chart>
     <script>
-      var doughnutCustomDataSets = [{
+      const doughnutCustomDataSets = [{
         data: [36, 30, 22, 16, 8.2, 5.7, 3.1, 2.4, 1.4, 0.9],
         backgroundColor: ['#0D47A1', '#1565C0', '#1976D2', '#1E88E5', '#2196F3', '#42A5F5', '#64B5F6', '#90CAF9', '#BBDEFB', '#E3F2FD'],
         borderWidth: 0
       }];
-      var doughnutCustom = document.getElementById('customize-color');
+      const doughnutCustom = document.getElementById('customize-color');
       doughnutCustom.config = {
         type: 'doughnut',
         data: {
@@ -600,15 +604,18 @@
           datasets: doughnutCustomDataSets
         },
         options: {
-          title: {
-            text: 'Operating Segments of AAPL.O in 2014'
-          },
-          tooltips: {
-            callbacks: {
-              label: function (tooltipItem, data) {
-                var title = data.labels[tooltipItem.index];
-                var result = data.datasets[0].data[tooltipItem.index];
-                return title + ': ' + result + '%';
+          plugins: {
+            title: {
+              text: 'Operating Segments of AAPL.O in 2014'
+            },
+            tooltip: {
+              callbacks: {
+                title: () => null,
+                label: (tooltipItem) => {
+                  const title = tooltipItem.label;
+                  const result = tooltipItem.raw;
+                  return title + ': ' + result + '%';
+                }
               }
             }
           }
@@ -620,7 +627,7 @@
   <demo-block layout="normal" header="Time Scale">
     <ef-chart id="timeScale"></ef-chart>
     <script>
-      var timeScale = document.getElementById('timeScale');
+      const timeScale = document.getElementById('timeScale');
       timeScale.config = {
         type: 'line',
         data: {
@@ -635,40 +642,42 @@
             new Date(2016, 8, 7, 17, 0, 0)
           ],
           datasets: [{
+            fill: true,
             label: 'Price',
             data: [107.53, 107.32, 107.35, 107.41, 107.56, 107.23, 108.37, 108.36]
           }]
         },
         options: {
-          title: {
-            text: 'Hourly Price of AAPL.O on 7 Sep 2016 (iPhone 7 release date)'
-          },
-          legend: {
-            display: false // Not display legend
+          plugins: {
+            title: {
+              text: 'Hourly Price of AAPL.O on 7 Sep 2016 (iPhone 7 release date)'
+            },
+            legend: {
+              display: false // Not display legend
+            },
+            tooltip: {
+              callbacks: {
+                label: (tooltipItem) => {
+                  return 'Price: $' + tooltipItem.raw;
+                }
+              }
+            }
           },
           scales: {
-            xAxes: [{
+            x: {
               type: 'time', // Set type of scale as time
               time: {
                 displayFormats: {
-                  hour: 'hA' // Set custom format for hour unit
+                  hour: 'haa' // Set custom format for hour unit
                 },
                 unit: 'hour',
-                tooltipFormat: 'D MMM YYYY - hA'
+                tooltipFormat: 'd MMM yyyy - haa'
               }
-            }],
-            yAxes: [{
-              scaleLabel: {
+            },
+            y: {
+              title: {
                 display: true,
-                labelString: 'Price ($)'
-              }
-            }]
-          },
-          tooltips: {
-            callbacks: {
-              label: function (tooltipItem, data) {
-                var result = data.datasets[0].data[tooltipItem.index];
-                return 'Price: $' + result;
+                text: 'Price ($)'
               }
             }
           }
@@ -680,8 +689,8 @@
   <demo-block layout="normal" header="Time Scale - Multi-line">
     <ef-chart id="multipleLinesTimeScale"></ef-chart>
     <script>
-      var multipleLinesTimeScale = document.getElementById('multipleLinesTimeScale');
-      var datasets = [{
+      const multipleLinesTimeScale = document.getElementById('multipleLinesTimeScale');
+      const TimeScaleDatasets = [{
         label: 'GOOGL.O',
         data: [0, 11, 66.68, -25.84, 49.44, 43.17, 55.69, 70.51, 170.14, 155.58, 274.71],
         fill: false,
@@ -734,49 +743,49 @@
             new Date(2014, 12, 31),
             new Date(2015, 12, 31)
           ],
-          datasets: datasets
+          datasets: TimeScaleDatasets
         },
         options: {
-          title: {
-            text: 'Yearly Price Change of Major Technology Companies'
+          plugins: {
+            title: {
+              text: 'Yearly Price Change of Major Technology Companies'
+            },
+            tooltip: {
+              callbacks: {
+                title: (tooltipItems) => {
+                  const item = tooltipItems[0];
+                  const year = item.label;
+                  const label = item.dataset.label;
+                  return year + ' - ' + label;
+                },
+                label: (tooltipItem) => {
+                  return 'Change: ' + tooltipItem.raw + '%';
+                }
+              }
+            }
           },
           scales: {
-            xAxes: [{
+            x: {
               type: 'time',
               time: {
                 displayFormats: {
-                  year: '\'YY' // Set custom format for hour unit
+                  year: 'yy' // Set custom format for hour unit
                 },
                 unit: 'year',
                 round: 'year', // Set round as year for starting of this unit
-                tooltipFormat: 'YYYY'
+                tooltipFormat: 'yyyy'
               }
-            }],
-            yAxes: [{
-              scaleLabel: {
+            },
+            y: {
+              title: {
                 display: true,
-                labelString: 'Price Changes'
+                text: 'Price Changes'
               },
               ticks: {
                 stepSize: 50,
-                callback: function (label, index) {
+                callback: (label, index) => {
                   return label + '%';
                 }
-              }
-            }]
-          },
-          tooltips: {
-            callbacks: {
-              title: function (tooltipItem, data) {
-                var item = tooltipItem[0];
-                var year = item.xLabel;
-                var datasets = data.datasets[item.datasetIndex];
-                var label = datasets.label;
-                return year + ' - ' + label;
-              },
-              label: function (tooltipItem, data) {
-                var result = data.datasets[0].data[tooltipItem.index];
-                return 'Change: ' + result + '%';
               }
             }
           }
@@ -788,8 +797,8 @@
   <demo-block layout="normal" header="Scatter Plot">
     <ef-chart id="scatterplot"></ef-chart>
     <script>
-      var scatterplot = document.getElementById('scatterplot');
-      scatterplot.config = {
+      const scatterPlot = document.getElementById('scatterplot');
+      scatterPlot.config = {
         type: 'line',
         data: {
           datasets: [
@@ -822,50 +831,44 @@
                 { x: 47.98, y: 64.75 },
                 { x: 47.64, y: 64.74 }
               ],
-              pointRadius: 1
+              pointRadius: 1,
+              showLine: false
             }
           ]
         },
         options: {
-          showLines: false,
-          legend: {
-            display: false // not display legend
-          },
-          title: {
-            text: 'Price of Oil vs Russian Ruble'
+          plugins: {
+            legend: {
+              display: false // not display legend
+            },
+            title: {
+              text: 'Price of Oil vs Russian Ruble'
+            },
+            tooltip: {
+              callbacks: {
+                title: () => null,
+                label: (tooltipItem) => {
+                  return 'Oil\'s price : ' + tooltipItem.raw.x + ' $';
+                },
+                afterLabel: (tooltipItem) => {
+                  return 'Ruble : ' + tooltipItem.raw.y;
+                }
+              }
+            }
           },
           scales: {
-            xAxes: [
-              {
-                type: 'linear',
-                position: 'bottom',
-                scaleLabel: {
-                  display: true,
-                  labelString: 'Price of Oil ($)'
-                }
+            x: {
+              type: 'linear',
+              position: 'bottom',
+              title: {
+                display: true,
+                text: 'Price of Oil ($)'
               }
-            ],
-            yAxes: [
-              {
-                scaleLabel: {
-                  display: true,
-                  labelString: 'Russian ruble (per $)'
-                }
-              }
-            ]
-          },
-          tooltips: {
-            callbacks: {
-              title: function () {
-                return '';
-              },
-              label: function (tooltipItem, data) {
-                var x = tooltipItem.xLabel;
-                return 'Oil\'s price : ' + x + ' $';
-              },
-              afterLabel: function (tooltipItem, data) {
-                var y = tooltipItem.yLabel;
-                return 'Ruble : ' + y;
+            },
+            y: {
+              title: {
+                display: true,
+                text: 'Russian ruble (per $)'
               }
             }
           }
@@ -877,8 +880,7 @@
   <demo-block layout="normal" header="Bubble Chart">
     <ef-chart id="bubble"></ef-chart>
     <script>
-      var bubble = document.getElementById('bubble');
-
+      const bubble = document.getElementById('bubble');
       bubble.config = {
         type: 'bubble',
         data: {
@@ -914,57 +916,52 @@
           ]
         },
         options: {
-          title: {
-            text: 'GDP vs. Life Expectancy (Size = Popuation)'
-          },
           scales: {
-            xAxes: [
-              {
-                type: 'logarithmic',
-                position: 'bottom',
-                ticks: {
-                  min: 450,
-                  max: 50000,
-                  maxRotation: 10,
-                  callback: function (label, index) {
-                    var xLabels = ['500', '1000', '2000', '5000', '10,000', '20000', '50000'];
-                    return xLabels.indexOf(label.toString()) > -1 ? label : '';
-                  }
-                },
-                scaleLabel: {
-                  display: true,
-                  labelString: 'GDP per person in US dollars (log scale)'
+            x: {
+              type: 'logarithmic',
+              position: 'bottom',
+              min: 450,
+              max: 50000,
+              ticks: {
+                maxRotation: 10,
+                callback: (label, index) => {
+                  const xLabels = ['500', '1000', '2000', '5000', '10,000', '20000', '50000'];
+                  return xLabels.indexOf(label.toString()) > -1 ? label : '';
                 }
+              },
+              title: {
+                display: true,
+                text: 'GDP per person in US dollars (log scale)'
               }
-            ],
-            yAxes: [
-              {
-                ticks: {
-                  min: 45,
-                  max: 85,
-                  stepSize: 5
-                },
-                scaleLabel: {
-                  display: true,
-                  labelString: 'Life expectancy at birth (years)'
-                }
+            },
+            y: {
+              min: 45,
+              max: 85,
+              ticks: {
+                stepSize: 5
+              },
+              title: {
+                display: true,
+                text: 'Life expectancy at birth (years)'
               }
-            ]
+            }
           },
-          tooltips: {
-            callbacks: {
-              title: function (tooltipItem, data) {
-                var item = tooltipItem[0];
-                var dataset = data.datasets[item.datasetIndex];
-                return dataset.label;
-              },
-              label: function (tooltipItem, data) {
-                var x = tooltipItem.xLabel;
-                return 'GDP per Capita : ' + x + '$';
-              },
-              afterLabel: function (tooltipItem, data) {
-                var y = tooltipItem.yLabel;
-                return 'Life expectancy : ' + y + ' Yrs';
+          plugins: {
+            title: {
+              text: 'GDP vs. Life Expectancy (Size = Popuation)'
+            },
+            tooltip: {
+              callbacks: {
+                title: (tooltipItems) => {
+                  const item = tooltipItems[0];
+                  return item.dataset.label;
+                },
+                label: (tooltipItem) => {
+                  return 'GDP per Capita : ' + tooltipItem.raw.x + '$';
+                },
+                afterLabel: (tooltipItem) => {
+                  return 'Life expectancy : ' + tooltipItem.raw.y + ' Yrs';
+                }
               }
             }
           }
@@ -976,44 +973,29 @@
   <demo-block layout="normal" header="Radar Chart">
     <ef-chart id="radar"></ef-chart>
     <script>
-      var radar = document.getElementById('radar');
-
+      const radar = document.getElementById('radar');
       radar.config = {
         type: 'radar',
         data: {
           labels: [['Eating', 'Dinner'], ['Drinking', 'Water'], 'Sleeping', ['Designing', 'Graphics'], 'Coding', 'Cycling', 'Running'],
           datasets: [{
             label: 'Humanoid A',
-            data: [
-              13,
-              10,
-              9,
-              14,
-              9,
-              5,
-              10
-            ]
+            data: [13, 10, 9, 14, 9, 5, 10]
           },
           {
             label: 'Humanoid B',
-            data: [
-              8,
-              5,
-              9,
-              7,
-              17,
-              11,
-              4
-            ]
+            data: [8, 5, 9, 7, 17, 11, 4]
           }]
         },
         options: {
-          legend: {
-            position: 'right'
-          },
-          title: {
-            display: true,
-            text: 'Humanoid Profile Comparison'
+          plugins: {
+            legend: {
+              position: 'right'
+            },
+            title: {
+              display: true,
+              text: 'Humanoid Profile Comparison'
+            }
           }
         }
       };
@@ -1022,11 +1004,11 @@
 
   <demo-block layout="normal" header="Toggle Chart Type">
     <ef-chart id="avgVolumeRicChart"></ef-chart>
-    <button onClick="showBar()">BAR</button>
-    <button onClick="showDoughnut()">PIE</button>
+    <button id="showBar">BAR</button>
+    <button id="showDoughnut">PIE</button>
     <script>
-      const barConfig = {
-        type: 'horizontalBar',
+      const horizontalBarConfig = {
+        type: 'bar',
         data: {
           labels: ['Data1', 'Data2', 'Data3'],
           datasets: [
@@ -1036,18 +1018,19 @@
           ]
         },
         options: {
-          title: {
-            text: 'Volume by stock, Top stocks by volume Today'
-          },
-          legend: {
-            display: false
+          indexAxis: 'y',
+          plugins: {
+            title: {
+              text: 'Volume by stock, Top stocks by volume Today'
+            },
+            legend: {
+              display: false
+            }
           },
           scales: {
-            xAxes: [{
-              ticks: {
-                beginAtZero: true
-              }
-            }]
+            x: {
+              beginAtZero: true
+            }
           }
         }
       };
@@ -1069,28 +1052,32 @@
             animateRotate: true,
             animateScale: true
           },
-          title: {
-            text: 'Volume by stock, Top stocks by volume Today'
-          },
-          legend: {
-            display: true
+          plugins: {
+            title: {
+              text: 'Volume by stock, Top stocks by volume Today'
+            },
+            legend: {
+              display: true
+            }
           }
         }
       };
 
-      /* eslint-disable no-unused-vars */
-      let avgRicChart = document.getElementById('avgVolumeRicChart');
-      avgRicChart.config = barConfig;
+      const avgRicChart = document.getElementById('avgVolumeRicChart');
+      const showBarButton = document.getElementById('showBar');
+      const showDoughnutButton = document.getElementById('showDoughnut');
 
-      let showBar = () => {
-        updateChart(barConfig);
-      };
+      avgRicChart.config = horizontalBarConfig;
 
-      let showDoughnut = () => {
+      showBarButton.addEventListener('tap', () => {
+        updateChart(horizontalBarConfig);
+      });
+      showDoughnutButton.addEventListener('tap', () => {
         updateChart(doughnutConfig);
-      };
+      });
 
-      let updateChart = (config) => {
+      /* eslint-disable no-unused-vars */
+      const updateChart = (config) => {
         avgRicChart.config = config;
         avgRicChart.updateChart();
       };
@@ -1100,7 +1087,7 @@
 
   <demo-block layout="normal" header="Add New Data">
     <ef-chart id="addNewDataSet"></ef-chart>
-    <button onclick="addData()">Add data</button>
+    <button id="addData">Add data</button>
     <script>
       const initConfig = {
         type: 'doughnut',
@@ -1116,25 +1103,24 @@
         }
       };
 
-      /* eslint-disable no-unused-vars */
-      let addData = () => {
+      const addDataButton = document.getElementById('addNewDataSet');
+      addDataButton.addEventListener('tap', () => {
         addDataChart.config.data.datasets[0].data.push(400);
         addDataChart.config.data.labels.push('New Data');
         addDataChart.updateChart();
-      };
+      });
 
-      let addDataChart = document.getElementById('addNewDataSet');
+      const addDataChart = document.getElementById('addNewDataSet');
       addDataChart.config = initConfig;
-      /* eslint-enable no-unused-vars */
     </script>
   </demo-block>
--->
+
   <demo-block layout="normal" header="Polar area">
     <ef-chart id="polarArea"></ef-chart>
     <script>
       const polarArea = document.getElementById('polarArea');
       const data = {
-        labels: [ 'Red', 'Green', 'Yellow', 'Grey', 'Blue'],
+        labels: ['Red', 'Green', 'Yellow', 'Grey', 'Blue'],
         datasets: [{
           label: 'My First Dataset',
           data: [11, 16, 7, 3, 14],
@@ -1146,7 +1132,7 @@
       polarArea.config = {
         type: 'polarArea',
         data
-      }
+      };
     </script>
   </demo-block>
 

--- a/packages/elements/src/chart/index.ts
+++ b/packages/elements/src/chart/index.ts
@@ -36,6 +36,8 @@ import type { ChartConfiguration, ChartOptions, UpdateMode, LegendItem } from 'c
 import type { Header } from '../header';
 import '../header/index.js';
 
+import 'chartjs-adapter-date-fns';
+
 // TODO: import only common types and let user registers specific type
 export * from 'chart.js';
 

--- a/packages/elements/src/chart/index.ts
+++ b/packages/elements/src/chart/index.ts
@@ -191,7 +191,7 @@ export class Chart extends BasicElement {
       id: 'ef-chart',
       beforeInit: (chart: ChartJS) => {
         const option: ChartOptions = this.themableChartOption;
-        merge(chart.config.options as unknown as MergeObject, option, true);
+        merge(chart.config.options as unknown as MergeObject, option);
       },
       beforeUpdate: this.decorateColors
     };
@@ -339,12 +339,12 @@ export class Chart extends BasicElement {
         case 'bubble':
           colors = this.generateColors(!isMultipleDatasets, !isMultipleDatasets && dataset.data ? dataset.data.length : 1, datasetIndex);
           borderColor = colors.solid;
-          backgroundColor = colors.solid;
+          backgroundColor = this.config?.type === 'bubble' ? colors.opaque : colors.solid;
           if (!dataset.borderColor) {
-            dataset.borderColor = colors.solid;
+            dataset.borderColor = borderColor;
           }
           if (!dataset.backgroundColor) {
-            dataset.backgroundColor = colors.solid;
+            dataset.backgroundColor = backgroundColor;
           }
           // Add more colors if items aren't enough
           if (Array.isArray(dataset.borderColor) && Array.isArray(borderColor) && dataset.borderColor.length < borderColor.length) {
@@ -412,6 +412,7 @@ export class Chart extends BasicElement {
         case 'line':
         case 'radar':
         case 'scatter':
+        case 'bubble':
           legend.fillStyle = (datasets[i] as LineControllerDatasetOptions).borderColor as Color;
           break;
         // For other chart types

--- a/packages/elements/src/chart/index.ts
+++ b/packages/elements/src/chart/index.ts
@@ -259,6 +259,7 @@ export class Chart extends BasicElement {
     ChartJS.defaults.scale.grid.color = (line) => {
       return line.index === 0 ? this.getComputedVariable('--zero-line-color', 'transparent') : this.getComputedVariable('--grid-line-color', 'transparent');
     };
+    ChartJS.defaults.scales.radialLinear.ticks.showLabelBackdrop = false;
   }
 
   /**


### PR DESCRIPTION
## Description

Update demo page to compatible with chartjs v4.

Found that chartjs v4 requires [date adapter](https://github.com/chartjs/awesome#adapters) to support scale type time axes. Comparing on v2, it included with moment. So I pick [chartjs-adapter-date-fns](https://github.com/chartjs/chartjs-adapter-date-fns) dependency because we already have had date-fns.

Fixes # ([STG-200)](https://jira.refinitiv.com/browse/STG-200))

## Type of change

- [x] Refactor (improves code without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update
