### PR TITLE
docs(flag,icon): remove src usage from docs and code block

### DIFF
--- a/documents/src/pages/elements/flag.md
+++ b/documents/src/pages/elements/flag.md
@@ -21,8 +21,8 @@ ef-flag {
 <ef-flag flag="gb"></ef-flag>
 <ef-flag flag="jp"></ef-flag>
 <ef-flag flag="th"></ef-flag>
-<ef-flag src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/bo.svg"></ef-flag>
-<ef-flag src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/pe.svg"></ef-flag>
+<ef-flag flag="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/bo.svg"></ef-flag>
+<ef-flag flag="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/pe.svg"></ef-flag>
 ```
 ::
 
@@ -30,14 +30,14 @@ ef-flag {
 
 ## Usage
 
-You can set a flag's code using the `flag` attribute to display the flag. Alternatively, you can set the url of an svg file or relative path to your svg file using the `src` attribute.
+You can set a flag's code using the `flag` attribute to display the flag. Alternatively, you can set the url of an svg file or relative path to your svg file using the `flag` attribute.
 
 ```html
 <ef-flag flag="br"></ef-flag>
 <ef-flag flag="ar"></ef-flag>
 <ef-flag flag="co"></ef-flag>
-<ef-flag src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/bo.svg"></ef-flag>
-<ef-flag src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/pe.svg"></ef-flag>
+<ef-flag flag="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/bo.svg"></ef-flag>
+<ef-flag flag="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/flags/pe.svg"></ef-flag>
 ```
 
 ## Changing size

--- a/documents/src/pages/elements/icon.md
+++ b/documents/src/pages/elements/icon.md
@@ -21,23 +21,23 @@ ef-icon {
 <ef-icon icon="search"></ef-icon>
 <ef-icon icon="word"></ef-icon>
 <ef-icon icon="excel"></ef-icon>
-<ef-icon id="powerpoint" src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/buzz.svg"></ef-icon>
-<ef-icon id="pdf" src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/chart-area.svg"></ef-icon>
+<ef-icon id="powerpoint" icon="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/buzz.svg"></ef-icon>
+<ef-icon id="pdf" icon="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/chart-area.svg"></ef-icon>
 ```
 ::
 
 Icons are provided as part of a theme. Icons also support pointing to urls of svg files. The size and coloring of icons can be changed using standard CSS.
 
 ## Usage
-You can set an icon's name using the `ef-icon` attribute. Alternatively, you can set the url of an svg file or relative path to your svg file using the `src` attribute.
+You can set an icon's name using the `icon` attribute. Alternatively, you can set the url of an svg file or relative path to your svg file using the `icon` attribute.
 
 ```html
 <ef-icon icon="tick"></ef-icon>
 <ef-icon icon="search"></ef-icon>
 <ef-icon icon="save"></ef-icon>
-<ef-icon id="filter" src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/filter.svg"></ef-icon>
-<ef-icon id="favorites" src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/favorites.svg"></ef-icon>
-<ef-icon id="help" src="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/help.svg"></ef-icon>
+<ef-icon id="filter" icon="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/filter.svg"></ef-icon>
+<ef-icon id="favorites" icon="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/favorites.svg"></ef-icon>
+<ef-icon id="help" icon="https://cdn.refinitiv.com/public/libs/elf/assets/elf-theme-halo/resources/icons/help.svg"></ef-icon>
 ```
 
 

--- a/packages/elements/src/flag/index.ts
+++ b/packages/elements/src/flag/index.ts
@@ -77,7 +77,7 @@ export class Flag extends BasicElement {
 
   private _src: string | null = null;
   /**
-   * Src location of a svg flag.
+   * Src location of an svg flag.
    * @example https://cdn.io/flags/gb.svg
    * @ignore
    * @default null

--- a/packages/elements/src/flag/index.ts
+++ b/packages/elements/src/flag/index.ts
@@ -17,13 +17,6 @@ export { preload } from './utils/FlagLoader.js';
 
 const EmptyTemplate = svg``;
 
-/**
- * Provides a collection of flags.
- *
- * @attr {string | null} src - Src location of a svg flag.
- * @prop {string | null} src - Src location of a svg flag
- *
- */
 @customElement('ef-flag')
 export class Flag extends BasicElement {
 
@@ -84,14 +77,20 @@ export class Flag extends BasicElement {
 
   private _src: string | null = null;
   /**
-   * Src location of an svg flag.
+   * Src location of a svg flag.
    * @example https://cdn.io/flags/gb.svg
+   * @ignore
    * @default null
    */
   @property({ type: String })
   public get src (): string | null {
     return this._src;
   }
+  /**
+   * @param value - location of a svg flag.
+   * @ignore
+   * @default null
+   */
   public set src (value: string | null) {
     if (this.src !== value) {
       this._src = value;

--- a/packages/elements/src/flag/index.ts
+++ b/packages/elements/src/flag/index.ts
@@ -87,7 +87,7 @@ export class Flag extends BasicElement {
     return this._src;
   }
   /**
-   * @param value - location of a svg flag.
+   * @param value - location of an svg flag.
    * @ignore
    * @default null
    */

--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -93,7 +93,7 @@ export class Icon extends BasicElement {
 
   private _src: string | null = null;
   /**
-   * Src location of a svg icon.
+   * Src location of an svg icon.
    * @example https://cdn.io/icons/heart.svg
    * @ignore
    * @default null

--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -93,15 +93,20 @@ export class Icon extends BasicElement {
 
   private _src: string | null = null;
   /**
-   * Src location of an svg icon.
+   * Src location of a svg icon.
    * @example https://cdn.io/icons/heart.svg
-   * @deprecated Use `icon` instead
+   * @ignore
    * @default null
    */
   @property({ type: String })
   public get src (): string | null {
     return this._src;
   }
+  /**
+   * @param value - location of a svg icon.
+   * @ignore
+   * @default null
+   */
   public set src (value: string | null) {
     if (this.src !== value) {
       this._src = value;

--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -103,7 +103,7 @@ export class Icon extends BasicElement {
     return this._src;
   }
   /**
-   * @param value - location of a svg icon.
+   * @param value - location of an svg icon.
    * @ignore
    * @default null
    */


### PR DESCRIPTION
## Description
Remove src usage from document of ef-icon and ef-flag

## Type of change

- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
