### PR TITLE
fix: fix theme-extractor not work on Windows

### DIFF
--- a/scripts/release/theme-extractor.mjs
+++ b/scripts/release/theme-extractor.mjs
@@ -12,7 +12,7 @@ import { ELEMENT_DIST, getElementList, getElementTagName } from './util.cjs';
 const PACKAGE_NAME = '@refinitiv-ui/elements';
 
 // Where to look for theme files
-const THEME_SOURCE = `${ROOT}/node_modules/${PACKAGE_NAME.split('/')[0]}/`;
+const THEME_SOURCE = `${ROOT}/node_modules/${PACKAGE_NAME.split('/')[0]}/`.replace(/\\/g, '/');
 
 // Post-fix of theme name
 const THEME_POSTFIX = '-theme';
@@ -78,7 +78,7 @@ const createDependencyMap = async () => {
     for (let j = 0; j < group.elements.length; j++) {
       // Assuming all themes have the same set of dependency
       const themeRepositoryName = THEMES[0] + THEME_POSTFIX;
-      const themesFound = await fg(`${path.join(THEME_SOURCE, themeRepositoryName)}/**/${group.elements[j]}.js`);
+      const themesFound = await fg(`${path.join(THEME_SOURCE, themeRepositoryName)}/**/${group.elements[j]}.js`.replace(/\\/g, '/'));
 
       for (const theme of themesFound) {
         dependencies = dependencies
@@ -126,7 +126,7 @@ const getThemes = async (elements) => {
   let themes = [];
   for (const theme of THEMES) {
     const themeRepositoryName = theme + THEME_POSTFIX;
-    themes = themes.concat(await fg(`${path.join(THEME_SOURCE, themeRepositoryName)}/**/${elements[0]}.js`));
+    themes = themes.concat(await fg(`${path.join(THEME_SOURCE, themeRepositoryName)}/**/${elements[0]}.js`.replace(/\\/g, '/')));
   }
 
   return themes;
@@ -160,10 +160,10 @@ const handler = async () => {
        * Entrypoint, using lib for backward compatibility
        * @example import '@refinitiv-ui/elements/lib/ef-icon/halo/dark';
        */
-      let entrypoint = path.join(ELEMENT_DIST, dir, THEMES_DIRECTORY, variantPath);
+      let entrypoint = path.join(ELEMENT_DIST, dir, THEMES_DIRECTORY, variantPath).replace(/\\/g, '/');
 
       if (src) {
-        entrypoint = path.join(src, entrypoint);
+        entrypoint = path.join(src, entrypoint).replace(/\\/g, '/');
       }
 
       // Prepare folders structure
@@ -181,7 +181,7 @@ const handler = async () => {
         // Strip element prefix
         const dep = dependency.replace(`${dependency.split('-')[0]}-`, '');
         const variant = path.dirname(variantPath);
-        const dependencyImport = `import '${path.join(PACKAGE_NAME, dep, THEMES_DIRECTORY, variant)}';\n`;
+        const dependencyImport = `import '${path.join(PACKAGE_NAME, dep, THEMES_DIRECTORY, variant)}';\n`.replace(/\\/g, '/');
 
         // Clean up file
         if (fs.existsSync(entrypoint)) {

--- a/scripts/release/theme-extractor.mjs
+++ b/scripts/release/theme-extractor.mjs
@@ -6,13 +6,13 @@ import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { log, errorHandler, success, ROOT } from '../helpers/esm.mjs';
-import { ELEMENT_DIST, getElementList, getElementTagName } from './util.cjs';
+import { ELEMENT_DIST, getElementList, getElementTagName, normalizePathSeparators } from './util.cjs';
 
 // Element package scope
 const PACKAGE_NAME = '@refinitiv-ui/elements';
 
 // Where to look for theme files
-const THEME_SOURCE = `${ROOT}/node_modules/${PACKAGE_NAME.split('/')[0]}/`.replace(/\\/g, '/');
+const THEME_SOURCE = normalizePathSeparators(`${ROOT}/node_modules/${PACKAGE_NAME.split('/')[0]}/`);
 
 // Post-fix of theme name
 const THEME_POSTFIX = '-theme';
@@ -78,7 +78,7 @@ const createDependencyMap = async () => {
     for (let j = 0; j < group.elements.length; j++) {
       // Assuming all themes have the same set of dependency
       const themeRepositoryName = THEMES[0] + THEME_POSTFIX;
-      const themesFound = await fg(`${path.join(THEME_SOURCE, themeRepositoryName)}/**/${group.elements[j]}.js`.replace(/\\/g, '/'));
+      const themesFound = await fg(normalizePathSeparators(`${path.join(THEME_SOURCE, themeRepositoryName)}/**/${group.elements[j]}.js`));
 
       for (const theme of themesFound) {
         dependencies = dependencies
@@ -126,7 +126,7 @@ const getThemes = async (elements) => {
   let themes = [];
   for (const theme of THEMES) {
     const themeRepositoryName = theme + THEME_POSTFIX;
-    themes = themes.concat(await fg(`${path.join(THEME_SOURCE, themeRepositoryName)}/**/${elements[0]}.js`.replace(/\\/g, '/')));
+    themes = themes.concat(await fg(normalizePathSeparators(`${path.join(THEME_SOURCE, themeRepositoryName)}/**/${elements[0]}.js`)));
   }
 
   return themes;
@@ -160,10 +160,10 @@ const handler = async () => {
        * Entrypoint, using lib for backward compatibility
        * @example import '@refinitiv-ui/elements/lib/ef-icon/halo/dark';
        */
-      let entrypoint = path.join(ELEMENT_DIST, dir, THEMES_DIRECTORY, variantPath).replace(/\\/g, '/');
+      let entrypoint = normalizePathSeparators(path.join(ELEMENT_DIST, dir, THEMES_DIRECTORY, variantPath));
 
       if (src) {
-        entrypoint = path.join(src, entrypoint).replace(/\\/g, '/');
+        entrypoint = normalizePathSeparators(path.join(src, entrypoint));
       }
 
       // Prepare folders structure
@@ -181,7 +181,7 @@ const handler = async () => {
         // Strip element prefix
         const dep = dependency.replace(`${dependency.split('-')[0]}-`, '');
         const variant = path.dirname(variantPath);
-        const dependencyImport = `import '${path.join(PACKAGE_NAME, dep, THEMES_DIRECTORY, variant)}';\n`.replace(/\\/g, '/');
+        const dependencyImport = `import '${normalizePathSeparators(path.join(PACKAGE_NAME, dep, THEMES_DIRECTORY, variant))}';\n`;
 
         // Clean up file
         if (fs.existsSync(entrypoint)) {

--- a/scripts/release/util.cjs
+++ b/scripts/release/util.cjs
@@ -27,6 +27,9 @@ const getElementTagName = (path) => {
 // This will help to detect if the JavaScript file is an element or not
 const DECORATE_SYNTAX = '    customElement';
 
+// Helper function to convert path separators
+const normalizePathSeparators = (filePath) => filePath.replace(/\\/g, '/');
+
 /**
  * Get list of element file path which contain element defining syntax
  * @param {string} directory directory's name
@@ -34,7 +37,7 @@ const DECORATE_SYNTAX = '    customElement';
  */
 const getElementList = async (directory) => {
   // All js files in source folder
-  const files = await fg([`${directory}/**/*.js`.replace(/\\/g, '/')], { unique: true });
+  const files = await fg([normalizePathSeparators(`${directory}/**/*.js`)], { unique: true });
 
   // Filter out incompatible elements
   return files
@@ -50,5 +53,6 @@ module.exports = {
   ELEMENT_PREFIX,
   PACKAGE_ROOT,
   getElementTagName,
-  getElementList
+  getElementList,
+  normalizePathSeparators
 };

--- a/scripts/release/util.cjs
+++ b/scripts/release/util.cjs
@@ -25,7 +25,7 @@ const getElementTagName = (path) => {
 
 // This is a compiled syntax of decorator we used to define our elements
 // This will help to detect if the JavaScript file is an element or not
-const DECORATE_SYNTAX = '__decorate([\n    customElement';
+const DECORATE_SYNTAX = '    customElement';
 
 /**
  * Get list of element file path which contain element defining syntax
@@ -34,7 +34,7 @@ const DECORATE_SYNTAX = '__decorate([\n    customElement';
  */
 const getElementList = async (directory) => {
   // All js files in source folder
-  const files = await fg([`${directory}/**/*.js`], { unique: true });
+  const files = await fg([`${directory}/**/*.js`.replace(/\\/g, '/')], { unique: true });
 
   // Filter out incompatible elements
   return files


### PR DESCRIPTION
## Description

Enable Windows users to run theme-extractor. Currently it works for mac user, but failed on Window.

Fixes # ([STG-441](https://jira.refinitiv.com/browse/STG-441))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
