### PR TITLE
Refactor/i18n-migrate-to-fast-memoize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4408,6 +4408,16 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "node_modules/bin-links": {
       "version": "3.0.3",
       "dev": true,
@@ -12940,6 +12950,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true
+    },
     "node_modules/playwright": {
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.31.1.tgz",
@@ -16312,7 +16328,8 @@
       },
       "devDependencies": {
         "@refinitiv-ui/phrasebook": "^7.0.0-next.0",
-        "@refinitiv-ui/test-helpers": "^7.0.0-next.0"
+        "@refinitiv-ui/test-helpers": "^7.0.0-next.0",
+        "benchmark": "^2.1.4"
       },
       "peerDependencies": {
         "@refinitiv-ui/phrasebook": "^7.0.0-next.0"
@@ -18342,9 +18359,10 @@
       "version": "file:packages/i18n",
       "requires": {
         "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/icu-messageformat-parser": "2.3.1",
+        "@formatjs/icu-messageformat-parser": "^2.3.1",
         "@refinitiv-ui/phrasebook": "^7.0.0-next.0",
         "@refinitiv-ui/test-helpers": "^7.0.0-next.0",
+        "benchmark": "^2.1.4",
         "intl-format-cache": "^4.3.1",
         "intl-messageformat": "^10.3.4",
         "tslib": "^2.3.1"
@@ -19780,6 +19798,16 @@
     "before-after-hook": {
       "version": "2.2.3",
       "dev": true
+    },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
     },
     "bin-links": {
       "version": "3.0.3",
@@ -25290,6 +25318,12 @@
           }
         }
       }
+    },
+    "platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true
     },
     "playwright": {
       "version": "1.31.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4408,16 +4408,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/benchmark": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
-      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.4",
-        "platform": "^1.3.3"
-      }
-    },
     "node_modules/bin-links": {
       "version": "3.0.3",
       "dev": true,
@@ -12950,12 +12940,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/platform": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
-      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "dev": true
-    },
     "node_modules/playwright": {
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.31.1.tgz",
@@ -16328,8 +16312,7 @@
       },
       "devDependencies": {
         "@refinitiv-ui/phrasebook": "^7.0.0-next.0",
-        "@refinitiv-ui/test-helpers": "^7.0.0-next.0",
-        "benchmark": "^2.1.4"
+        "@refinitiv-ui/test-helpers": "^7.0.0-next.0"
       },
       "peerDependencies": {
         "@refinitiv-ui/phrasebook": "^7.0.0-next.0"
@@ -18362,7 +18345,6 @@
         "@formatjs/icu-messageformat-parser": "^2.3.1",
         "@refinitiv-ui/phrasebook": "^7.0.0-next.0",
         "@refinitiv-ui/test-helpers": "^7.0.0-next.0",
-        "benchmark": "^2.1.4",
         "intl-format-cache": "^4.3.1",
         "intl-messageformat": "^10.3.4",
         "tslib": "^2.3.1"
@@ -19798,16 +19780,6 @@
     "before-after-hook": {
       "version": "2.2.3",
       "dev": true
-    },
-    "benchmark": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
-      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.4",
-        "platform": "^1.3.3"
-      }
     },
     "bin-links": {
       "version": "3.0.3",
@@ -25318,12 +25290,6 @@
           }
         }
       }
-    },
-    "platform": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
-      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "dev": true
     },
     "playwright": {
       "version": "1.31.1",

--- a/packages/i18n/__demo__/index.html
+++ b/packages/i18n/__demo__/index.html
@@ -14,8 +14,8 @@
   </style>
   <body>
     <script type="module">
-      import 'lodash';
-      import 'benchmark';
+      import 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js';
+      import 'https://cdn.jsdelivr.net/npm/benchmark@2.1.4/benchmark.min.js';
       import '@refinitiv-ui/demo-block';
       import { Phrasebook } from '@refinitiv-ui/phrasebook';
       import { t, DEFAULT_LOCALE } from '@refinitiv-ui/i18n';

--- a/packages/i18n/__demo__/index.html
+++ b/packages/i18n/__demo__/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Calendar</title>
+    <link rel="stylesheet" href="/node_modules/@refinitiv-ui/demo-block/demo.css">
+  </head>
+  <style>
+    demo-block::part(body) {
+      flex-direction: column;
+      justify-content: center;
+    }
+  </style>
+  <body>
+    <script type="module">
+      import 'lodash';
+      import 'benchmark';
+      import '@refinitiv-ui/demo-block';
+      import { Phrasebook } from '@refinitiv-ui/phrasebook';
+      import { t, DEFAULT_LOCALE } from '@refinitiv-ui/i18n';
+
+      const scope = 'i18n-benchmark';
+
+      // Define test phrasebooks
+      Phrasebook.define(DEFAULT_LOCALE, scope, {
+        OK: 'default: OK',
+        NUMBER: 'default: { count }'
+      });
+      Phrasebook.define('es', scope, {
+        OK: 'es: OK',
+        NUMBER: 'es: { count }'
+      });
+      Phrasebook.define('es-US', scope, {
+        OK: 'es-US: OK',
+        NUMBER: 'es-US: { count }'
+      });
+      Phrasebook.define('th', scope, {
+        DATE: '{date, date, ::yyyy}'
+      });
+      // 2020-Jan-01 00:00:00 local time
+      const date = new Date();
+      date.setHours(0, 0, 0, 0);
+      date.setFullYear(2020, 0, 1);
+
+      globalThis.runBenchmark = () => {
+        new Benchmark.Suite()
+          .add('translate message in different locales', async function () {
+            await t(scope, 'es', 'OK');
+          })
+          .add('translate message in different locales with parameters', async function () {
+            await t(scope, 'es-US', 'NUMBER', { count: 3 });
+          })
+          .add('fallback translation if high level locale is defined', async function () {
+            await t(scope, 'es-ES', 'OK');
+          })
+          .add('get unknown locale should return the default locale', async function () {
+            await t(scope, 'un-LO', 'OK');
+          })
+          .add('get unknown key should return the key', async function () {
+            await t(scope, DEFAULT_LOCALE, 'UNKNOWN_KEY');
+          })
+          .add('Unicode extensions', async function () {
+            await t(scope, 'th', 'DATE', { date }, {
+              unicodeExtensions: {
+                ca: 'gregory'
+              }
+            });
+          })
+          .add('override unicode extensions', async function () {
+            await t(scope, 'th-u-ca-indian', 'DATE', { date }, {
+              unicodeExtensions: {
+                ca: 'gregory'
+              }
+            });
+          })
+          .on('cycle', function (event) {
+            // eslint-disable-next-line no-console
+            console.log(String(event.target));
+          })
+          .on('start', function () {
+            // eslint-disable-next-line no-console
+            console.log('=== benchmark started ===');
+          })
+          .on('complete', function () {
+            // eslint-disable-next-line no-console
+            console.log('=== benchmark complete ===');
+          })
+          .run({ async: true });
+      };
+    </script>
+
+    <demo-block header="Start Benchmark" tags="performance,benchmark">
+      <button id="start">Start Benchmark</button>
+      <p>Check the benchmark result in console.</p>
+      <script type="module">
+        const startButton = document.getElementById('start');
+        startButton.addEventListener('click', () => {
+          globalThis.runBenchmark();
+        });
+      </script>
+    </demo-block>
+
+  </body>
+</html>

--- a/packages/i18n/__demo__/index.html
+++ b/packages/i18n/__demo__/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Calendar</title>
+    <title>i18n Translate Benchmark</title>
     <link rel="stylesheet" href="/node_modules/@refinitiv-ui/demo-block/demo.css">
   </head>
   <style>
@@ -20,7 +20,7 @@
       import { Phrasebook } from '@refinitiv-ui/phrasebook';
       import { t, DEFAULT_LOCALE } from '@refinitiv-ui/i18n';
 
-      const scope = 'i18n-benchmark';
+      const scope = 'i18n-translate-benchmark';
 
       // Define test phrasebooks
       Phrasebook.define(DEFAULT_LOCALE, scope, {

--- a/packages/i18n/__demo__/index.html
+++ b/packages/i18n/__demo__/index.html
@@ -90,10 +90,13 @@
       };
     </script>
 
-    <demo-block header="Start Benchmark" tags="performance,benchmark">
+    <demo-block header="Translate Function Benchmark" tags="performance,benchmark">
       <button id="start">Start Benchmark</button>
-      <p>Check the benchmark result in console.</p>
-      <script type="module">
+      <p>
+        Benchmark the performance of translate function based on its unit test.
+        Open console to check the result.
+      </p>
+      <script>
         const startButton = document.getElementById('start');
         startButton.addEventListener('click', () => {
           globalThis.runBenchmark();

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -33,8 +33,7 @@
   },
   "devDependencies": {
     "@refinitiv-ui/phrasebook": "^7.0.0-next.0",
-    "@refinitiv-ui/test-helpers": "^7.0.0-next.0",
-    "benchmark": "^2.1.4"
+    "@refinitiv-ui/test-helpers": "^7.0.0-next.0"
   },
   "peerDependencies": {
     "@refinitiv-ui/phrasebook": "^7.0.0-next.0"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -16,6 +16,7 @@
     "build:prod": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "start": "npm run build && concurrently \"npm run build:watch\" \"web-dev-server --config ../../server.config.mjs --app-index __demo__\"",
     "test": "npm run build && node ../../scripts/tests/run.mjs  --package=i18n",
     "test:watch": "npm run test -- --watch",
     "prepack": "npm run version",
@@ -32,7 +33,8 @@
   },
   "devDependencies": {
     "@refinitiv-ui/phrasebook": "^7.0.0-next.0",
-    "@refinitiv-ui/test-helpers": "^7.0.0-next.0"
+    "@refinitiv-ui/test-helpers": "^7.0.0-next.0",
+    "benchmark": "^2.1.4"
   },
   "peerDependencies": {
     "@refinitiv-ui/phrasebook": "^7.0.0-next.0"

--- a/packages/i18n/src/memoiser.ts
+++ b/packages/i18n/src/memoiser.ts
@@ -1,7 +1,9 @@
-// see https://github.com/formatjs/formatjs/tree/main/packages/intl-format-cache
-// to understand more why memoiser is required
+// Creating instances of Intl formats is an expensive operation.
+// Memoizer caches these instances for reuse improving performance.
+// Although, IntlMessageFormat provides memoizers internally,
+// performance can still be further improved by caching IntlMessageFormat itself
 import IntlMessageFormat from 'intl-messageformat';
-import memoizeFormatConstructor from 'intl-format-cache';
+import { memoize, strategies } from '@formatjs/fast-memoize';
 import type {
   TranslateOptions,
   TranslateMessage,
@@ -90,7 +92,11 @@ abstract class Memoiser {
     // set the formatter first
     if (!memoised) {
       memoised = {
-        formatter: memoizeFormatConstructor(IntlMessageFormat),
+        formatter: memoize(
+          (...args: ConstructorParameters<typeof IntlMessageFormat>) =>
+            new IntlMessageFormat(...args),
+          { strategy: strategies.variadic }
+        ),
         keys: {},
         time: 0
       };


### PR DESCRIPTION
## Description

- add i18n's demo page containg performance benchmark implemented with benchmark.js
- migrate from intl-format-cache to @formatjs/fast-memoize

## Type of change

Please delete options that are not relevant.

- [x] Refactor (improves code without changing its functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
