### PR TITLE
fix/prevent deselect date on calendar

### DIFF
--- a/packages/elements/src/calendar/__test__/calendar.range.test.js
+++ b/packages/elements/src/calendar/__test__/calendar.range.test.js
@@ -104,7 +104,7 @@ describe('calendar/Range', () => {
       await elementUpdated(el);
       expect(el.values.join(','), 'from should be populated').to.equal('2005-04-06');
     });
-    it('It should be possible to select a range of values within the same day on click', async () => {
+    it('It should be possible to select the same value for From and To', async () => {
       const el = await fixture('<ef-calendar range view="2005-04" lang="en-GB"></ef-calendar>');
       let cells = getDateCells(el);
 

--- a/packages/elements/src/calendar/__test__/calendar.range.test.js
+++ b/packages/elements/src/calendar/__test__/calendar.range.test.js
@@ -84,9 +84,10 @@ describe('calendar/Range', () => {
       expect(el.values.join(','), 'range should populate through views').to.equal('2005-04-12,2005-05-02');
       expect(el).shadowDom.to.equalSnapshot();
     });
-    it('It should be possible to select range values on the same day on click', async () => {
+    it('It should not be possible to deselect all range values', async () => {
       const el = await fixture('<ef-calendar range view="2005-04" lang="en-GB"></ef-calendar>');
       let cells = getDateCells(el);
+
       cells[5].click(); // April 06
       await elementUpdated(el);
       expect(el.values.join(','), 'from should be populated').to.equal('2005-04-06');
@@ -98,6 +99,14 @@ describe('calendar/Range', () => {
       cells[9].click(); // April 10
       await elementUpdated(el);
       expect(el.values.join(','), 'from should be populated').to.equal('2005-04-10');
+
+      cells[5].click(); // April 06
+      await elementUpdated(el);
+      expect(el.values.join(','), 'from should be populated').to.equal('2005-04-06');
+    });
+    it('It should be possible to select a range of values within the same day on click', async () => {
+      const el = await fixture('<ef-calendar range view="2005-04" lang="en-GB"></ef-calendar>');
+      let cells = getDateCells(el);
 
       cells[5].click(); // April 06
       await elementUpdated(el);

--- a/packages/elements/src/calendar/__test__/calendar.range.test.js
+++ b/packages/elements/src/calendar/__test__/calendar.range.test.js
@@ -84,5 +84,28 @@ describe('calendar/Range', () => {
       expect(el.values.join(','), 'range should populate through views').to.equal('2005-04-12,2005-05-02');
       expect(el).shadowDom.to.equalSnapshot();
     });
+    it('It should be possible to select range values on the same day on click', async () => {
+      const el = await fixture('<ef-calendar range view="2005-04" lang="en-GB"></ef-calendar>');
+      let cells = getDateCells(el);
+      cells[5].click(); // April 06
+      await elementUpdated(el);
+      expect(el.values.join(','), 'from should be populated').to.equal('2005-04-06');
+
+      cells[9].click(); // April 10
+      await elementUpdated(el);
+      expect(el.values.join(','), 'to should be populated').to.equal('2005-04-06,2005-04-10');
+
+      cells[9].click(); // April 10
+      await elementUpdated(el);
+      expect(el.values.join(','), 'from should be populated').to.equal('2005-04-10');
+
+      cells[5].click(); // April 06
+      await elementUpdated(el);
+      expect(el.values.join(','), 'from should be populated').to.equal('2005-04-06');
+
+      cells[5].click(); // April 06
+      await elementUpdated(el);
+      expect(el.values.join(','), 'should be able to select the same day as from').to.equal('2005-04-06,2005-04-06');
+    });
   });
 });

--- a/packages/elements/src/calendar/__test__/calendar.value.test.js
+++ b/packages/elements/src/calendar/__test__/calendar.value.test.js
@@ -76,6 +76,19 @@ describe('calendar/Value', () => {
       expect(el.values.join(','), 'values is not set').to.equal('2005-04-30');
     });
 
+    it('It should not be possible to deselect value on click', async () => {
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const cells = getDateCells(el);
+      cells[0].click(); // April 01
+      await elementUpdated(el);
+      expect(el.values.join(',')).to.equal('2005-04-01');
+      expect(el.value).to.equal('2005-04-01');
+      cells[0].click(); // April 01
+      await elementUpdated(el);
+      expect(el.values.join(',')).to.equal('2005-04-01');
+      expect(el.value, 'value should not be changed').to.equal('2005-04-01');
+    })
+
     it('AD/BC It should be possible to select value on click', async () => {
       const el = await fixture('<ef-calendar view="-000011-04" lang="en-GB"></ef-calendar>');
       const values = listenValueChangeEvent(el);

--- a/packages/elements/src/calendar/__test__/calendar.value.test.js
+++ b/packages/elements/src/calendar/__test__/calendar.value.test.js
@@ -87,7 +87,7 @@ describe('calendar/Value', () => {
       await elementUpdated(el);
       expect(el.values.join(',')).to.equal('2005-04-01');
       expect(el.value, 'value should not be changed').to.equal('2005-04-01');
-    })
+    });
 
     it('AD/BC It should be possible to select value on click', async () => {
       const el = await fixture('<ef-calendar view="-000011-04" lang="en-GB"></ef-calendar>');
@@ -111,6 +111,17 @@ describe('calendar/Value', () => {
       await keyboardEvent(cells[0], 'Spacebar');
       await keyboardEvent(cells[0], 'Spacebar', 'keyup'); // April 01
       expect(el.value, 'value is not set').to.equal('2005-04-01');
+    });
+
+    it('It should not be possible to deselect value on Spacebar', async () => {
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const cells = getDateCells(el);
+      await keyboardEvent(cells[0], 'Spacebar');
+      await keyboardEvent(cells[0], 'Spacebar', 'keyup'); // April 01
+      expect(el.value, 'value is not set').to.equal('2005-04-01');
+      await keyboardEvent(cells[0], 'Spacebar');
+      await keyboardEvent(cells[0], 'Spacebar', 'keyup'); // April 01
+      expect(el.value).to.equal('2005-04-01');
     });
 
     it('It should be possible to select value on \' \' ', async () => {

--- a/packages/elements/src/calendar/index.ts
+++ b/packages/elements/src/calendar/index.ts
@@ -991,12 +991,8 @@ export class Calendar extends ControlElement implements MultiValue {
           values = [value];
         }
       }
-      else if (this.values.indexOf(value) === -1) {
-        values = [value];
-      }
       else {
-        // remove range if start/end index match
-        values = [];
+        values = [value];
       }
     }
     else {

--- a/packages/elements/src/calendar/index.ts
+++ b/packages/elements/src/calendar/index.ts
@@ -1000,7 +1000,7 @@ export class Calendar extends ControlElement implements MultiValue {
       }
     }
     else {
-      values = this.value === value ? [] : [value];
+      values = [value];
     }
 
     this.notifyValuesChange(values);

--- a/packages/elements/src/datetime-picker/__demo__/index.html
+++ b/packages/elements/src/datetime-picker/__demo__/index.html
@@ -37,10 +37,10 @@
         </div>
         <div style="flex: 1">
           <p>
-            <textarea id="console" readonly style="width: 500px; height: 350px; font-size: 10rem;"></textarea>
+            <textarea id="console" readonly style="width: 500px; height: 350px; font-size: 12px;"></textarea>
           </p>
           <p>
-            <textarea id="events" style="width: 500px; height: 100px; font-size: 10rem;"></textarea>
+            <textarea id="events" style="width: 500px; height: 100px; font-size: 12px;"></textarea>
           </p>
           <p>
             <ef-datetime-picker id="date-value" placeholder="Set Value"></ef-datetime-picker>

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -95,6 +95,20 @@ describe('datetime-picker/Value', () => {
       expect(el.value).to.be.equal('2020-04-01', 'Value has not update');
       expect(el.inputEl.value).to.be.equal('01-Apr-2020', 'Input value has not updated');
     });
+    it('It should not be possible to deselect value by clicking on calendar', async () => {
+      const el = await fixture('<ef-datetime-picker lang="en-gb" opened view="2020-04"></ef-datetime-picker>');
+      const calendarEl = el.calendarEl;
+      await elementUpdated(el);
+      const cell = calendarEl.shadowRoot.querySelectorAll('div[tabindex]')[2]; // 2020-04-01
+      cell.click();
+      await elementUpdated(el);
+      expect(el.value).to.be.equal('2020-04-01', 'Value has not update');
+      expect(el.inputEl.value).to.be.equal('01-Apr-2020', 'Input value has not updated');
+      cell.click();
+      await elementUpdated(el);
+      expect(el.value).to.be.equal('2020-04-01');
+      expect(el.inputEl.value).to.be.equal('01-Apr-2020');
+    });
     it('It should be possible to select value in range duplex mode', async () => {
       const el = await fixture('<ef-datetime-picker lang="en-gb" opened range duplex></ef-datetime-picker>');
       el.views = ['2020-04', '2020-05'];

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -134,6 +134,39 @@ describe('datetime-picker/Value', () => {
       expect(el.inputEl.value).to.be.equal('01-Apr-2020', 'Input from value has not updated');
       expect(el.inputToEl.value).to.be.equal('01-May-2020', 'Input to value has not updated');
     });
+    it('It should not be possible to deselect values in range duplex mode', async () => {
+      const el = await fixture('<ef-datetime-picker lang="en-gb" opened range duplex></ef-datetime-picker>');
+      el.views = ['2020-04', '2020-05'];
+      await elementUpdated(el);
+      await nextFrame(2);
+
+      const calendarEl = el.calendarEl;
+      const fromCell = calendarEl.shadowRoot.querySelectorAll('div[tabindex]')[0]; // 2020-04-01
+      fromCell.click();
+      await elementUpdated(el);
+      await nextFrame();
+
+      const calendarToEl = el.calendarToEl;
+      const toCell = calendarToEl.shadowRoot.querySelectorAll('div[tabindex]')[0]; // 2020-05-01
+      toCell.click();
+      await elementUpdated(el);
+      await nextFrame();
+
+      expect(el.values[0]).to.be.equal('2020-04-01', 'Value from has not been updated');
+      expect(el.values[1]).to.be.equal('2020-05-01', 'Value to has not been update');
+
+      expect(el.inputEl.value).to.be.equal('01-Apr-2020', 'Input from value has not updated');
+      expect(el.inputToEl.value).to.be.equal('01-May-2020', 'Input to value has not updated');
+
+      toCell.click();
+      await elementUpdated(el);
+      await nextFrame();
+      expect(el.values.join(',')).to.equal('2020-05-01');
+      toCell.click();
+      await elementUpdated(el);
+      await nextFrame();
+      expect(el.values.join(',')).to.equal('2020-05-01,2020-05-01');
+    });
     it('Timepicker value is populated', async () => {
       const el = await fixture('<ef-datetime-picker lang="en-gb" opened timepicker with-seconds value="2020-04-21T13:14:15"></ef-datetime-picker>');
       const timePicker = el.timepickerEl;


### PR DESCRIPTION
## Description
In version 6, users can deselect a date by clicking on the currently selected date within the DateTime Picker. However, this functionality is not available in version 4, where a selected date cannot be deselected.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
