### PR TITLE
fix(interactive-chart): reduce canvas memory size for safari

### DIFF
--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -247,7 +247,6 @@ export class InteractiveChart extends ResponsiveElement {
       }
       window.addEventListener('beforeunload', this.handleMemoryUsage);
     }
-
     super.connectedCallback();
   }
 
@@ -258,7 +257,7 @@ export class InteractiveChart extends ResponsiveElement {
   public disconnectedCallback (): void {
     if (isSafari()) {
       // Safari doesn't clear memory after refreshing page
-      // workaround: Need to minimize size of element to 1x1 to reduce memory usage
+      // workaround: Need to minimize size of element to 1x1 to reduce canvas memory usage
       OLD_HEIGHT = this.height;
       OLD_WIDTH = this.width;
       this.resizedCallback({ width: 1, height: 1 });


### PR DESCRIPTION
## Description
There was an issue about the memory limit in Safari that cause some canvas to not render. So, I was purposing the workaround to reduce the size of the canvas that accumulates in memory and decrease chance of the canvas reaching the limit.

Fixes # (issue) 
STG-430

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
