### PR TITLE
refactor(number-field): remove number pattern

### DIFF
--- a/packages/elements/src/number-field/__test__/number-field.test.js
+++ b/packages/elements/src/number-field/__test__/number-field.test.js
@@ -13,17 +13,14 @@ describe('number-field/NumberField', () => {
   describe('Dom Structure', () => {
     it('DOM structure is correct', async () => {
       const el = await fixture('<ef-number-field></ef-number-field>');
-      await expect(el).shadowDom.to.equalSnapshot({
-        ignoreAttributes: ['pattern']
-      });
+      await expect(el).shadowDom.to.equalSnapshot();
     });
     it('DOM structure without spinner is correct', async () => {
       const el = await fixture('<ef-number-field></ef-number-field>');
       el.setAttribute('no-spinner', true);
-      await elementUpdated();
-      await expect(el).shadowDom.to.equalSnapshot({
-        ignoreAttributes: ['pattern']
-      });
+
+      await elementUpdated(el);
+      await expect(el).shadowDom.to.equalSnapshot();
     });
   });
 

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -17,7 +17,6 @@ import '../icon/index.js';
 
 type SelectionDirection = 'forward' | 'backward' | 'none';
 
-const NUMBER_PATTERN = '^[\\-\\+]?[0-9]*\\.?[0-9]+([eE][\\-\\+]?[0-9]+)?$';
 const DEFAULT_STEP_BASE = 1;
 const ANY_STEP = 'any';
 
@@ -552,7 +551,7 @@ export class NumberField extends FormFieldElement {
 
     return getDecimalPrecision(numberString);
   }
-  
+
   /**
    * Check if value subtracted from the step base is not an integral multiple of the allowed value step
    * @param value value to check
@@ -848,7 +847,6 @@ export class NumberField extends FormFieldElement {
    * type="text" - always `text`
    * part="input" - always "input", used for styling
    * inputmode="decimal" - show decimals keyboard by default
-   * pattern="'^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$'" - numbers only
    * role="spinbutton" - number field is actually a spinner
    * aria-valuenow - current value or 0
    * @keydown - Listener for `keydown` event. Runs `this.onInputKeyDown`
@@ -861,7 +859,6 @@ export class NumberField extends FormFieldElement {
       'type': 'text',
       'part': 'input',
       'inputmode': 'decimal',
-      'pattern': NUMBER_PATTERN,
       'role': 'spinbutton',
       'aria-valuenow': `${this.value || 0}`,
       '@keydown': this.onInputKeyDown,


### PR DESCRIPTION
## Description

Nowadays, we build our custom `checkValidty` instead of using `checkValidty` from native API. Therefore, pattern property is become unnecessary for the number-field.

[ELF-2184](https://jira.refinitiv.com/browse/ELF-2184)

## Type of change

- [x] Refactor (improves code without changing its functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
