### PR TITLE
Add env for setup latest browsers launcher

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ env:
   BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
   BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
   BROWSERSTACK_BUILD: "Test ${{ github.run_number }}"
+  BROWSERSTACK_LATEST_BROWSERS_LAUNCHER: "Playwright"
 
 jobs:
   build:

--- a/scripts/tests/run.mjs
+++ b/scripts/tests/run.mjs
@@ -125,7 +125,7 @@ if (useBrowserStack) {
     browserName = browserName.charAt(0).toUpperCase() + browserName.slice(1);
     // Default desktop browsers (latest) must use Playwright launcher in the default config
     let browserLauncher = undefined;
-    if (isLatestDesktopBrowser(launcher)) {
+    if (env.BROWSERSTACK_LATEST_BROWSERS_LAUNCHER === 'Playwright' && isLatestDesktopBrowser(launcher)) {
       browserLauncher = getDefaultLauncher(launcher.browser);
     } else {
       browserLauncher = browserstackLauncher({ capabilities: { ...sharedCapabilities, ...launcher, browserName } });


### PR DESCRIPTION
## Description

Use environment variable `BROWSERSTACK_LATEST_BROWSERS_LAUNCHER` for switch launcher between BrowserStack and Playwright

Fixes # (issue)

## Type of change

- [x] Refactor (improves code without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
