### PR TITLE
feat: export `nothing` value from `lit`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,8 @@ export {
   svg,
   css,
   unsafeCSS,
-  render
+  render,
+  nothing
 } from 'lit';
 
 export type {


### PR DESCRIPTION
## Description

Export `nothing` from `lit` for more consistent behaviour on false value in attribute, template and property.

https://lit.dev/docs/api/templates/#nothing

_`"In child expressions, undefined, null, '', and nothing all behave the same and render no nodes. In attribute expressions, nothing removes the attribute, while undefined and null will render an empty string. In property expressions nothing becomes undefined."`_

## Type of change

Please delete options that are not relevant.

- [ ] Refactor (improves code without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
