### PR TITLE
fix: fix theme-extractor not work on Windows

### DIFF
--- a/scripts/release/theme-extractor.js
+++ b/scripts/release/theme-extractor.js
@@ -6,13 +6,13 @@ const yargs  = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers')
 
 const { log, errorHandler, success, ROOT } = require('../helpers/index.js');
-const { ELEMENT_SOURCE, ELEMENT_DIST, getElementList, getElementTagName } = require('./util.js');
+const { ELEMENT_SOURCE, ELEMENT_DIST, getElementList, getElementTagName, normalizePathSeparators } = require('./util.js');
 
 // Element package scope
 const PACKAGE_NAME = '@refinitiv-ui/elements';
 
 // Where to look for theme files
-const THEME_SOURCE = `${ROOT}/node_modules/${PACKAGE_NAME.split('/')[0]}/`;
+const THEME_SOURCE = normalizePathSeparators(`${ROOT}/node_modules/${PACKAGE_NAME.split('/')[0]}/`);
 
 // Post-fix of theme name
 const THEME_POSTFIX = '-theme';
@@ -78,7 +78,7 @@ const createDependencyMap = async () => {
     for (let j = 0; j < group.elements.length; j++) {
       // Assuming all themes have the same set of dependency
       const themeRepositoryName = THEMES[0] + THEME_POSTFIX;
-      const themesFound = await fg(`${path.join(THEME_SOURCE, themeRepositoryName)}/**/${group.elements[j]}.js`);
+      const themesFound = await fg(normalizePathSeparators(`${path.join(THEME_SOURCE, themeRepositoryName)}/**/${group.elements[j]}.js`));
 
       for (const theme of themesFound) {
         dependencies = dependencies
@@ -126,7 +126,7 @@ const getThemes = async (elements) => {
   let themes = [];
   for (const theme of THEMES) {
     const themeRepositoryName = theme + THEME_POSTFIX;
-    themes = themes.concat(await fg(`${path.join(THEME_SOURCE, themeRepositoryName)}/**/${elements[0]}.js`));
+    themes = themes.concat(await fg(normalizePathSeparators(`${path.join(THEME_SOURCE, themeRepositoryName)}/**/${elements[0]}.js`)));
   }
 
   return themes;
@@ -170,10 +170,10 @@ const handler = async () => {
        * Themes entrypoint
        * @example lib/appstate-bar/themes/halo/light/index.js
        */
-      let entrypoint = path.join(ELEMENT_DIST, dir, THEMES_DIRECTORY, variantPath);
+      let entrypoint = normalizePathSeparators(path.join(ELEMENT_DIST, dir, THEMES_DIRECTORY, variantPath));
 
       if (src) {
-        entrypoint = path.join(src, entrypoint);
+        entrypoint = normalizePathSeparators(path.join(src, entrypoint));
       }
 
       // Prepare folders structure
@@ -191,7 +191,7 @@ const handler = async () => {
         // Strip element prefix
         const dep = dependency.replace(`${dependency.split('-')[0]}-`, '');
         const variant = path.dirname(variantPath);
-        const dependencyImport = `import '${path.join(PACKAGE_NAME, dep, THEMES_DIRECTORY, variant)}';\n`;
+        const dependencyImport = `import '${normalizePathSeparators(path.join(PACKAGE_NAME, dep, THEMES_DIRECTORY, variant))}';\n`;
 
         // Clean up file
         if (fs.existsSync(entrypoint)) {

--- a/scripts/release/util.js
+++ b/scripts/release/util.js
@@ -28,6 +28,9 @@ const getElementTagName = (path) => {
 // This will help to detect if the JavaScript file is an element or not
 const DECORATE_SYNTAX = '@customElement';
 
+// Helper function to convert path separators
+const normalizePathSeparators = (filePath) => filePath.replace(/\\/g, '/');
+
 /**
  * Get list of element file path which contain element defining syntax
  * @param {string} directory directory's name
@@ -35,7 +38,7 @@ const DECORATE_SYNTAX = '@customElement';
  */
 const getElementList = async (directory) => {
   // All ts files in source folder
-  const files = await fg([`${directory}/**/*.ts`], { unique: true });
+  const files = await fg([normalizePathSeparators(`${directory}/**/*.ts`)], { unique: true });
 
   // Filter out incompatible elements
   return files
@@ -51,5 +54,6 @@ module.exports = {
   ELEMENT_PREFIX,
   PACKAGE_ROOT,
   getElementTagName,
-  getElementList
+  getElementList,
+  normalizePathSeparators
 };


### PR DESCRIPTION
## Description

- Enable Windows users to run theme-extractor. Currently it works for mac user, but failed on Window.
- Same as to this pr https://github.com/Refinitiv/refinitiv-ui/pull/711 that implements on v7.
- Merge to **replace-skypack** branch

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
