### PR TITLE
feat(theme-compiler):  add less style generation for native elements

### DIFF
--- a/packages/theme-compiler/bin/theme-compiler.js
+++ b/packages/theme-compiler/bin/theme-compiler.js
@@ -17,9 +17,7 @@ const chalk = require('chalk');
 
   let stylesES5 = ''; // for all-elements bundle
   let nativeCSS = ''; // for native-elements css
-  // This css is generated as less as a workaround for a less parser bug described in https://github.com/less/less.js/pull/3700
-  // For Less 4.1.3, the PR has been merged but the fix is yet to be released.
-  let fullSemicolonCSS = ''; // for full semicolon native-elements less
+  let allSemicolonCSS = ''; // for native-elements less
 
   console.log(chalk.grey(`ELF Theme Compiler (${chalk.green(version)})\n`));
 
@@ -35,7 +33,7 @@ const chalk = require('chalk');
   await Promise.all(elementStyles.map(style => {
     if (style.name.indexOf('-') === -1) {
       nativeCSS += (style.css + '\n');
-      fullSemicolonCSS += (style.fullSemicolonCSS + '\n');
+      allSemicolonCSS += (style.allSemicolonCSS + '\n');
     }
     stylesES5 += style.injector + '\n';
     const filename = path.join(options.outdir, style.name + '.js');
@@ -54,10 +52,13 @@ const chalk = require('chalk');
   await fs.writeFile(cssFilename, nativeCSS);
 
   // Save native-elements less
+  // This less has 1 difference compared to its CSS version: a semicolon after last property
+  // This extra semicolon is a workaround for a less-parser bug described in https://github.com/less/less.js/pull/3700
+  // The PR has been merged but it's not released yet as of less 4.1.3.
   await fs.ensureDir(lessOutDir);
   const lessFilename = path.join(lessOutDir, 'native-elements.less');
   console.log(chalk.yellow('Output'), lessFilename);
-  await fs.writeFile(lessFilename, fullSemicolonCSS);
+  await fs.writeFile(lessFilename, allSemicolonCSS);
 
   // Generate combined import files
   let importStr;

--- a/packages/theme-compiler/bin/theme-compiler.js
+++ b/packages/theme-compiler/bin/theme-compiler.js
@@ -11,11 +11,15 @@ const chalk = require('chalk');
 
   const options = require('../src/cli-options');
   const cssOutDir = path.join(options.outdir, 'css');
+  const lessOutDir = path.join(options.outdir, 'less');
   const importsOutDir = path.join(options.outdir, 'imports');
   const compiledOutDir = path.join(options.outdir, 'es5');
 
   let stylesES5 = ''; // for all-elements bundle
-  let nativeCss = ''; // for native-elements css
+  let nativeCSS = ''; // for native-elements css
+  // This css is generated as less as a workaround for a less parser bug described in https://github.com/less/less.js/pull/3700
+  // For Less 4.1.3, the PR has been merged but the fix is yet to be released.
+  let fullSemicolonCSS = ''; // for full semicolon native-elements less
 
   console.log(chalk.grey(`ELF Theme Compiler (${chalk.green(version)})\n`));
 
@@ -30,7 +34,8 @@ const chalk = require('chalk');
   await fs.ensureDir(options.outdir);
   await Promise.all(elementStyles.map(style => {
     if (style.name.indexOf('-') === -1) {
-      nativeCss += (style.css + '\n');
+      nativeCSS += (style.css + '\n');
+      fullSemicolonCSS += (style.fullSemicolonCSS + '\n');
     }
     stylesES5 += style.injector + '\n';
     const filename = path.join(options.outdir, style.name + '.js');
@@ -42,11 +47,17 @@ const chalk = require('chalk');
   await fs.ensureDir(compiledOutDir);
   await fs.writeFile(path.join(compiledOutDir, 'all-elements.js'), stylesES5);
 
-  // Save native CSS
+  // Save native-elements CSS
   await fs.ensureDir(cssOutDir);
   const cssFilename = path.join(cssOutDir, 'native-elements.css');
   console.log(chalk.yellow('Output'), cssFilename);
-  await fs.writeFile(cssFilename, nativeCss);
+  await fs.writeFile(cssFilename, nativeCSS);
+
+  // Save native-elements less
+  await fs.ensureDir(lessOutDir);
+  const lessFilename = path.join(lessOutDir, 'native-elements.less');
+  console.log(chalk.yellow('Output'), lessFilename);
+  await fs.writeFile(lessFilename, fullSemicolonCSS);
 
   // Generate combined import files
   let importStr;

--- a/packages/theme-compiler/bin/theme-compiler.js
+++ b/packages/theme-compiler/bin/theme-compiler.js
@@ -53,7 +53,7 @@ const chalk = require('chalk');
 
   // Save native-elements less
   // This less has 1 difference compared to its CSS version: a semicolon after last property
-  // This extra semicolon is a workaround for a less-parser bug described in https://github.com/less/less.js/pull/3700
+  // A workaround for a less-parser bug described in https://github.com/less/less.js/pull/3700
   // The PR has been merged but it's not released yet as of less 4.1.3.
   await fs.ensureDir(lessOutDir);
   const lessFilename = path.join(lessOutDir, 'native-elements.less');

--- a/packages/theme-compiler/src/helpers.js
+++ b/packages/theme-compiler/src/helpers.js
@@ -105,6 +105,9 @@ const getElementNameFromLess = (filename) => {
  * @param {string} variables option variables that include using event condition
  * @returns {object}
  */
+// Generate both regular minified CSS & a similar version with a semicolon after last property
+// A workaround for a less-parser bug described in https://github.com/less/less.js/pull/3700
+// The PR has been merged but it's not released yet as of less 4.1.3.
 const generateOutput = (filename, output, variables) => {
   return autoPrefix(output.css).then(prefixedCSS => {
     return {

--- a/packages/theme-compiler/src/helpers.js
+++ b/packages/theme-compiler/src/helpers.js
@@ -107,15 +107,16 @@ const getElementNameFromLess = (filename) => {
  */
 const generateOutput = (filename, output, variables) => {
   return autoPrefix(output.css).then(prefixedCSS => {
-    const minifiedCSS =  cleanCSS(prefixedCSS);
-    const fullSemicolonMinifiedCSS = cleanCSS(prefixedCSS, true);
-    return { minifiedCSS, fullSemicolonMinifiedCSS };
-  }).then(({ minifiedCSS, fullSemicolonMinifiedCSS }) => {
+    return {
+      minifiedCSS: cleanCSS(prefixedCSS),
+      allSemicolonMinifiedCSS: cleanCSS(prefixedCSS, true)
+    };
+  }).then(({ minifiedCSS, allSemicolonMinifiedCSS }) => {
     return {
       minifiedCSS: wrapHostSelectors(minifiedCSS),
-      fullSemicolonMinifiedCSS: wrapHostSelectors(fullSemicolonMinifiedCSS)
-    }
-  }).then(({ minifiedCSS, fullSemicolonMinifiedCSS }) => {
+      allSemicolonMinifiedCSS: wrapHostSelectors(allSemicolonMinifiedCSS)
+    };
+  }).then(({ minifiedCSS, allSemicolonMinifiedCSS }) => {
     let name = path.basename(filename).replace(/\.less$/, '');
     let dependencies = output.imports
       .filter(filename => prefix.test(filename))
@@ -127,7 +128,7 @@ const generateOutput = (filename, output, variables) => {
       injector: styleInfo.injectorString,
       contents: generateJs(styleInfo),
       css: minifiedCSS,
-      fullSemicolonCSS: fullSemicolonMinifiedCSS
+      allSemicolonCSS: allSemicolonMinifiedCSS
     };
   });
 };


### PR DESCRIPTION
## Description

Add less style generation for native elments. The file contains semicolon after last property resolving less parser bug.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
