### PR TITLE
refactor: remove legacy Enter keyCode

### DIFF
--- a/packages/elements/src/multi-input/index.ts
+++ b/packages/elements/src/multi-input/index.ts
@@ -551,7 +551,7 @@ export class MultiInput extends ControlElement implements MultiValue {
     if (event.key === 'Backspace') {
       this.removeLastItemByKeyboard(event);
     }
-    else if (event.key === 'Enter') {
+    else if (event.key === 'Enter' || event.keyCode === 13) {
       this.addItemByKeyboard();
     }
   }

--- a/packages/elements/src/multi-input/index.ts
+++ b/packages/elements/src/multi-input/index.ts
@@ -551,7 +551,7 @@ export class MultiInput extends ControlElement implements MultiValue {
     if (event.key === 'Backspace') {
       this.removeLastItemByKeyboard(event);
     }
-    else if (event.key === 'Enter' || event.keyCode === 13) {
+    else if (event.key === 'Enter') {
       this.addItemByKeyboard();
     }
   }

--- a/packages/elements/src/slider/index.ts
+++ b/packages/elements/src/slider/index.ts
@@ -803,9 +803,7 @@ export class Slider extends ControlElement {
       return;
     }
 
-    if (
-      (event.keyCode === 13 || event.keyCode === 32)
-      || (event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter')) {
+    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
       (event.target as NumberField).blur();
     }
   }

--- a/packages/elements/src/slider/index.ts
+++ b/packages/elements/src/slider/index.ts
@@ -803,7 +803,9 @@ export class Slider extends ControlElement {
       return;
     }
 
-    if (event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter') {
+    if (
+      (event.keyCode === 13 || event.keyCode === 32)
+      || (event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter')) {
       (event.target as NumberField).blur();
     }
   }

--- a/packages/elements/src/toggle/__test__/toggle.test.js
+++ b/packages/elements/src/toggle/__test__/toggle.test.js
@@ -1,4 +1,4 @@
-import { fixture, expect, elementUpdated, oneEvent, isIE } from '@refinitiv-ui/test-helpers';
+import { fixture, expect, elementUpdated, oneEvent, keyboardEvent } from '@refinitiv-ui/test-helpers';
 
 // import element and theme
 import '@refinitiv-ui/elements/toggle';
@@ -64,7 +64,7 @@ describe('toggle/Toggle', () => {
       await elementUpdated(el);
       expect(el).to.be.accessible();
     });
-  })
+  });
 
   describe('Reflect attribute', () => {
     it('Label', async () => {
@@ -248,20 +248,15 @@ describe('toggle/Toggle', () => {
   });
 
   describe('Enter keypress', () => {
-    let enterEvent;
-    beforeEach(() => {
-      enterEvent = isIE() ? createIEKeyboardEvent(13) : createKeyboardEvent(13);
-    });
-
     describe('Checked value & event', () => {
       it('Should toggle checked value', async () => {
         const el = await fixture('<ef-toggle></ef-toggle>');
-        el.dispatchEvent(enterEvent);
+        el.dispatchEvent(keyboardEvent('keydown', { key: 'Enter' }));
         expect(el.checked).to.equal(true);
       });
       it('Should fired an checked-changed event on Enter keypress and change checked value', async () => {
         const el = await fixture('<ef-toggle></ef-toggle>');
-        setTimeout(() => el.dispatchEvent(enterEvent));
+        setTimeout(() => el.dispatchEvent(keyboardEvent('keydown', { key: 'Enter' })));
         const event = await oneEvent(el, 'checked-changed');
         expect(event.target.checked).to.equal(true);
       });
@@ -271,7 +266,7 @@ describe('toggle/Toggle', () => {
         const el = await fixture('<ef-toggle disabled></ef-toggle>');
         expect(el.disabled).to.equal(true);
         expect(el.checked).to.equal(false);
-        el.dispatchEvent(enterEvent);
+        el.dispatchEvent(keyboardEvent('keydown', { key: 'Enter' }));
         expect(el.checked).to.equal(false);
       });
     });
@@ -280,27 +275,22 @@ describe('toggle/Toggle', () => {
         const el = await fixture('<ef-toggle readonly></ef-toggle>');
         expect(el.readonly).to.equal(true);
         expect(el.checked).to.equal(false);
-        el.dispatchEvent(enterEvent);
+        el.dispatchEvent(keyboardEvent('keydown', { key: 'Enter' }));
         expect(el.checked).to.equal(false);
       });
     });
   });
 
   describe('Spacebar keypress', () => {
-    let spacebarEvent;
-    beforeEach(() => {
-      spacebarEvent = isIE() ? createIEKeyboardEvent(32) : createKeyboardEvent(32);
-    });
-
     describe('Checked value & event', () => {
       it('Should toggle checked value', async () => {
         const el = await fixture('<ef-toggle></ef-toggle>');
-        el.dispatchEvent(spacebarEvent);
+        el.dispatchEvent(keyboardEvent('keydown', { key: 'Spacebar' }));
         expect(el.checked).to.equal(true);
       });
       it('Should fired an checked-changed event on Spacebar keypress and change checked value', async () => {
         const el = await fixture('<ef-toggle></ef-toggle>');
-        setTimeout(() => el.dispatchEvent(spacebarEvent));
+        setTimeout(() => el.dispatchEvent(keyboardEvent('keydown', { key: 'Spacebar' })));
         const event = await oneEvent(el, 'checked-changed');
         expect(event.target.checked).to.equal(true);
       });
@@ -310,7 +300,7 @@ describe('toggle/Toggle', () => {
         const el = await fixture('<ef-toggle disabled></ef-toggle>');
         expect(el.disabled).to.equal(true);
         expect(el.checked).to.equal(false);
-        el.dispatchEvent(spacebarEvent);
+        el.dispatchEvent(keyboardEvent('keydown', { key: 'Spacebar' }));
         expect(el.checked).to.equal(false);
       });
     });
@@ -319,38 +309,9 @@ describe('toggle/Toggle', () => {
         const el = await fixture('<ef-toggle readonly></ef-toggle>');
         expect(el.readonly).to.equal(true);
         expect(el.checked).to.equal(false);
-        el.dispatchEvent(spacebarEvent);
+        el.dispatchEvent(keyboardEvent('keydown', { key: 'Spacebar' }));
         expect(el.checked).to.equal(false);
       });
     });
   });
 });
-
-const createKeyboardEvent = (key) => {
-  return new KeyboardEvent('keydown', {
-    keyCode: key,
-    which: key
-  });
-};
-const createIEKeyboardEvent = (key) => {
-  const event = document.createEvent('KeyboardEvent');
-  Object.defineProperty(event, 'which', {
-    get: () => key
-  });
-  Object.defineProperty(event, 'keyCode', {
-    get: () => key
-  });
-  event.initKeyboardEvent(
-    'keydown',
-    true, // canBubbleArg,
-    true, // cancelableArg,
-    null, // viewArg,  Specifies UIEvent.view. This value may be null.
-    false, // ctrlKeyArg,
-    false, // altKeyArg,
-    false, // shiftKeyArg,
-    false, // metaKeyArg,
-    key, // keyCodeArg,
-    0
-  );
-  return event;
-};

--- a/packages/elements/src/toggle/index.ts
+++ b/packages/elements/src/toggle/index.ts
@@ -129,7 +129,10 @@ export class Toggle extends ControlElement {
    * @returns {void}
    */
   private handleKeyDown (event: KeyboardEvent): void {
-    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+    if (
+      (event.keyCode === 13 || event.keyCode === 32)
+      || (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar')
+    ) {
       this.handleCheckedChange();
     }
   }

--- a/packages/elements/src/toggle/index.ts
+++ b/packages/elements/src/toggle/index.ts
@@ -129,10 +129,7 @@ export class Toggle extends ControlElement {
    * @returns {void}
    */
   private handleKeyDown (event: KeyboardEvent): void {
-    if (
-      (event.keyCode === 13 || event.keyCode === 32)
-      || (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar')
-    ) {
+    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
       this.handleCheckedChange();
     }
   }

--- a/packages/elements/src/toggle/index.ts
+++ b/packages/elements/src/toggle/index.ts
@@ -132,9 +132,6 @@ export class Toggle extends ControlElement {
     if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
       this.handleCheckedChange();
     }
-    else if (event.keyCode && event.keyCode === 13 || event.keyCode === 32) { // For older browsers
-      this.handleCheckedChange();
-    }
   }
 
   /**


### PR DESCRIPTION
## Description

Remove legacy Enter `keyCode`, I'm not sure if we do need Enter for `toggle` though. Checkbox and radio buttons which are in the same family do not support `Enter`.

## Type of change

Please delete options that are not relevant.

- [x] Refactor (improves code without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
