### PR TITLE
fix(interactive-chart): export chart interface

### DIFF
--- a/packages/elements/src/interactive-chart/helpers/types.ts
+++ b/packages/elements/src/interactive-chart/helpers/types.ts
@@ -80,7 +80,9 @@ export {
   Theme,
   RowLegend,
   SeriesList,
+  SeriesData,
   SeriesDataItem,
+  SeriesOptions,
   SeriesStyleOptions,
   ColorToStringFunction,
   LegendStyle

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -61,7 +61,6 @@ export type {
   SeriesDataItem,
   SeriesOptions,
   SeriesStyleOptions,
-  ColorToStringFunction,
   LegendStyle
 };
 

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -19,7 +19,7 @@ import {
   BarData,
   MouseEventParams,
   ITimeScaleApi,
-  SeriesOptions,
+  SeriesOptions as ChartSeriesOptions,
   LineData,
   HistogramData,
   ChartOptions,
@@ -40,7 +40,9 @@ import type {
   Theme,
   RowLegend,
   SeriesList,
+  SeriesData,
   SeriesDataItem,
+  SeriesOptions,
   SeriesStyleOptions,
   ColorToStringFunction
 } from './helpers/types';
@@ -51,6 +53,15 @@ import { merge, MergeObject } from './helpers/merge.js';
 export type {
   InteractiveChartConfig,
   InteractiveChartSeries,
+  Time,
+  Theme,
+  RowLegend,
+  SeriesList,
+  SeriesData,
+  SeriesDataItem,
+  SeriesOptions,
+  SeriesStyleOptions,
+  ColorToStringFunction,
   LegendStyle
 };
 
@@ -514,7 +525,7 @@ export class InteractiveChart extends ResponsiveElement {
       for (let index = 0; index < this.internalConfig.series.length; index++) {
 
         // Get seriesOptions and type
-        const seriesOptions = this.internalConfig.series[index].seriesOptions as SeriesOptions<SeriesStyleOptions> || {};
+        const seriesOptions = this.internalConfig.series[index].seriesOptions as ChartSeriesOptions<SeriesStyleOptions> || {};
         const type = this.internalConfig.series[index].type;
 
         let seriesThemeOptions = {};
@@ -586,7 +597,7 @@ export class InteractiveChart extends ResponsiveElement {
         }
         // Update config seriesOptions not have seriesOptions
         if (!this.internalConfig.series[index].seriesOptions) {
-          this.internalConfig.series[index].seriesOptions = seriesThemeOptions as SeriesOptions<SeriesStyleOptions>;
+          this.internalConfig.series[index].seriesOptions = seriesThemeOptions as ChartSeriesOptions<SeriesStyleOptions>;
         }
         else {
           merge(seriesOptions as unknown as MergeObject, seriesThemeOptions);

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -45,7 +45,7 @@ import type {
   SeriesOptions,
   SeriesStyleOptions,
   ColorToStringFunction
-} from './helpers/types';
+} from './helpers/types.js';
 
 import { LegendStyle } from './helpers/types.js';
 import { merge, MergeObject } from './helpers/merge.js';


### PR DESCRIPTION
## Description

Export interactive-chart interface missing on v6

#### Consider point:
the interactive-chart interface has an interface name `SeriesOptions` that is duplicated with SeriesOptions from the ChartJS interface, so I desire to rename SeriesOptions from ChartJS that using inside our code to `ChartSeriesOptions` instead.

```javascript
import { SeriesOptions as ChartSeriesOptions } from './helpers/types';
```

SharePoint Draft:
https://lsegroup.sharepoint.com/teams/ElementFramework/SitePages/Element-Framework-v6-Migration-Guide.aspx#interactive-chart-types

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-2168

## Type of change

Please delete options that are not relevant.

- [ ] Refactor (improves code without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
