### PR TITLE
docs(elements): deprecate src from ef-icon and ef-flag

### DIFF
--- a/documents/src/pages/elements/flag.md
+++ b/documents/src/pages/elements/flag.md
@@ -30,7 +30,7 @@ ef-flag {
 
 ## Usage
 
-You can set a flag's code via the `flag` attribute to display the flag. See list of flags in [Flag List](#flag-list). Alternatively, you can set the url of an svg file or relative path to your svg file.
+You can set a flag's code via the `flag` attribute to display the flag. See list of flags in [Flag List](./elements/flag#flag-list). Alternatively, you can set the url of an svg file or relative path to your svg file.
 
 ```html
 <ef-flag flag="br"></ef-flag>

--- a/documents/src/pages/elements/flag.md
+++ b/documents/src/pages/elements/flag.md
@@ -21,8 +21,8 @@ ef-flag {
 <ef-flag flag="gb"></ef-flag>
 <ef-flag flag="jp"></ef-flag>
 <ef-flag flag="th"></ef-flag>
-<ef-flag src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/bo.svg"></ef-flag>
-<ef-flag src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/pe.svg"></ef-flag>
+<ef-flag flag="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/bo.svg"></ef-flag>
+<ef-flag flag="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/pe.svg"></ef-flag>
 ```
 ::
 
@@ -30,14 +30,14 @@ ef-flag {
 
 ## Usage
 
-You can set a flag's code via the `flag` attribute to display the flag. Alternatively, you can set the url of an svg file or relative path to your svg file using the `src` attribute.
+You can set a flag's code via the `flag` attribute to display the flag. See list of flags in [Flag List](#flag-list). Alternatively, you can set the url of an svg file or relative path to your svg file.
 
 ```html
 <ef-flag flag="br"></ef-flag>
 <ef-flag flag="ar"></ef-flag>
 <ef-flag flag="co"></ef-flag>
-<ef-flag src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/bo.svg"></ef-flag>
-<ef-flag src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/pe.svg"></ef-flag>
+<ef-flag flag="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/bo.svg"></ef-flag>
+<ef-flag flag="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/pe.svg"></ef-flag>
 ```
 
 ## Changing size
@@ -85,13 +85,13 @@ preload(
 ## Accessibility
 ::a11y-intro::
 
-`ef-flag` delegates focus into its internal svg which has native `role="image"`. Assistive technology users ascertain the purpose of the icon via its accessible name.
+`ef-flag` delegates focus into its internal svg which has native `role="image"`. Assistive technology users ascertain the purpose of the flag via its accessible name.
 
 Typically, flag may not be tabbable or focusable. However, if it's required, you can set `tabindex` and use `aria-label` or `title` to add its accessible name.
 
 ```html
-<ef-icon flag="nz" tabindex="0" aria-label="New Zealand Flag"></ef-icon>
-<ef-icon flag="nz" tabindex="0" title="New Zealand Flag"></ef-icon>
+<ef-flag flag="nz" tabindex="0" aria-label="New Zealand Flag"></ef-flag>
+<ef-flag flag="nz" tabindex="0" title="New Zealand Flag"></ef-flag>
 ```
 
 ::a11y-end::

--- a/documents/src/pages/elements/icon.md
+++ b/documents/src/pages/elements/icon.md
@@ -75,11 +75,11 @@ import { preload } from '@refinitiv-ui/elements/icon';
 // preload function supports both icon name or svg location, either single icon or multiple.
 preload('eye');
 preload('https://cdn.io/eye.svg');
-preload('eye', 'heart', 'like', 'arrow-up');
+preload('eye', 'home', 'like-empty', 'arrow-up');
 preload(
   'https://cdn.io/eye.svg',
-  'https://cdn.io/heart.svg',
-  'https://cdn.io/like.svg',
+  'https://cdn.io/home.svg',
+  'https://cdn.io/like-empty.svg',
   'https://cdn.io/arrow-up.svg'
 );
 ```

--- a/documents/src/pages/elements/icon.md
+++ b/documents/src/pages/elements/icon.md
@@ -29,7 +29,7 @@ ef-icon {
 Icons are provided as part of a theme. Icons also support pointing to urls of svg files. The size and coloring of icons can be changed using standard CSS.
 
 ## Usage
-You can set an icon's name using the `icon` attribute. See list of icons in [Icon List](#icon-list). Alternatively, you can set the url of an svg file or relative path to your svg file.
+You can set an icon's name using the `icon` attribute. See list of icons in [Icon List](./elements/icon#icon-list). Alternatively, you can set the url of an svg file or relative path to your svg file.
 
 ```html
 <ef-icon icon="tick"></ef-icon>

--- a/documents/src/pages/elements/icon.md
+++ b/documents/src/pages/elements/icon.md
@@ -21,23 +21,23 @@ ef-icon {
 <ef-icon icon="search"></ef-icon>
 <ef-icon icon="word"></ef-icon>
 <ef-icon icon="excel"></ef-icon>
-<ef-icon id="powerpoint" src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/buzz.svg"></ef-icon>
-<ef-icon id="pdf" src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/chart-area.svg"></ef-icon>
+<ef-icon icon="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/buzz.svg"></ef-icon>
+<ef-icon icon="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/chart-area.svg"></ef-icon>
 ```
 ::
 
 Icons are provided as part of a theme. Icons also support pointing to urls of svg files. The size and coloring of icons can be changed using standard CSS.
 
 ## Usage
-You can set an icon's name using the `ef-icon` attribute. Alternatively, you can set the url of an svg file or relative path to your svg file using the `src` attribute.
+You can set an icon's name using the `icon` attribute. See list of icons in [Icon List](#icon-list). Alternatively, you can set the url of an svg file or relative path to your svg file.
 
 ```html
 <ef-icon icon="tick"></ef-icon>
 <ef-icon icon="search"></ef-icon>
 <ef-icon icon="save"></ef-icon>
-<ef-icon id="filter" src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/filter.svg"></ef-icon>
-<ef-icon id="favorites" src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/favorites.svg"></ef-icon>
-<ef-icon id="help" src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/help.svg"></ef-icon>
+<ef-icon icon="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/filter.svg"></ef-icon>
+<ef-icon icon="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/favorites.svg"></ef-icon>
+<ef-icon icon="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/help.svg"></ef-icon>
 ```
 
 
@@ -64,7 +64,7 @@ The size and color of an icon can be changed using standard CSS styling.
 <ef-icon class="large" icon="flag-2"></ef-icon>
 ```
 
-## Icon preloading
+## Preloading
 `ef-icon` has a helper function to preload a set of icons. Icons can be loaded faster if you have a known set of icons for use in the app.
 
 Preloading icons will be deferred until the first `ef-icon` component is created.

--- a/packages/elements/src/flag/index.ts
+++ b/packages/elements/src/flag/index.ts
@@ -54,7 +54,7 @@ export class Flag extends BasicElement {
   private _flag: string | null = null;
 
   /**
-   * Name of a known flag to render or URL of flag SVG file.
+   * Code of a known flag to render or URL of flag SVG file.
    * @example gb | https://cdn.io/flags/gb.svg
    * @default null
    */

--- a/packages/elements/src/flag/index.ts
+++ b/packages/elements/src/flag/index.ts
@@ -16,13 +16,7 @@ export { preload } from './utils/FlagLoader.js';
 
 const EmptyTemplate = svg``;
 
-/**
- * Provides a collection of flags.
- *
- * @attr {string | null} src - Src location of a svg flag.
- * @prop {string | null} src - Src location of a svg flag
- *
- */
+
 @customElement('ef-flag')
 export class Flag extends BasicElement {
 
@@ -60,8 +54,8 @@ export class Flag extends BasicElement {
   private _flag: string | null = null;
 
   /**
-   * Name of a known flag to render.
-   * @example gb
+   * Name of a known flag to render or URL of flag SVG file.
+   * @example gb | https://cdn.io/flags/gb.svg
    * @default null
    */
   @property({ type: String })
@@ -80,6 +74,7 @@ export class Flag extends BasicElement {
 
   /**
    * Src location of an svg flag.
+   * @ignore
    * @example https://cdn.io/flags/gb.svg
    * @deprecated Use `flag` instead
    * @default null
@@ -88,6 +83,10 @@ export class Flag extends BasicElement {
   public get src (): string | null {
     return this._src;
   }
+  /**
+    * @ignore
+    * @param value Location of an svg
+    */
   public set src (value: string | null) {
     if (this.src !== value) {
       this.deferFlagReady();

--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -60,7 +60,7 @@ export class Icon extends BasicElement {
 
   /**
    * Name of a known icon to render or URL of SVG icon.
-   * @example heart | https://cdn.io/icons/heart.svg
+   * @example home | https://cdn.io/icons/home.svg
    * @default null
    */
   @property({ type: String, reflect: true })
@@ -81,7 +81,8 @@ export class Icon extends BasicElement {
 
   /**
    * Src location of an svg icon.
-   * @example https://cdn.io/icons/heart.svg
+   * @ignore
+   * @example https://cdn.io/icons/home.svg
    * @deprecated Use `icon` instead
    * @default null
    */
@@ -89,6 +90,10 @@ export class Icon extends BasicElement {
   public get src (): string | null {
     return this._src;
   }
+  /**
+    * @ignore
+    * @param value Location of an svg
+    */
   public set src (value: string | null) {
     if (this.src !== value) {
       this.deferIconReady();


### PR DESCRIPTION
- Remove `src` from API docs on ef-icon and ef-flag
- Update / correct content on ef-icon and ef-flag documentation