### PR TITLE
fix(ci): add dist-tag v6-latest

### DIFF
--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -49,7 +49,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Publish to NPM
-        run: npx lerna publish from-git --yes
+        run: npx lerna publish from-git --yes --dist-tag v6-latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/documents/src/index.md
+++ b/documents/src/index.md
@@ -7,7 +7,7 @@ layout: default
 -->
 
 =[ef_major_version]: 6
-=[npm_dist_tag]: latest
+=[npm_dist_tag]: v6-latest
 # Introduction
 
 o> This is the documentation for **Element Framework v%ef_major_version%**.\


### PR DESCRIPTION
## Description

[ui.refinitiv.com/v6](ui.refinitiv.com/v6) current v6 doc shows wrong version. My solution is to create a new npm tag named v6-latest, and use this for our v6 doc.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
