### PR TITLE
docs: fix to use correct lang code on japanese sample on Langauges page

### DIFF
--- a/documents/src/pages/start/languages.md
+++ b/documents/src/pages/start/languages.md
@@ -37,7 +37,7 @@ import { halo } from '/theme-loader.js';
 halo('panel');
 import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
 
-document.documentElement.setAttribute('lang', 'zh-CN');
+document.documentElement.setAttribute('lang', 'ja-JP');
 ```
 ::
 


### PR DESCRIPTION
On Language Support page, doc was using zh lang attribute for Japanese sample block. This is wrong and need to change to ja-JP.