### PR TITLE
fix: flag attribute not reflecting when set through property

### DIFF
--- a/packages/elements/src/flag/__demo__/index.html
+++ b/packages/elements/src/flag/__demo__/index.html
@@ -72,7 +72,11 @@
     </demo-block>
     <demo-block header="Border" layout="normal" tags="border">
       <ef-flag flag="kr" title="kr"></ef-flag>
-      <ef-flag flag="np" title="np"></ef-flag>
+      <ef-flag id="np" title="np"></ef-flag>
+      <script>
+        const nepalFlag = document.getElementById('np');
+        nepalFlag.flag = 'np';
+      </script>
       <ef-flag flag="es-ga" title="es-ga"></ef-flag>
       <ef-flag flag="cy" title="cy"></ef-flag>
     </demo-block>

--- a/packages/elements/src/flag/__test__/flag.test.js
+++ b/packages/elements/src/flag/__test__/flag.test.js
@@ -82,32 +82,41 @@ describe('flag/Flag', () => {
     });
   });
 
-  describe('Should Have Correct Properties', () => {
-    it('flag', async () => {
-      createFakeResponse(gbSvg, responseConfigSuccess);
-      const el = await fixture('<ef-flag></ef-flag>');
+  describe('Should have correct attributes and properties', () => {
+    describe('flag attribute/property', () => {
+      let el;
+      beforeEach(async () => {
+        el = await fixture('<ef-flag></ef-flag>');
+        createFakeResponse(gbSvg, responseConfigSuccess);
+      });
 
-      expect(el.hasAttribute('flag')).to.equal(false, 'Flag should not have the flag attribute by default');
-      expect(el.flag).to.equal(null, 'Flag should not have the flag property by default');
+      it('should not have flag attribute by default', () => {
+        expect(el.hasAttribute('flag')).to.equal(false, 'Flag should not have the flag attribute by default');
+        expect(el.flag).to.equal(null, 'Flag should not have the flag property by default');
+      });
 
-      el.setAttribute('flag', flagName);
-      await elementUpdated(el);
+      it('should have flag attribute when set', async () => {
+        el.setAttribute('flag', flagName);
+        await elementUpdated(el);
 
-      expect(el.hasAttribute('flag')).to.equal(true, 'Flag should have the flag attribute when set');
-      expect(el.getAttribute('flag')).to.equal(flagName, 'Flag should have the same flag attribute as was set');
-      expect(el.flag).to.equal(flagName, 'Flag should reflect the flag attribute to property');
+        expect(el.hasAttribute('flag')).to.equal(true, 'Flag should have the flag attribute when set');
+        expect(el.getAttribute('flag')).to.equal(
+          flagName,
+          'Flag should have the same flag attribute as was set'
+        );
+        expect(el.flag).to.equal(flagName, 'Flag should reflect the flag attribute to property');
+      });
 
-      el.removeAttribute('flag');
-      await elementUpdated(el);
+      it('should have flag attribute reflected when flag property is set', async () => {
+        el.flag = flagName;
+        await elementUpdated(el);
 
-      expect(el.hasAttribute('flag')).to.equal(false, 'Flag should not have the flag attribute after it was removed');
-      expect(el.flag).to.equal(null, 'Flag should not have the flag property after attribute was removed');
-
-      el.flag = flagName;
-      await elementUpdated(el);
-
-      expect(el.flag).to.equal(flagName, 'Flag should have the same flag property as was set');
-      expect(el.hasAttribute('flag')).to.equal(false, 'Flag should not reflect the flag property to the attribute');
+        expect(el.hasAttribute('flag')).to.equal(true, 'Flag should have the flag attribute reflected');
+        expect(el.getAttribute('flag')).to.equal(
+          flagName,
+          'Flag should not have the flag property after attribute was removed'
+        );
+      });
     });
   });
 

--- a/packages/elements/src/flag/index.ts
+++ b/packages/elements/src/flag/index.ts
@@ -57,15 +57,17 @@ export class Flag extends BasicElement {
    * @example gb | https://cdn.io/flags/gb.svg
    * @default null
    */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   public get flag (): string | null {
     return this._flag;
   }
   public set flag (value: string | null) {
-    if (this.flag !== value) {
+    const oldValue = this._flag;
+    if (oldValue !== value) {
       this.deferFlagReady();
       this._flag = value;
       void this.setFlagSrc();
+      this.requestUpdate('flag', oldValue);
     }
   }
 


### PR DESCRIPTION
## Description

`flag` attribute not reflecting when set through property

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
