### PR TITLE
refactor(configuration): update import type syntax to support old ts

### DIFF
--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -14,7 +14,8 @@ import { Deferred, isUrl, isBase64svg } from '@refinitiv-ui/utils/loader.js';
 import { VERSION } from '../version.js';
 import { IconLoader } from './utils/IconLoader.js';
 import { consume } from '@lit-labs/context';
-import { efConfig, type Config } from '../configuration/index.js';
+import { efConfig } from '../configuration/index.js';
+import type { Config } from '../configuration/index.js';
 import { SpriteLoader } from './utils/SpriteLoader.js';
 
 const EmptyTemplate = svg``;


### PR DESCRIPTION
## Description

Sync configuration code missing from the last sync v6 to v7

v6 PR: https://github.com/Refinitiv/refinitiv-ui/pull/783

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-2166