### PR TITLE
docs: remove via with using

### DIFF
--- a/documents/src/pages/accessibility.md
+++ b/documents/src/pages/accessibility.md
@@ -57,7 +57,7 @@ When developing your UI, be cognizant of the common keyboard interactions noted 
 Keyboard navigation is best implemented in such a way that it promotes logical rules of orientation and navigation (see figure 2 below).
 
 - Focus usually starts from the top-left of the screen when it first loads.
-- Focus can be followed easily via the use of a visually consistent focus indication.
+- Focus can be followed easily using the use of a visually consistent focus indication.
 - Upon activation of a component, focus can automatically be initiated on a logical starting point. For example, when an Overlay Menu or Overlay is highlighted, focus programmatically moves to the first item.
 - Modal components can restrict the focus to remain within the modal region. 
 - When a control is dismissed, focus should be returned to the triggering element. 

--- a/documents/src/pages/build-element/element-types.md
+++ b/documents/src/pages/build-element/element-types.md
@@ -29,7 +29,7 @@ class MyLogo extends BasicElement {
 
 The control element is used mainly for elements that require user interaction and need to be included in keyboard navigation sequences. A good example of a control element is a button.
 
-- Makes the item reachable via key navigation
+- Makes the item reachable using key navigation
 - Support getter and setter `value` property 
 - Support control states e.g. `disabled` and `readonly` 
 
@@ -44,7 +44,7 @@ class CameraButton extends ControlElement {
 The form field element class is used for control elements that contains **input fields**. This abstract class is extended from Control Elements. It provides additional logic for managing accessibility features and should be used when creating new form field elements. An example of a form field element is Number Input Field
 
 - Adds support for aria tags to be used for accessibility
-- Makes the item reachable via key navigation
+- Makes the item reachable using key navigation
 - Support state validation `error` and `warning`    
 
 ```typescript

--- a/documents/src/pages/build-element/notice-messages.md
+++ b/documents/src/pages/build-element/notice-messages.md
@@ -7,7 +7,7 @@ layout: default
 
 # Notice Messages
 
-When creating elements, it's best to keep things simple and try to reduce any errors that may occur. However, your elements should feedback to developers via console log when necessary.
+When creating elements, it's best to keep things simple and try to reduce any errors that may occur. However, your elements should feedback to developers using console log when necessary.
 
 o> **Tip**:\
 Try to implement flexibility into your element by handling invalid input in a way that least disrupts a user.

--- a/documents/src/pages/elements/appstate-bar.md
+++ b/documents/src/pages/elements/appstate-bar.md
@@ -47,7 +47,7 @@ ef-appstate-bar {
 `ef-appstate-bar` is used to display status or other information at the top of an application. App State Bar comes with pre-defined colors in the theme.
 
 ## Usage
-Styles for App State Bar content can be set using the `state` attribute/property. The App State Bar's heading can be set via the `heading` attribute/property.
+Styles for App State Bar content can be set using the `state` attribute/property. The App State Bar's heading can be set using the `heading` attribute/property.
 
 ```html
 <ef-appstate-bar heading="Heading">

--- a/documents/src/pages/elements/button.md
+++ b/documents/src/pages/elements/button.md
@@ -189,7 +189,7 @@ btn.addEventListener('tap', () => {
 ## Accessibility
 ::a11y-intro::
 
-`ef-button` has been assigned the role of `button` and can have a `pressed` state. Always try to include a text label for a button. Avoid relying solely upon an image or icon to convey the button’s purpose to users. Assistive technology users ascertain the purpose of a button via its accessible name which gets computed from either its visual label, alternative text, or aria-label attribute – so be sure to fill them in accurately. Whenever the button’s visual state changes, the button state programmatically updates to inform assistive technology users of the element’s changed state. 
+`ef-button` has been assigned the role of `button` and can have a `pressed` state. Always try to include a text label for a button. Avoid relying solely upon an image or icon to convey the button’s purpose to users. Assistive technology users ascertain the purpose of a button using its accessible name which gets computed from either its visual label, alternative text, or aria-label attribute – so be sure to fill them in accurately. Whenever the button’s visual state changes, the button state programmatically updates to inform assistive technology users of the element’s changed state. 
 
 `ef-button` handles role and aria value but when using button without any text label, assign `aria-label` as the accessible name.
 

--- a/documents/src/pages/elements/color-dialog.md
+++ b/documents/src/pages/elements/color-dialog.md
@@ -34,7 +34,7 @@ document.getElementById('button').addEventListener('click', () => {
 ```
 ::
 
-`ef-color-dialog` allows users to select any color. You can set the value as a hex color code (short hex is also supported) or as Red/Green/Blue (0 - 255). Users can choose a color directly from a pallete UI or via input boxes in the dialog.
+`ef-color-dialog` allows users to select any color. You can set the value as a hex color code (short hex is also supported) or as Red/Green/Blue (0 - 255). Users can choose a color directly from a pallete UI or using input boxes in the dialog.
 
 ## Usage
 

--- a/documents/src/pages/elements/color-picker.md
+++ b/documents/src/pages/elements/color-picker.md
@@ -35,7 +35,7 @@ ef-color-picker {
 `ef-color-picker` allows users to pick any colours from colour dialog.
 
 ### Basic usage
-You can set an initial value via `value` attribute. The `value` must be a string of hex colour code.
+You can set an initial value using `value` attribute. The `value` must be a string of hex colour code.
 
 ```html
 <ef-color-picker value="#001EFF"></ef-color-picker>

--- a/documents/src/pages/elements/combo-box.md
+++ b/documents/src/pages/elements/combo-box.md
@@ -63,7 +63,7 @@ The `ef-combo-box` uses the [ComboBoxData](https://github.com/Refinitiv/refiniti
 ## Getting value on single and multiple mode
 When an item is selected, the item's `value` will set to Combo Box's `value`.
 
-Value can be preset via `selected` field when set data or by programmatically setting the Combo Box `value` property.
+Value can be preset using `selected` field when set data or by programmatically setting the Combo Box `value` property.
 
 ```javascript
 comboBox.data = [

--- a/documents/src/pages/elements/configuration.md
+++ b/documents/src/pages/elements/configuration.md
@@ -22,7 +22,7 @@ Import it to your project.
 import '@refinitiv-ui/configuration';
 ```
 
-Set context to `ef-configuration` via `config` property. Any EF components in its scope will receive the context and use it accordingly.
+Set context to `ef-configuration` using `config` property. Any EF components in its scope will receive the context and use it accordingly.
 
 ```html
 <ef-configuration id="custom-config">
@@ -47,7 +47,7 @@ customConfig.config = {
 @>Note that context is also cascaded to any EF components within shadow root. For instance, `config.icon.map` will be cascaded to `ef-icon` in shadow root of `ef-button`.
 
 ## Context List
-List of context that can be set to `ef-configuration` via `config` property.
+List of context that can be set to `ef-configuration` using `config` property.
 
 ### Icon Mapping Context
 `ef-icon` element supports the icon map from the configuration. You either define new icon or override data of the existing EF icons on CDN. Value of icon map should be base64 SVG format.

--- a/documents/src/pages/elements/counter.md
+++ b/documents/src/pages/elements/counter.md
@@ -22,7 +22,7 @@ layout: default
 `ef-counter` is a badge component which can be used to show a number of selected items.
 
 ## Usage
-The number that displays on the counter can be set via the `value` attribute/property. If `value` is unset, negative or not a string number, it will display '0'. Any decimal value will be truncated e.g. '9.9' will be converted to '9'.
+The number that displays on the counter can be set using the `value` attribute/property. If `value` is unset, negative or not a string number, it will display '0'. Any decimal value will be truncated e.g. '9.9' will be converted to '9'.
 
 ::
 ```javascript

--- a/documents/src/pages/elements/flag.md
+++ b/documents/src/pages/elements/flag.md
@@ -30,7 +30,7 @@ ef-flag {
 
 ## Usage
 
-You can set a flag's code via the `flag` attribute to display the flag. Alternatively, you can set the url of an svg file or relative path to your svg file using the `src` attribute.
+You can set a flag's code using the `flag` attribute to display the flag. Alternatively, you can set the url of an svg file or relative path to your svg file using the `src` attribute.
 
 ```html
 <ef-flag flag="br"></ef-flag>
@@ -85,7 +85,7 @@ preload(
 ## Accessibility
 ::a11y-intro::
 
-`ef-flag` delegates focus into its internal svg which has native `role="image"`. Assistive technology users ascertain the purpose of the icon via its accessible name.
+`ef-flag` delegates focus into its internal svg which has native `role="image"`. Assistive technology users ascertain the purpose of the icon using its accessible name.
 
 Typically, flag may not be tabbable or focusable. However, if it's required, you can set `tabindex` and use `aria-label` or `title` to add its accessible name.
 

--- a/documents/src/pages/elements/heatmap.md
+++ b/documents/src/pages/elements/heatmap.md
@@ -224,7 +224,7 @@ el.renderCallback = (cell) => { foregroundColor: "#f0f0f0" };
 
 ## Custom cell rendering
 
-Heatmap accepts a custom rendering function via the `renderCallback` property to override `label`, `backgroundColor` and `foregroundColor` for each cell.
+Heatmap accepts a custom rendering function using the `renderCallback` property to override `label`, `backgroundColor` and `foregroundColor` for each cell.
 
 The following cell information is also available:
 

--- a/documents/src/pages/elements/icon.md
+++ b/documents/src/pages/elements/icon.md
@@ -87,7 +87,7 @@ preload(
 ## Accessibility
 ::a11y-intro::
 
-`ef-icon` delegates focus into its internal svg which has native `role="image"`. Assistive technology users ascertain the purpose of the icon via its accessible name.
+`ef-icon` delegates focus into its internal svg which has native `role="image"`. Assistive technology users ascertain the purpose of the icon using its accessible name.
 
 Typically, icon may not be tabbable or focusable. However, if it's required, you can set `tabindex` and use `aria-label` or `title` to add its accessible name.
 

--- a/documents/src/pages/elements/interactive-chart.md
+++ b/documents/src/pages/elements/interactive-chart.md
@@ -74,7 +74,7 @@ ef-interactive-chart {
 ```
 ::
 
-Interactive Chart is a lightweight chart component that allows you to create different use cases for financial chart. The component uses the [lightweight-charts](https://github.com/tradingview/lightweight-charts) library. You can see a demo of different chart types and the APIs of the lightweight chart library via this [documentation](https://www.tradingview.com/lightweight-charts/).
+Interactive Chart is a lightweight chart component that allows you to create different use cases for financial chart. The component uses the [lightweight-charts](https://github.com/tradingview/lightweight-charts) library. You can see a demo of different chart types and the APIs of the lightweight chart library using this [documentation](https://www.tradingview.com/lightweight-charts/).
 
 ## Usage
 Chart can be create by passing the configuration and initial dataset using the `config` property. Interactive chart supports the following chart types. The `value` must be a number.

--- a/documents/src/pages/elements/multi-input.md
+++ b/documents/src/pages/elements/multi-input.md
@@ -56,7 +56,7 @@ catEl.data = cats;
 
 ## Usage
 
-`ef-multi-input` can be created by setting an initial list of pills via `data` property.
+`ef-multi-input` can be created by setting an initial list of pills using `data` property.
 
 ```javascript
 const el = document.querySelector('ef-multi-input');

--- a/documents/src/pages/elements/number-field.md
+++ b/documents/src/pages/elements/number-field.md
@@ -58,7 +58,7 @@ Number field can be used in a similar fashion to the native number input.
 ```
 
 ## Getting value
-Just like the HTML native input, the number field input value is a `string` which can be accessed via the `value` property.
+Just like the HTML native input, the number field input value is a `string` which can be accessed using the `value` property.
 
 ```html
 <ef-number-field id="number-input" placehoder="Total items" value="3"></ef-number-field>

--- a/documents/src/pages/elements/pill.md
+++ b/documents/src/pages/elements/pill.md
@@ -67,7 +67,7 @@ A pill can display a clear button, or a small cross icon, when the `clears` attr
 ## Accessibility
 ::a11y-intro::
 
-`ef-pill` is assigned `role="button"` and can have a `pressed` state. Assistive technology users ascertain the purpose that a pill serves via its accessible name, which is computed from the visual label. States such as `disabled` and `pressed` are programmatically updated to match the element’s visual state.
+`ef-pill` is assigned `role="button"` and can have a `pressed` state. Assistive technology users ascertain the purpose that a pill serves using its accessible name, which is computed from the visual label. States such as `disabled` and `pressed` are programmatically updated to match the element’s visual state.
 
 In some scenarios, pills are used for presenting a short text without any users interaction. For that, pill can be assigned `role="none"` or `role="presentation"`.
 

--- a/documents/src/pages/elements/swing-gauge.md
+++ b/documents/src/pages/elements/swing-gauge.md
@@ -132,7 +132,7 @@ ef-swing-gauge {
 ```
 
 ## Customize value format
-The value that shows on Swing Gauge can be custom via the `valueFormatter` property. The first parameter will be the percentage that calculates by the input value. The second parameter will be the raw value of your input.
+The value that shows on Swing Gauge can be custom using the `valueFormatter` property. The first parameter will be the percentage that calculates by the input value. The second parameter will be the raw value of your input.
 
 ::
 ```javascript

--- a/documents/src/pages/elements/tab-bar.md
+++ b/documents/src/pages/elements/tab-bar.md
@@ -332,9 +332,9 @@ When users changed the active tab, Tab Bar will fire `value-changed` event with 
 
 `ef-tab-bar` is assigned the `role="tablist"`. Since the Tab Bar serves as a container for Tab elements, it does not itself receive keyboard focus. As a best practice to accommodate accessible users, try to minimize the number of tabs that they need to navigate within a Tab Bar. Note that the Tab Bar should not be used in place of the Button Bar, which is intended to group buttons that allow users to take actions – maintaining this distinction will help accessible users understand the purpose of the component.
 
-`ef-tab-bar` provides role and keyboard navigation for users to navigate within the tab bar. You should provide `aria-label` on `ef-tab-bar` and `ef-tab` for users to understand the purpose of the tab via assistive technology.
+`ef-tab-bar` provides role and keyboard navigation for users to navigate within the tab bar. You should provide `aria-label` on `ef-tab-bar` and `ef-tab` for users to understand the purpose of the tab using assistive technology.
 
-In case you use `ef-tab-bar` with clears feature, you could assign more descriptive text in `aria-label` of `ef-tab-bar` or assign `aria-description` to each `ef-tab`, thus, users are aware that the tab is able to delete via Delete key.
+In case you use `ef-tab-bar` with clears feature, you could assign more descriptive text in `aria-label` of `ef-tab-bar` or assign `aria-description` to each `ef-tab`, thus, users are aware that the tab is able to delete using Delete key.
 
 ```html
 <ef-tab-bar aria-label="News categories. Use delete key to delete tab">


### PR DESCRIPTION
Re suggestion from Derek.

"Our guidance is not to use latin words or phrases such as 'via'. So, instead of 'Set context to ef-configuration via config property' we should write something like 'Set context to ef-configuration using config property'."