### PR TITLE
chore(icon): remove preload deprecated notice

### DIFF
--- a/packages/elements/src/icon/utils/IconLoader.ts
+++ b/packages/elements/src/icon/utils/IconLoader.ts
@@ -1,5 +1,4 @@
 import { SVGLoader } from '@refinitiv-ui/utils/loader.js';
-import { DeprecationNotice } from '@refinitiv-ui/core';
 
 /**
  * Caches and provides icon SVGs, Loaded either by name from CDN or directly by URL.
@@ -12,13 +11,6 @@ const iconLoaderInstance = new IconLoader();
 export { iconLoaderInstance as IconLoader };
 
 /**
-   * Deprecation notice displays a warning message
-   * when deprecated features are used.
-  */
-const deprecationNotice = new DeprecationNotice('Icon `preload()` is deprecated.');
-
-
-/**
  * @deprecated Icon `preload()` is deprecated.
  * Helper function to preload set of icons.
  * It could help to reduce icon loading delay when ef-icon has a known set of icons that it can use.
@@ -27,6 +19,5 @@ const deprecationNotice = new DeprecationNotice('Icon `preload()` is deprecated.
  * @returns Array of promises, which will be resolved with SVG bodies.
  */
 export const preload = (...attrs: string[]): Promise<string | undefined>[] => {
-  deprecationNotice.once();
   return attrs.map(icon => iconLoaderInstance.loadSVG(icon));
 };

--- a/packages/elements/src/icon/utils/IconLoader.ts
+++ b/packages/elements/src/icon/utils/IconLoader.ts
@@ -11,7 +11,6 @@ const iconLoaderInstance = new IconLoader();
 export { iconLoaderInstance as IconLoader };
 
 /**
- * @deprecated Icon `preload()` is deprecated.
  * Helper function to preload set of icons.
  * It could help to reduce icon loading delay when ef-icon has a known set of icons that it can use.
  * @param attrs - list of arguments, representing icons.


### PR DESCRIPTION
## Description

Remove preload deprecated notice, because preload is used by internal elements
