### PR TITLE
fix(number-field): fix Floating point Division on validate method

### DIFF
--- a/packages/elements/src/number-field/__test__/number-field.validity.test.js
+++ b/packages/elements/src/number-field/__test__/number-field.validity.test.js
@@ -1,4 +1,4 @@
-import { fixture, expect } from '@refinitiv-ui/test-helpers';
+import { fixture, expect, elementUpdated } from '@refinitiv-ui/test-helpers';
 
 import '@refinitiv-ui/elements/number-field';
 import '@refinitiv-ui/elemental-theme/light/ef-number-field';
@@ -22,5 +22,15 @@ describe('number-field/Validity', () => {
       const el = await fixture('<ef-number-field min="1" max="5" value="4.5"></ef-number-field>');
       expect(el.checkValidity()).to.be.equal(false);
     });
+  });
+});
+
+describe('Check Floating point', function () {
+  // Test Floating point precision issue that results approximation of real number. e.g. 1111111/0.00001 should equal to 111111100000. 
+  it('Input remains valid upon value update with a step of float value', async function () {
+    const el = await fixture('<ef-number-field step="0.00001" value="111111"></ef-number-field>');
+    el.value="1111111";
+    await elementUpdated(el);
+    expect(el.checkValidity()).to.be.equal(true);
   });
 });

--- a/packages/elements/src/number-field/__test__/number-field.validity.test.js
+++ b/packages/elements/src/number-field/__test__/number-field.validity.test.js
@@ -28,7 +28,7 @@ describe('number-field/Validity', () => {
 describe('Check Floating point', function () {
   // Test Floating point precision issue that results approximation of real number. e.g. 1111111/0.00001 should equal to 111111100000. 
   it('Input remains valid upon value update with a step of float value', async function () {
-    const el = await fixture('<ef-number-field step="0.00001" value="111111"></ef-number-field>');
+    const el = await fixture('<ef-number-field step="0.00001"></ef-number-field>');
     el.value="1111111";
     await elementUpdated(el);
     expect(el.checkValidity()).to.be.equal(true);

--- a/packages/elements/src/number-field/__test__/number-field.validity.test.js
+++ b/packages/elements/src/number-field/__test__/number-field.validity.test.js
@@ -27,10 +27,18 @@ describe('number-field/Validity', () => {
 
 describe('Check Floating point', function () {
   // Test Floating point precision issue that results approximation of real number. e.g. 1111111/0.00001 should equal to 111111100000. 
-  it('Input remains valid upon value update with a step of float value', async function () {
-    const el = await fixture('<ef-number-field step="0.00001"></ef-number-field>');
-    el.value="1111111";
-    await elementUpdated(el);
-    expect(el.checkValidity()).to.be.equal(true);
+  describe('Input remains valid upon value update with a step of float value', function () {
+    it('step = 0.00001 and value = 1111111', async function () {
+      const el = await fixture('<ef-number-field step="0.00001"></ef-number-field>');
+      el.value="1111111";
+      await elementUpdated(el);
+      expect(el.checkValidity()).to.be.equal(true);
+    });
+    it('step = 0.14 and value = 7', async function () {
+      const el = await fixture('<ef-number-field step="0.14"></ef-number-field>');
+      el.value="7";
+      await elementUpdated(el);
+      expect(el.checkValidity()).to.be.equal(true);
+    });
   });
 });

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -540,7 +540,7 @@ export class NumberField extends FormFieldElement {
   private getPrecision (number: number): number {
     const getDecimalPrecision = (number: string | number): number => {
       const [wholeNumber, decimalNumber] = number.toString().split('.');
-      return (whole.length ?? 0) + (part?.length ?? 0);
+      return (wholeNumber.length ?? 0) + (decimalNumber?.length ?? 0);
     };
 
     const numberString = number.toString();

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -538,7 +538,7 @@ export class NumberField extends FormFieldElement {
    * @returns precision number
    */
   private getPrecision (number: number): number {
-    const getDecimalPrecision = (number: string | number): number => {
+    const getDecimalPrecision = (number: string): number => {
       const [wholeNumber, decimalNumber] = number.toString().split('.');
       return (wholeNumber.length ?? 0) + (decimalNumber?.length ?? 0);
     };

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -533,6 +533,29 @@ export class NumberField extends FormFieldElement {
   }
 
   /**
+   * Count precision number
+   * @param number value to count
+   * @returns precision number
+   */
+  private getPrecision (number: number): number {
+    const getDecimalPrecision = (number: string | number): number => {
+      const [whole, part] = number.toString().split('.');
+      return (whole.length ?? 0) + (part?.length ?? 0);
+    };
+
+    const numberString = number.toString();
+
+    // Check if the number is in exponential notation.
+    if (numberString.includes('e')) {
+      const [mantissa, exponent] = numberString.split('e');
+      const precision = getDecimalPrecision(mantissa) + Math.abs(Number(exponent));
+      return precision;
+    }
+
+    return getDecimalPrecision(numberString);
+  }
+  
+  /**
    * Check if value subtracted from the step base is not an integral multiple of the allowed value step
    * @param value value to check
    * @returns true if value is integral
@@ -542,7 +565,12 @@ export class NumberField extends FormFieldElement {
       return true;
     }
     const decimals = Math.max(this.getDecimalPlace(value), this.stepDecimals);
-    const division = (this.stepBase - value) / this.getAllowedValueStep();
+    const dividend = this.stepBase - value;
+    const divisor = this.getAllowedValueStep();
+    // calculate precision to prevent Floating point precision issue.
+    // e.g. 1111111/0.00001 would not result in 111111100000 as expected.
+    const precision = this.getPrecision(dividend) + this.getPrecision(divisor);
+    const division = parseFloat((dividend / divisor).toPrecision(precision));
     const number = decimals ? this.toFixedNumber(division, decimals) : division;
 
     // (2 - 1.01) % 0.33 needs to give 0. So we cannot use % directly as it is intended for integers

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -539,7 +539,7 @@ export class NumberField extends FormFieldElement {
    */
   private getPrecision (number: number): number {
     const getDecimalPrecision = (number: string | number): number => {
-      const [whole, part] = number.toString().split('.');
+      const [wholeNumber, decimalNumber] = number.toString().split('.');
       return (whole.length ?? 0) + (part?.length ?? 0);
     };
 

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -539,7 +539,7 @@ export class NumberField extends FormFieldElement {
    */
   private getPrecision (number: number): number {
     const getDecimalPrecision = (number: string): number => {
-      const [wholeNumber, decimalNumber] = number.toString().split('.');
+      const [wholeNumber, decimalNumber] = number.split('.');
       return (wholeNumber.length ?? 0) + (decimalNumber?.length ?? 0);
     };
 


### PR DESCRIPTION
## Description

There is a red border around the input for valid numbers.

**Steps to replicate:**
1. Open https://elf.int.refinitiv.com/elements/coral-number-field.html page and find sandbox with element like this:
<coral-number-field no-spiner step="0.00001"></coral-number-field>
2. Enter a number to the input filed, like 111 then blur(click somewhere else) the input. Then repeat the previous step: 111111 and blur.

Fixes # ([STG-457](https://jira.refinitiv.com/browse/STG-457))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
