### PR TITLE
refactor(number-field): remove number pattern

### DIFF
--- a/packages/elements/src/number-field/__snapshots__/NumberField.md
+++ b/packages/elements/src/number-field/__snapshots__/NumberField.md
@@ -10,7 +10,6 @@
   autocomplete="off"
   inputmode="decimal"
   part="input"
-  pattern="^[\-\+]?[0-9]*\.?[0-9]+([eE][\-\+]?[0-9]+)?$"
   role="spinbutton"
   type="text"
 >
@@ -37,7 +36,6 @@
   autocomplete="off"
   inputmode="decimal"
   part="input"
-  pattern="^[\-\+]?[0-9]*\.?[0-9]+([eE][\-\+]?[0-9]+)?$"
   role="spinbutton"
   type="text"
 >

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -18,7 +18,6 @@ import { VERSION } from '../version.js';
 
 type SelectionDirection = 'forward' | 'backward' | 'none';
 
-const NUMBER_PATTERN = '^[\\-\\+]?[0-9]*\\.?[0-9]+([eE][\\-\\+]?[0-9]+)?$';
 const DEFAULT_STEP_BASE = 1;
 const ANY_STEP = 'any';
 
@@ -863,7 +862,6 @@ export class NumberField extends FormFieldElement {
    * type="text" - always `text`
    * part="input" - always "input", used for styling
    * inputmode="decimal" - show decimals keyboard by default
-   * pattern="'^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$'" - numbers only
    * role="spinbutton" - number field is actually a spinner
    * aria-valuenow - current value or 0
    * @keydown - Listener for `keydown` event. Runs `this.onInputKeyDown`
@@ -876,7 +874,6 @@ export class NumberField extends FormFieldElement {
       type: 'text',
       part: 'input',
       inputmode: 'decimal',
-      pattern: NUMBER_PATTERN,
       role: 'spinbutton',
       'aria-valuenow': `${this.value || 0}`,
       '@keydown': this.onInputKeyDown,


### PR DESCRIPTION
## Description

Nowadays, we build our custom `checkValidty` instead of using `checkValidty` from native API. Therefore, pattern property is become unnecessary for the number-field.
(sync changed from v7)

[ELF-2184](https://jira.refinitiv.com/browse/ELF-2184)

## Type of change

- [x] Refactor (improves code without changing its functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
