### PR TITLE
chore: add conventional graduate option production release

### DIFF
--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -7,6 +7,10 @@ on:
         description: Force publish all packages?
         type: boolean
         default: false
+      graduate:
+        description: Graduate next version packages?
+        type: boolean
+        default: false
 
 jobs:
   publish:
@@ -31,15 +35,16 @@ jobs:
       - name: Gather resources and build
         uses: ./.github/actions/checkout-install-and-build
 
-      - name: Bump all package versions and create GitHub release
-        if: ${{ inputs.force }}
-        run: lerna version --create-release github --conventional-commits --force-publish --yes
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Setup command line option
+        shell: bash
+        run: |
+          [[ "${{ inputs.force }}" == "true" ]] && export FORCE=--force-publish || export FORCE=''
+          [[ "${{ inputs.graduate }}" == "true" ]] && export GRADUATE=--conventional-graduate || export GRADUATE=''
+          echo "FORCE_OPTION=$FORCE" >> $GITHUB_ENV
+          echo "GRADUATE_OPTION=$GRADUATE" >> $GITHUB_ENV
 
-      - name: Bump modified package versions and create GitHub release
-        if: ${{ !inputs.force }}
-        run: lerna version --create-release github --conventional-commits --yes
+      - name: Bump package versions and create GitHub release
+        run: lerna version --create-release github --conventional-commits ${{ env.FORCE_OPTION }} ${{ env.GRADUATE_OPTION }} --yes
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -8,7 +8,7 @@ on:
         type: boolean
         default: false
       graduate:
-        description: Graduate next version packages?
+        description: Graduate prerelease packages?
         type: boolean
         default: false
 


### PR DESCRIPTION
## Description

To allow tag version next to be release, we need to add **conventional-graduate** flag to the publish workflow.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
