### PR TITLE
fix(number-field): fix Floating point Division on validate method

### DIFF
--- a/packages/elements/src/number-field/__test__/number-field.validity.test.js
+++ b/packages/elements/src/number-field/__test__/number-field.validity.test.js
@@ -34,6 +34,12 @@ describe('Check Floating point', function () {
       await elementUpdated(el);
       expect(el.checkValidity()).to.be.equal(true);
     });
+    it('step = 0.00001 and value = 11111111111', async function () {
+      const el = await fixture('<ef-number-field step="0.00001"></ef-number-field>');
+      el.value="11111111111";
+      await elementUpdated(el);
+      expect(el.checkValidity()).to.be.equal(true);
+    });
     it('step = 0.14 and value = 7', async function () {
       const el = await fixture('<ef-number-field step="0.14"></ef-number-field>');
       el.value="7";

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -540,7 +540,16 @@ export class NumberField extends FormFieldElement {
   private getPrecision (number: number): number {
     const getDecimalPrecision = (number: string): number => {
       const [wholeNumber, decimalNumber] = number.split('.');
-      return (wholeNumber.length ?? 0) + (decimalNumber?.length ?? 0);
+      let wholeLength = wholeNumber.length ?? 0;
+      // doesn't count +- operation
+      if (wholeNumber.indexOf('-') > -1 || wholeNumber.indexOf('+') > -1) {
+        wholeLength -= 1;
+      }
+      // 0 should not count for precision
+      if (wholeNumber === '0') {
+        wholeLength = 0;
+      }
+      return wholeLength + (decimalNumber?.length ?? 0);
     };
 
     const numberString = number.toString();


### PR DESCRIPTION
## Description

User found that https://github.com/Refinitiv/refinitiv-ui/pull/757 still have a bug.

There is a red border around the input for valid numbers.

**Steps to replicate:**
1. <coral-number-field step="0.00001"></coral-number-field>
2. Enter a number to the input filed, like 1111111111 or 11111111111.

Fixes # ([STG-457](https://jira.refinitiv.com/browse/STG-457))


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
