### PR TITLE
🔐 Use HTTP2 with Web Test Runner

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -24,6 +24,10 @@ inputs:
     required: false
     # Default value 3 is OK for every browsers except Safari need to be one to make it stable
     default: 1
+  https:
+    description: 'Enable HTTPS on the test server'
+    required: false
+    default: 'true'
 runs:
   using: "composite"
   steps:
@@ -41,9 +45,13 @@ runs:
       run: |
         [[ "${{ inputs.mode }}" == "all" ]] && export NX_SKIP_NX_CACHE=true && unset NX_BASE
         npm run test:${{ inputs.mode }} -- --browserstack ${{ inputs.browsers }} --includeCoverage=${{ inputs.coverage }} --output=minimal --parallel=${{ inputs.parallel }}
+      env:
+        TEST_HTTPS: ${{ inputs.https }}
 
     - name: Test Package or Element
       if: ${{ inputs.target != '' && inputs.target != 'all' }}
       shell: bash
       run: |
         npm run test ${{ inputs.target }} -- --browserstack ${{ inputs.browsers }} --includeCoverage=${{ inputs.coverage }}
+      env:
+        TEST_HTTPS: ${{ inputs.https }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ env:
   BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
   BROWSERSTACK_BUILD: "Test ${{ github.run_number }}"
   BROWSERSTACK_LATEST_BROWSERS_LAUNCHER: "Playwright"
+  TEST_SSL_CERT: ${{ secrets.TEST_SSL_CERT }}
+  TEST_SSL_KEY: ${{ secrets.TEST_SSL_KEY }}
 
 jobs:
   build:

--- a/.github/workflows/test_nightly.yml
+++ b/.github/workflows/test_nightly.yml
@@ -8,6 +8,8 @@ env:
   BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
   BROWSERSTACK_BUILD: "Nightly Test ${{ github.run_number }}"
   BROWSERSTACK_LATEST_BROWSERS_LAUNCHER: "Playwright"
+  TEST_SSL_CERT: ${{ secrets.TEST_SSL_CERT }}
+  TEST_SSL_KEY: ${{ secrets.TEST_SSL_KEY }}
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -185,6 +187,7 @@ jobs:
         with:
           browsers: 'safari_minus2'
           mode: 'all'
+          https: 'false'
 #endregion
 
 #region ios
@@ -203,6 +206,7 @@ jobs:
         with:
           browsers: 'ios'
           mode: 'all'
+          https: 'false'
 
   test-ios-minus-1:
     name: "test ios minus 1"
@@ -219,6 +223,7 @@ jobs:
         with:
           browsers: 'ios_minus1'
           mode: 'all'
+          https: 'false'
 
   test-ios-minus-2:
     name: "test ios minus 2"
@@ -235,6 +240,7 @@ jobs:
         with:
           browsers: 'ios_minus2'
           mode: 'all'
+          https: 'false'
 #endregion
 
 #region android

--- a/.github/workflows/test_nightly.yml
+++ b/.github/workflows/test_nightly.yml
@@ -1,7 +1,7 @@
-name: Nightly Test v6
+name: Nightly Test v7
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 20 * * *'
 env:
   CI: "true"
   BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ custom-elements.json
 ## editors
 /.idea
 /.vscode
+
+# Certificates
+certs

--- a/scripts/tests/run.mjs
+++ b/scripts/tests/run.mjs
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 import { env } from 'node:process';
-import process from 'node:process';
 import path from 'node:path';
 import yargs from 'yargs/yargs';
 import { hideBin } from 'yargs/helpers';
 import { browserstackLauncher } from '@web/test-runner-browserstack';
 import { summaryReporter } from "@web/test-runner";
-import { PACKAGES_ROOT, error, info } from '../helpers/esm.mjs';
+import { PACKAGES_ROOT, ROOT, error, info, success } from '../helpers/esm.mjs';
 import { BrowserStack } from '../../browsers.config.mjs';
 import wtrConfig from '../../web-test-runner.config.mjs';
 import { ELEMENTS_ROOT, getElements, checkElement } from '../../packages/elements/scripts/helpers/index.mjs';
 import { useTestOptions } from './cli-options.mjs';
 import { startTestRunner, startQueueTestRunner } from './runner.mjs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 
 // Create CLI
 const cli = yargs(hideBin(process.argv))
@@ -40,7 +40,7 @@ const target = argv._[0];
 const testTarget = getElements().includes(target) ? target : packageName;
 
 // Merge the base config and the config option from CLI
-const config = {
+let config = {
   ...wtrConfig,
   files: [path.join(basePath, '/__test__/**/*.test.js')],
   watch,
@@ -49,6 +49,29 @@ const config = {
     include: [`**/${packageName}/lib/**/*.js`],
   }
 };
+
+// Use HTTP2 (Safari browsers does not work with Web Test Runner)
+if (env.TEST_HTTPS === 'true') {
+  // Create paths
+  const certsPath = path.join(ROOT , 'certs');
+  const sslCert = path.join(certsPath , 'test-cert.pem');
+  const sslKey = path.join(certsPath , 'test-key.pem');
+
+  // Create certs directory, cert and key files
+  if (!existsSync(certsPath)) mkdirSync(certsPath);
+  if (!existsSync(sslCert) && env.TEST_SSL_CERT) writeFileSync(sslCert, env.TEST_SSL_CERT);
+  if (!existsSync(sslKey) && env.TEST_SSL_KEY) writeFileSync(sslKey, env.TEST_SSL_KEY);
+
+  success('Enable HTTPS with HTTP2');
+  // Setup HTTP2 into Web Test Runner config
+  config = {
+    ...config,
+    protocol: 'https:',
+    http2: true,
+    sslKey,
+    sslCert
+  };
+}
 
 // Handle outputs
 if (argv.output === 'full') {
@@ -66,6 +89,7 @@ if (useBrowserStack) {
     'browserstack.user': env.BROWSERSTACK_USERNAME,
     'browserstack.key': env.BROWSERSTACK_ACCESS_KEY,
     'browserstack.idleTimeout': 1800,
+    acceptInsecureCerts: true,
     project: env.BROWSERSTACK_PROJECT_NAME || 'Refinitiv UI',
     name: testTarget,
     build: `build ${env.BROWSERSTACK_BUILD || 'unknown'}`

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -37,16 +37,30 @@ export default {
   ],
   concurrentBrowsers: 3,
   browsers: [
-    playwrightLauncher({ product: 'chromium' }, {
-      headless: true,
-      args: [
-        '--disable-setuid-sandbox',
-        '--disable-extensions'
-      ]
+    playwrightLauncher({
+      product: 'chromium',
+      createBrowserContext: ({browser}) => browser.newContext({ignoreHTTPSErrors: true}),
+      launchOptions: {
+        headless: true,
+        args: ['--incognito', '--allow-insecure-localhost'],
+      }
     }),
-    playwrightLauncher({ product: 'firefox' }, { headless: true }),
-    playwrightLauncher({ product: 'webkit' }, { headless: true }),
+    playwrightLauncher({
+      product: 'firefox',
+      createBrowserContext: ({browser}) => browser.newContext({ignoreHTTPSErrors: true}),
+      launchOptions: {
+        headless: true
+      }
+    }),
+    playwrightLauncher({
+      product: 'webkit',
+      createBrowserContext: ({browser}) => browser.newContext({ignoreHTTPSErrors: true}),
+      launchOptions: {
+        headless: true
+      }
+    }),
   ],
+
   // in a monorepo you need to set set the root dir to resolve modules
   rootDir: ROOT,
   browserStartTimeout: 600000, // 10 minutes

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -41,23 +41,16 @@ export default {
       product: 'chromium',
       createBrowserContext: ({browser}) => browser.newContext({ignoreHTTPSErrors: true}),
       launchOptions: {
-        headless: true,
         args: ['--incognito', '--allow-insecure-localhost'],
       }
     }),
     playwrightLauncher({
       product: 'firefox',
-      createBrowserContext: ({browser}) => browser.newContext({ignoreHTTPSErrors: true}),
-      launchOptions: {
-        headless: true
-      }
+      createBrowserContext: ({browser}) => browser.newContext({ignoreHTTPSErrors: true})
     }),
     playwrightLauncher({
       product: 'webkit',
-      createBrowserContext: ({browser}) => browser.newContext({ignoreHTTPSErrors: true}),
-      launchOptions: {
-        headless: true
-      }
+      createBrowserContext: ({browser}) => browser.newContext({ignoreHTTPSErrors: true})
     }),
   ],
 


### PR DESCRIPTION
## Description

🔐 Enable HTTP2 in Web Test Runner to improve performance and stability when running on BrowserStack or Playwright.

## Type of change

- [ ] Refactor (improves code without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
