### PR TITLE
docs: workaround to avoid skypack issue

### DIFF
--- a/documents/src/pages/elements/accordion.md
+++ b/documents/src/pages/elements/accordion.md
@@ -115,8 +115,8 @@ Other features of `ef-collapse` can still be used e.g. slots.
 ::
 ```javascript
 ::accordion::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/checkbox?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/checkbox?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('checkbox');
 halo('button');
 ```

--- a/documents/src/pages/elements/autosuggest.md
+++ b/documents/src/pages/elements/autosuggest.md
@@ -10,7 +10,7 @@ layout: default
 ::
 ```javascript
 ::autosuggest::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
 halo('text-field');
 const data = [
   { label: 'Cornelius Martin' },
@@ -107,7 +107,7 @@ Autosuggest uses the item `label` property to display item labels in the popup a
 ::
 ```javascript
 ::autosuggest::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
 halo('text-field');
 const data = [
   { label: 'Cornelius Martin' },
@@ -161,7 +161,7 @@ Autosuggest understands the Item object model, allowing the display of non-selec
 ::
 ```javascript
 ::autosuggest::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
 halo('text-field');
 const data = [{ label: 'Cornelius Martin', group: 'Core Team' },
   { label: 'Memphis Hoover', group: 'Contractors' },
@@ -276,7 +276,7 @@ This example implements pagination and limits the result to show five suggestion
 ::
 ```javascript
 ::autosuggest::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
 halo('text-field');
 const data = [
   { label: 'Cornelius Martin' },
@@ -364,7 +364,7 @@ Optionally, the `debounce-rate` attribute can reduce the number of server calls,
 ::
 ```javascript
 ::autosuggest::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
 halo('text-field');
 const data = [
   { label: 'Cornelius Martin' },
@@ -450,8 +450,8 @@ Header and/or footer can be added to autosuggest by using slots.
 ::
 ```javascript
 ::autosuggest::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/header?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/header?min';
 halo('text-field');
 halo('header');
 const data = [
@@ -522,7 +522,7 @@ Use the `request-on-focus` attribute to request suggestions when the input is fo
 ::
 ```javascript
 ::autosuggest::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
 halo('text-field');
 const data = [
   { label: 'Cornelius Martin' },
@@ -581,7 +581,7 @@ For further position customization, `ef-autosuggest` supports attributes and pro
 ::
 ```javascript
 ::autosuggest::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
 halo('text-field');
 const data = [
   { label: 'Cornelius Martin' },
@@ -668,7 +668,7 @@ If autosuggest is customized and doesn't use `ef-item` or a descendant, a `highl
 ::
 ```javascript
 ::autosuggest::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
 halo('text-field');
 const data = [
   { label: 'Cornelius Martin', group: 'Core Team' },
@@ -823,7 +823,7 @@ While autosuggest natively understands the Item object model, it is data agnosti
 ::
 ```javascript
 ::autosuggest::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
 halo('text-field');
 const data = [
   { value: 'Cornelius Martin', readonly: true },
@@ -971,7 +971,7 @@ autoSuggest.addEventListener('item-select', (ev) => {
 ::
 ```javascript
 ::autosuggest::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/multi-input?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/multi-input?min';
 halo('multi-input');
 const data = [
   { label: 'Cornelius Martin' },
@@ -1099,8 +1099,8 @@ In addition to string-based queries, autosuggest `query` also supports objects, 
 ::
 ```javascript
 ::autosuggest::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/select?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/select?min';
 halo('text-field');
 halo('select');
 const data = [

--- a/documents/src/pages/elements/calendar.md
+++ b/documents/src/pages/elements/calendar.md
@@ -197,7 +197,7 @@ The calendar supports adding footer content. This can be used to give informatio
 ::
 ```javascript
 ::calendar::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 const calendarEl = document.querySelector('ef-calendar');
 const resetEl = document.querySelector('ef-button');

--- a/documents/src/pages/elements/card.md
+++ b/documents/src/pages/elements/card.md
@@ -67,7 +67,7 @@ Use the `item-trigger` event to detect when users click on any menu item.
 ::
 ```javascript
 ::card::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/interactive-chart?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/interactive-chart?min';
 halo('interactive-chart');
 const card = document.getElementById('card');
 const chart = document.getElementById('chart');

--- a/documents/src/pages/elements/clock.md
+++ b/documents/src/pages/elements/clock.md
@@ -137,7 +137,7 @@ Set the `interactive` attribute of `ef-clock` to allow users to interact with it
 ::
 ```javascript
 ::clock::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 
 document.getElementById('reset').addEventListener('click', () => {

--- a/documents/src/pages/elements/collapse.md
+++ b/documents/src/pages/elements/collapse.md
@@ -128,8 +128,8 @@ The header can contain simple text or components such as checkbox, button. These
 ::
 ```javascript
 ::collapse::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/checkbox?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/checkbox?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('checkbox');
 halo('button');
 ```

--- a/documents/src/pages/elements/color-dialog.md
+++ b/documents/src/pages/elements/color-dialog.md
@@ -10,7 +10,7 @@ layout: default
 ::
 ```javascript
 ::color-dialog::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 document.getElementById('button').addEventListener('click', () => {
   let dlg = document.getElementById('d1');
@@ -51,7 +51,7 @@ Color Dialog also accepts an initial color value. To set the default value, use 
 ::
 ```javascript
 ::color-dialog::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 document.getElementById('button').addEventListener('click', () => {
   let dlg = document.getElementById('d1');
@@ -88,7 +88,7 @@ When users select "no color" from the UI, the color dialog sets the attribute/pr
 ::
 ```javascript
 ::color-dialog::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 document.getElementById('button').addEventListener('click', () => {
   let dlg = document.getElementById('d1');

--- a/documents/src/pages/elements/combo-box.md
+++ b/documents/src/pages/elements/combo-box.md
@@ -393,9 +393,9 @@ comboBox.renderer = (item, composer, element) => {
 ::
 ```javascript
 ::combo-box::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/flag?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/flag?min';
 halo('flag');
-import { ComboBoxRenderer } from "https://cdn.skypack.dev/@refinitiv-ui/elements/combo-box?min";
+import { ComboBoxRenderer } from "https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/combo-box?min";
 
 const comboBox = document.querySelector('ef-combo-box');
 comboBox.data = [

--- a/documents/src/pages/elements/configuration.md
+++ b/documents/src/pages/elements/configuration.md
@@ -56,7 +56,7 @@ When `ef-icon` received SVG data of the icon, it will not request SVG icon file 
 
 ::
 ```javascript
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/configuration?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/configuration?min';
 ::icon::
 const configEl = document.getElementById('config');
 configEl.config = {

--- a/documents/src/pages/elements/email-field.md
+++ b/documents/src/pages/elements/email-field.md
@@ -9,7 +9,7 @@ layout: default
 ::
 ```javascript
 ::email-field::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
 halo('panel');
 ```
 ```css

--- a/documents/src/pages/elements/header.md
+++ b/documents/src/pages/elements/header.md
@@ -76,8 +76,8 @@ You can include a component in a header by assigning the component to a slot.
 ::
 ```javascript
 ::header::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/checkbox?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/checkbox?min';
 halo('button');
 halo('checkbox');
 ```

--- a/documents/src/pages/elements/heatmap.md
+++ b/documents/src/pages/elements/heatmap.md
@@ -450,8 +450,8 @@ el.config = {...};
 ::
 ```javascript
 ::heatmap::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/overlay-menu?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/dialog?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/overlay-menu?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/dialog?min';
 halo('overlay-menu');
 halo('dialog');
 

--- a/documents/src/pages/elements/item.md
+++ b/documents/src/pages/elements/item.md
@@ -177,8 +177,8 @@ Custom content can be added using slots. `ef-item` provides bopth `left` and `ri
 ::
 ```javascript
 ::item::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/checkbox?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/checkbox?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('checkbox');
 halo('button');
 ```

--- a/documents/src/pages/elements/number-field.md
+++ b/documents/src/pages/elements/number-field.md
@@ -9,7 +9,7 @@ layout: default
 ::
 ```javascript
 ::number-field::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
 halo('panel');
 const curr1 = document.getElementById('curr1');
 const cf = document.getElementById('cf');

--- a/documents/src/pages/elements/overlay-menu.md
+++ b/documents/src/pages/elements/overlay-menu.md
@@ -10,7 +10,7 @@ layout: default
 ::
 ```javascript
 ::overlay-menu::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 const button = document.getElementById('button');
 const menu = document.getElementById('menu');
@@ -78,7 +78,7 @@ As the overlay menu is designed to support several use cases (multi-selection, t
 ::
 ```javascript
 ::overlay-menu::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 const button = document.getElementById('button');
 const menu = document.getElementById('menu');
@@ -157,7 +157,7 @@ Menu and sub-menus are bound together using the `for` and `id` attributes of `ef
 ::
 ```javascript
 ::overlay-menu::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 const button = document.getElementById('button');
 const menu = document.getElementById('menu');
@@ -237,7 +237,7 @@ If there is not enough space to fit sub-menus, add the `compact` attribute. In t
 ::
 ```javascript
 ::overlay-menu::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 const button = document.getElementById('button');
 const menu = document.getElementById('menu');
@@ -300,7 +300,7 @@ The developer may specify `with-backdrop` together with `no-cancel-on-outside-cl
 ::
 ```javascript
 ::overlay-menu::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 const button = document.getElementById('button');
 const menu = document.getElementById('menu');
@@ -366,7 +366,7 @@ Alternatively, you can set `data` using a [CollectionComposer](./resources/colle
 ::
 ```javascript
 ::overlay-menu::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 const button = document.getElementById('button');
 const menu = document.getElementById('menu');
@@ -456,7 +456,7 @@ The `data` property of the `ef-overlay-menu` use the [OverlayMenuData](https://g
 ::
 ```javascript
 ::overlay-menu::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 const button = document.getElementById('button');
 const menu = document.getElementById('menu');
@@ -551,7 +551,7 @@ menuController.addEventListener('item-trigger', (e) => {
 ::
 ```javascript
 ::overlay-menu::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 const button = document.getElementById('button');
 const menu = document.getElementById('menu');

--- a/documents/src/pages/elements/overlay.md
+++ b/documents/src/pages/elements/overlay.md
@@ -9,7 +9,7 @@ layout: default
 ::
 ```javascript
 ::overlay::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 
 const openButton = document.getElementById('open-overlay');
@@ -83,7 +83,7 @@ By default `ef-overlay` appears at the centre of the window. You can set `positi
 ::
 ```javascript
 ::overlay::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 
 const openButton = document.getElementById('open-overlay');
@@ -156,7 +156,7 @@ Overlay can be attached to an element by setting the `positionTarget` property t
 ::
 ```javascript
 ::overlay::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
 halo('text-field');
 
 const target = document.getElementById('target');
@@ -226,7 +226,7 @@ The first part defines *position*. The optional second part defines *align*. For
 ::
 ```javascript
 ::overlay::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 
 const openButton = document.getElementById('open-overlay');
@@ -306,9 +306,9 @@ You can use `transition-style` to add a transition.
 ::
 ```javascript
 ::overlay::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/select?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/item?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/select?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/item?min';
 halo('button');
 halo('select');
 halo('item');

--- a/documents/src/pages/elements/password-field.md
+++ b/documents/src/pages/elements/password-field.md
@@ -9,7 +9,7 @@ layout: default
 ::
 ```javascript
 ::password-field::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
 halo('panel');
 const pw = document.getElementById('pw');
 const confirmedPw = document.getElementById('confirmedPw');

--- a/documents/src/pages/elements/progress-bar.md
+++ b/documents/src/pages/elements/progress-bar.md
@@ -163,7 +163,7 @@ You may have to add some CSS to your content, to ensure that it looks nice.
 ::
 ```javascript
 ::progress-bar::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/icon?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/icon?min';
 halo('icon');
 ```
 ```css

--- a/documents/src/pages/elements/search-field.md
+++ b/documents/src/pages/elements/search-field.md
@@ -10,7 +10,7 @@ layout: default
 ::
 ```javascript
 ::search-field::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
 halo('panel');
 ```
 ```html

--- a/documents/src/pages/elements/sidebar-layout.md
+++ b/documents/src/pages/elements/sidebar-layout.md
@@ -9,8 +9,8 @@ layout: default
 ::
 ```javascript
 ::sidebar-layout::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/header?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/header?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
 halo('header');
 halo('panel');
 ```
@@ -53,8 +53,8 @@ The header slots can be omitted. Also, the component will automatically provide 
 ::
 ```javascript
 ::sidebar-layout::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/header?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/header?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
 halo('header');
 halo('panel');
 ```
@@ -98,9 +98,9 @@ Menus on header could be implemented by using slots of `ef-header`.
 ::
 ```javascript
 ::sidebar-layout::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/header?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/header?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('header');
 halo('panel');
 halo('button');
@@ -149,9 +149,9 @@ Sidebar can be hidden by adding the `collapsed` attribute. A toggle button to co
 ::
 ```javascript
 ::sidebar-layout::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/header?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/header?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('header');
 halo('panel');
 halo('button');

--- a/documents/src/pages/elements/tab-bar.md
+++ b/documents/src/pages/elements/tab-bar.md
@@ -10,7 +10,7 @@ layout: default
 ::
 ```javascript
 ::tab-bar::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
 halo('panel');
 const tabs = document.getElementById('tabs');
 const title = document.getElementById('title');
@@ -252,7 +252,7 @@ Setting the `vertical` attribute/property to true will change the layout of the 
 ::
 ```javascript
 ::tab-bar::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/tab?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/tab?min';
 halo('tab');
 const tabs = document.getElementById('tabs');
 

--- a/documents/src/pages/elements/text-field.md
+++ b/documents/src/pages/elements/text-field.md
@@ -11,7 +11,7 @@ layout: default
 
 ```javascript
 ::text-field::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
 halo('panel');
 ```
 

--- a/documents/src/pages/elements/tooltip.md
+++ b/documents/src/pages/elements/tooltip.md
@@ -9,7 +9,7 @@ layout: default
 ::
 ```javascript
 ::tooltip::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 ```
 ```html
@@ -63,7 +63,7 @@ To customize the behavior of `ef-tooltip`, use `selector` to specify the CSS sel
 ::
 ```javascript
 ::tooltip::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 ```
 ```html
@@ -193,7 +193,7 @@ Custom content can be added to a tooltip instead of just text.
 ::
 ```javascript
 ::tooltip::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 halo('button');
 ```
 ```html
@@ -368,7 +368,7 @@ Use custom condition to trigger a tooltip only when a condition is met.
 ::
 ```javascript
 ::tooltip::
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
 halo('text-field');
 const input = document.getElementById('amount');
 const tooltip = document.getElementById('amount-tooltip');

--- a/documents/src/pages/start/languages.md
+++ b/documents/src/pages/start/languages.md
@@ -35,7 +35,7 @@ body {
 ```javascript
 import { halo } from '/theme-loader.js';
 halo('panel');
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
 
 document.documentElement.setAttribute('lang', 'ja-JP');
 ```
@@ -65,7 +65,7 @@ body {
 ```javascript
 import { halo } from '/theme-loader.js';
 halo('panel');
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
 
 document.documentElement.setAttribute('lang', 'zh-CN');
 ```

--- a/documents/src/pages/styles/movement-colors.md
+++ b/documents/src/pages/styles/movement-colors.md
@@ -183,9 +183,9 @@ td:nth-child(even) {
 }
 ```
 ```javascript
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button-bar?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button-bar?min';
 import { halo } from '/theme-loader.js';
 halo('panel', 'button', 'button-bar');
 

--- a/documents/src/templates/import-element/ef-accordion.md
+++ b/documents/src/templates/import-element/ef-accordion.md
@@ -3,6 +3,6 @@ type: template
 name: accordion
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/accordion?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/accordion?min';
 import { halo } from '/theme-loader.js';
 halo('accordion');

--- a/documents/src/templates/import-element/ef-appstate-bar.md
+++ b/documents/src/templates/import-element/ef-appstate-bar.md
@@ -3,6 +3,6 @@ type: template
 name: appstate-bar
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/appstate-bar?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/appstate-bar?min';
 import { halo } from '/theme-loader.js';
 halo('appstate-bar');

--- a/documents/src/templates/import-element/ef-autosuggest.md
+++ b/documents/src/templates/import-element/ef-autosuggest.md
@@ -3,6 +3,6 @@ type: template
 name: autosuggest
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/autosuggest?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/autosuggest?min';
 import { halo } from '/theme-loader.js';
 halo('autosuggest');

--- a/documents/src/templates/import-element/ef-button-bar.md
+++ b/documents/src/templates/import-element/ef-button-bar.md
@@ -3,6 +3,6 @@ type: template
 name: button-bar
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button-bar?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button-bar?min';
 import { halo } from '/theme-loader.js';
 halo('button-bar');

--- a/documents/src/templates/import-element/ef-button.md
+++ b/documents/src/templates/import-element/ef-button.md
@@ -3,6 +3,6 @@ type: template
 name: button
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/button?min';
 import { halo } from '/theme-loader.js';
 halo('button');

--- a/documents/src/templates/import-element/ef-calendar.md
+++ b/documents/src/templates/import-element/ef-calendar.md
@@ -3,6 +3,6 @@ type: template
 name: calendar
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/calendar?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/calendar?min';
 import { halo } from '/theme-loader.js';
 halo('calendar');

--- a/documents/src/templates/import-element/ef-canvas.md
+++ b/documents/src/templates/import-element/ef-canvas.md
@@ -3,6 +3,6 @@ type: template
 name: canvas
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/canvas?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/canvas?min';
 import { halo } from '/theme-loader.js';
 halo('canvas');

--- a/documents/src/templates/import-element/ef-card.md
+++ b/documents/src/templates/import-element/ef-card.md
@@ -3,6 +3,6 @@ type: template
 name: card
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/card?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/card?min';
 import { halo } from '/theme-loader.js';
 halo('card');

--- a/documents/src/templates/import-element/ef-chart.md
+++ b/documents/src/templates/import-element/ef-chart.md
@@ -3,6 +3,6 @@ type: template
 name: chart
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/chart?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/chart?min';
 import { halo } from '/theme-loader.js';
 halo('chart');

--- a/documents/src/templates/import-element/ef-checkbox.md
+++ b/documents/src/templates/import-element/ef-checkbox.md
@@ -3,6 +3,6 @@ type: template
 name: checkbox
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/checkbox?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/checkbox?min';
 import { halo } from '/theme-loader.js';
 halo('checkbox');

--- a/documents/src/templates/import-element/ef-clock.md
+++ b/documents/src/templates/import-element/ef-clock.md
@@ -3,6 +3,6 @@ type: template
 name: clock
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/clock?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/clock?min';
 import { halo } from '/theme-loader.js';
 halo('clock');

--- a/documents/src/templates/import-element/ef-collapse.md
+++ b/documents/src/templates/import-element/ef-collapse.md
@@ -3,6 +3,6 @@ type: template
 name: collapse
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/collapse?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/collapse?min';
 import { halo } from '/theme-loader.js';
 halo('collapse');

--- a/documents/src/templates/import-element/ef-color-dialog.md
+++ b/documents/src/templates/import-element/ef-color-dialog.md
@@ -3,6 +3,6 @@ type: template
 name: color-dialog
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/color-dialog?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/color-dialog?min';
 import { halo } from '/theme-loader.js';
 halo('color-dialog');

--- a/documents/src/templates/import-element/ef-color-picker.md
+++ b/documents/src/templates/import-element/ef-color-picker.md
@@ -3,6 +3,6 @@ type: template
 name: color-picker
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/color-picker?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/color-picker?min';
 import { halo } from '/theme-loader.js';
 halo('color-picker');

--- a/documents/src/templates/import-element/ef-combo-box.md
+++ b/documents/src/templates/import-element/ef-combo-box.md
@@ -3,6 +3,6 @@ type: template
 name: combo-box
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/combo-box?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/combo-box?min';
 import { halo } from '/theme-loader.js';
 halo('combo-box');

--- a/documents/src/templates/import-element/ef-counter.md
+++ b/documents/src/templates/import-element/ef-counter.md
@@ -3,6 +3,6 @@ type: template
 name: counter
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/counter?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/counter?min';
 import { halo } from '/theme-loader.js';
 halo('counter');

--- a/documents/src/templates/import-element/ef-datetime-picker.md
+++ b/documents/src/templates/import-element/ef-datetime-picker.md
@@ -3,6 +3,6 @@ type: template
 name: datetime-picker
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/datetime-picker?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/datetime-picker?min';
 import { halo } from '/theme-loader.js';
 halo('datetime-picker');

--- a/documents/src/templates/import-element/ef-dialog.md
+++ b/documents/src/templates/import-element/ef-dialog.md
@@ -3,6 +3,6 @@ type: template
 name: dialog
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/dialog?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/dialog?min';
 import { halo } from '/theme-loader.js';
 halo('dialog');

--- a/documents/src/templates/import-element/ef-email-field.md
+++ b/documents/src/templates/import-element/ef-email-field.md
@@ -3,6 +3,6 @@ type: template
 name: email-field
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/email-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/email-field?min';
 import { halo } from '/theme-loader.js';
 halo('email-field');

--- a/documents/src/templates/import-element/ef-flag.md
+++ b/documents/src/templates/import-element/ef-flag.md
@@ -3,6 +3,6 @@ type: template
 name: flag
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/flag?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/flag?min';
 import { halo } from '/theme-loader.js';
 halo('flag');

--- a/documents/src/templates/import-element/ef-header.md
+++ b/documents/src/templates/import-element/ef-header.md
@@ -3,6 +3,6 @@ type: template
 name: header
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/header?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/header?min';
 import { halo } from '/theme-loader.js';
 halo('header');

--- a/documents/src/templates/import-element/ef-heatmap.md
+++ b/documents/src/templates/import-element/ef-heatmap.md
@@ -3,6 +3,6 @@ type: template
 name: heatmap
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/heatmap?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/heatmap?min';
 import { halo } from '/theme-loader.js';
 halo('heatmap');

--- a/documents/src/templates/import-element/ef-icon.md
+++ b/documents/src/templates/import-element/ef-icon.md
@@ -3,6 +3,6 @@ type: template
 name: icon
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/icon?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/icon?min';
 import { halo } from '/theme-loader.js';
 halo('icon');

--- a/documents/src/templates/import-element/ef-interactive-chart.md
+++ b/documents/src/templates/import-element/ef-interactive-chart.md
@@ -3,6 +3,6 @@ type: template
 name: interactive-chart
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/interactive-chart?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/interactive-chart?min';
 import { halo } from '/theme-loader.js';
 halo('interactive-chart');

--- a/documents/src/templates/import-element/ef-item.md
+++ b/documents/src/templates/import-element/ef-item.md
@@ -3,6 +3,6 @@ type: template
 name: item
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/item?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/item?min';
 import { halo } from '/theme-loader.js';
 halo('item');

--- a/documents/src/templates/import-element/ef-label.md
+++ b/documents/src/templates/import-element/ef-label.md
@@ -3,6 +3,6 @@ type: template
 name: label
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/label?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/label?min';
 import { halo } from '/theme-loader.js';
 halo('label');

--- a/documents/src/templates/import-element/ef-layout.md
+++ b/documents/src/templates/import-element/ef-layout.md
@@ -3,6 +3,6 @@ type: template
 name: layout
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/layout?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/layout?min';
 import { halo } from '/theme-loader.js';
 halo('layout');

--- a/documents/src/templates/import-element/ef-led-gauge.md
+++ b/documents/src/templates/import-element/ef-led-gauge.md
@@ -3,6 +3,6 @@ type: template
 name: led-gauge
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/led-gauge?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/led-gauge?min';
 import { halo } from '/theme-loader.js';
 halo('led-gauge');

--- a/documents/src/templates/import-element/ef-list.md
+++ b/documents/src/templates/import-element/ef-list.md
@@ -3,6 +3,6 @@ type: template
 name: list
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/list?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/list?min';
 import { halo } from '/theme-loader.js';
 halo('list');

--- a/documents/src/templates/import-element/ef-loader.md
+++ b/documents/src/templates/import-element/ef-loader.md
@@ -3,6 +3,6 @@ type: template
 name: loader
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/loader?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/loader?min';
 import { halo } from '/theme-loader.js';
 halo('loader');

--- a/documents/src/templates/import-element/ef-multi-input.md
+++ b/documents/src/templates/import-element/ef-multi-input.md
@@ -3,6 +3,6 @@ type: template
 name: multi-input
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/multi-input?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/multi-input?min';
 import { halo } from '/theme-loader.js';
 halo('multi-input');

--- a/documents/src/templates/import-element/ef-notification.md
+++ b/documents/src/templates/import-element/ef-notification.md
@@ -3,6 +3,6 @@ type: template
 name: notification
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/notification?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/notification?min';
 import { halo } from '/theme-loader.js';
 halo('notification');

--- a/documents/src/templates/import-element/ef-number-field.md
+++ b/documents/src/templates/import-element/ef-number-field.md
@@ -3,6 +3,6 @@ type: template
 name: number-field
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/number-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/number-field?min';
 import { halo } from '/theme-loader.js';
 halo('number-field');

--- a/documents/src/templates/import-element/ef-overlay-menu.md
+++ b/documents/src/templates/import-element/ef-overlay-menu.md
@@ -3,6 +3,6 @@ type: template
 name: overlay-menu
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/overlay-menu?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/overlay-menu?min';
 import { halo } from '/theme-loader.js';
 halo('overlay-menu');

--- a/documents/src/templates/import-element/ef-overlay.md
+++ b/documents/src/templates/import-element/ef-overlay.md
@@ -3,6 +3,6 @@ type: template
 name: overlay
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/overlay?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/overlay?min';
 import { halo } from '/theme-loader.js';
 halo('overlay');

--- a/documents/src/templates/import-element/ef-pagination.md
+++ b/documents/src/templates/import-element/ef-pagination.md
@@ -3,6 +3,6 @@ type: template
 name: pagination
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/pagination?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/pagination?min';
 import { halo } from '/theme-loader.js';
 halo('pagination');

--- a/documents/src/templates/import-element/ef-panel.md
+++ b/documents/src/templates/import-element/ef-panel.md
@@ -3,6 +3,6 @@ type: template
 name: panel
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/panel?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/panel?min';
 import { halo } from '/theme-loader.js';
 halo('panel');

--- a/documents/src/templates/import-element/ef-password-field.md
+++ b/documents/src/templates/import-element/ef-password-field.md
@@ -3,6 +3,6 @@ type: template
 name: password-field
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/password-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/password-field?min';
 import { halo } from '/theme-loader.js';
 halo('password-field');

--- a/documents/src/templates/import-element/ef-pill.md
+++ b/documents/src/templates/import-element/ef-pill.md
@@ -3,6 +3,6 @@ type: template
 name: pill
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/pill?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/pill?min';
 import { halo } from '/theme-loader.js';
 halo('pill');

--- a/documents/src/templates/import-element/ef-progress-bar.md
+++ b/documents/src/templates/import-element/ef-progress-bar.md
@@ -3,6 +3,6 @@ type: template
 name: progress-bar
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/progress-bar?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/progress-bar?min';
 import { halo } from '/theme-loader.js';
 halo('progress-bar');

--- a/documents/src/templates/import-element/ef-radio-button.md
+++ b/documents/src/templates/import-element/ef-radio-button.md
@@ -3,6 +3,6 @@ type: template
 name: radio-button
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/radio-button?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/radio-button?min';
 import { halo } from '/theme-loader.js';
 halo('radio-button');

--- a/documents/src/templates/import-element/ef-rating.md
+++ b/documents/src/templates/import-element/ef-rating.md
@@ -3,6 +3,6 @@ type: template
 name: rating
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/rating?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/rating?min';
 import { halo } from '/theme-loader.js';
 halo('rating');

--- a/documents/src/templates/import-element/ef-search-field.md
+++ b/documents/src/templates/import-element/ef-search-field.md
@@ -3,6 +3,6 @@ type: template
 name: search-field
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/search-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/search-field?min';
 import { halo } from '/theme-loader.js';
 halo('search-field');

--- a/documents/src/templates/import-element/ef-select.md
+++ b/documents/src/templates/import-element/ef-select.md
@@ -3,6 +3,6 @@ type: template
 name: select
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/select?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/select?min';
 import { halo } from '/theme-loader.js';
 halo('select');

--- a/documents/src/templates/import-element/ef-sidebar-layout.md
+++ b/documents/src/templates/import-element/ef-sidebar-layout.md
@@ -3,6 +3,6 @@ type: template
 name: sidebar-layout
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/sidebar-layout?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/sidebar-layout?min';
 import { halo } from '/theme-loader.js';
 halo('sidebar-layout');

--- a/documents/src/templates/import-element/ef-slider.md
+++ b/documents/src/templates/import-element/ef-slider.md
@@ -3,6 +3,6 @@ type: template
 name: slider
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/slider?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/slider?min';
 import { halo } from '/theme-loader.js';
 halo('slider');

--- a/documents/src/templates/import-element/ef-sparkline.md
+++ b/documents/src/templates/import-element/ef-sparkline.md
@@ -3,6 +3,6 @@ type: template
 name: sparkline
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/sparkline?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/sparkline?min';
 import { halo } from '/theme-loader.js';
 halo('sparkline');

--- a/documents/src/templates/import-element/ef-swing-gauge.md
+++ b/documents/src/templates/import-element/ef-swing-gauge.md
@@ -3,6 +3,6 @@ type: template
 name: swing-gauge
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/swing-gauge?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/swing-gauge?min';
 import { halo } from '/theme-loader.js';
 halo('swing-gauge');

--- a/documents/src/templates/import-element/ef-tab-bar.md
+++ b/documents/src/templates/import-element/ef-tab-bar.md
@@ -3,6 +3,6 @@ type: template
 name: tab-bar
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/tab-bar?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/tab-bar?min';
 import { halo } from '/theme-loader.js';
 halo('tab-bar');

--- a/documents/src/templates/import-element/ef-text-field.md
+++ b/documents/src/templates/import-element/ef-text-field.md
@@ -3,6 +3,6 @@ type: template
 name: text-field
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/text-field?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/text-field?min';
 import { halo } from '/theme-loader.js';
 halo('text-field');

--- a/documents/src/templates/import-element/ef-time-picker.md
+++ b/documents/src/templates/import-element/ef-time-picker.md
@@ -3,6 +3,6 @@ type: template
 name: time-picker
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/time-picker?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/time-picker?min';
 import { halo } from '/theme-loader.js';
 halo('time-picker');

--- a/documents/src/templates/import-element/ef-toggle.md
+++ b/documents/src/templates/import-element/ef-toggle.md
@@ -3,6 +3,6 @@ type: template
 name: toggle
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/toggle?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/toggle?min';
 import { halo } from '/theme-loader.js';
 halo('toggle');

--- a/documents/src/templates/import-element/ef-tooltip.md
+++ b/documents/src/templates/import-element/ef-tooltip.md
@@ -3,6 +3,6 @@ type: template
 name: tooltip
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/tooltip?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/tooltip?min';
 import { halo } from '/theme-loader.js';
 halo('tooltip');

--- a/documents/src/templates/import-element/ef-tornado-chart.md
+++ b/documents/src/templates/import-element/ef-tornado-chart.md
@@ -3,6 +3,6 @@ type: template
 name: tornado-chart
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/tornado-chart?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/tornado-chart?min';
 import { halo } from '/theme-loader.js';
 halo('tornado-chart');

--- a/documents/src/templates/import-element/ef-tree-select.md
+++ b/documents/src/templates/import-element/ef-tree-select.md
@@ -3,6 +3,6 @@ type: template
 name: tree-select
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/tree-select?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/tree-select?min';
 import { halo } from '/theme-loader.js';
 halo('tree-select');

--- a/documents/src/templates/import-element/ef-tree.md
+++ b/documents/src/templates/import-element/ef-tree.md
@@ -3,6 +3,6 @@ type: template
 name: tree
 -->
 
-import 'https://cdn.skypack.dev/@refinitiv-ui/elements/tree?min';
+import 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1/tree?min';
 import { halo } from '/theme-loader.js';
 halo('tree');

--- a/documents/src/theme-loader.js
+++ b/documents/src/theme-loader.js
@@ -3,7 +3,7 @@ const themeVariant = document.documentElement.getAttribute('prefers-color-scheme
 const HaloThemePackage = 'https://cdn.skypack.dev/@refinitiv-ui/halo-theme';
 const SolarThemePackage = 'https://cdn.skypack.dev/@refinitiv-ui/solar-theme';
 const CorePackage = 'https://cdn.skypack.dev/@refinitiv-ui/core?min';
-const ElementsPackage = 'https://cdn.skypack.dev/@refinitiv-ui/elements';
+const ElementsPackage = 'https://cdn.skypack.dev/@refinitiv-ui/elements@v6.8.4-next.1';
 
 const ThemePackage = {
   halo: {


### PR DESCRIPTION
Issue:
The document can't use Skypack to load @refinitiv-ui/elements latest version

Workaround:
Temporary point the document to use the elements from version `6.8.4-next.1`

![image](https://github.com/Refinitiv/refinitiv-ui/assets/102957966/5185ad4d-73a2-44d9-a52e-565d5d3a8650)
