### PR TITLE
fix(chart): wrong type on onRenderLabel

### DIFF
--- a/packages/elements/src/chart/plugins/doughnut-center-label.ts
+++ b/packages/elements/src/chart/plugins/doughnut-center-label.ts
@@ -32,7 +32,7 @@ export interface Selected {
 export interface CenterLabelConfig {
   defaultText: CenterLabel[];
   selected: Selected;
-  onRenderLabel(chart: ChartJS, chartItems: ActiveElement[]): CenterLabel[];
+  onRenderLabel(chart: ChartJS, chartItems: ActiveElement[]): CenterLabel[] | undefined;
 }
 
 declare module 'chart.js' {
@@ -155,10 +155,10 @@ const plugins: Plugin = {
       active = activeElements;
     }
 
-    const renderText = config.onRenderLabel(chart, active);
+    const labels = config.onRenderLabel(chart, active);
 
     // Get Texts
-    const texts = renderText || config.defaultText;
+    const texts = labels || config.defaultText;
 
     if (!texts) {
       return;


### PR DESCRIPTION
## Description

"onRenderLabel" callback function in DoughnutCenterLabel Plugin can return CenterLabel[] to show as label in the middle of donut chart. If the function returns undefined, it means using `defaultText` option. But I found that v7 can't do this. v6 still can do this.

Fixes # ([ELF-2165](https://jira.refinitiv.com/browse/ELF-2165))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
