### PR TITLE
fix(datetime-picker): allow user to clear invalid value in input

### DIFF
--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -89,6 +89,7 @@ describe('datetime-picker/Value', () => {
       await elementUpdated(el);
 
       expect(el.inputEl.value).to.be.equal('');
+      expect(el.error).to.be.equal(false);
     });
     it('It should be able to clear input values when user type invalid format for range mode', async () => {
       const el = await fixture('<ef-datetime-picker lang="en-gb" range opened></ef-datetime-picker>');
@@ -110,6 +111,7 @@ describe('datetime-picker/Value', () => {
 
       expect(el.inputEl.value).to.be.equal('');
       expect(el.inputToEl.value).to.be.equal('');
+      expect(el.error).to.be.equal(false);
     });
     it('It should not be possible to set from value after to', async () => {
       const el = await fixture(

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -42,7 +42,6 @@ describe('datetime-picker/Value', () => {
       expect(el.min).to.be.equal('', 'Invalid min should reset min');
       expect(el.max).to.be.equal('', 'Invalid max should reset max');
     });
-
     it('It must not error when user input empty string value', async () => {
       const el = await fixture(
         '<ef-datetime-picker lang="en-gb" min="2022-04-01" max="2022-04-30"></ef-datetime-picker>'
@@ -63,7 +62,6 @@ describe('datetime-picker/Value', () => {
       await elementUpdated(el);
       expect(el.error).to.be.equal(false, 'input empty string must not make element error in range mode');
     });
-
     it('Typing invalid value in input should mark datetime picker as invalid and error-changed event is fired', async () => {
       const el = await fixture('<ef-datetime-picker lang="en-gb" opened></ef-datetime-picker>');
       setTimeout(() => typeText(el.inputEl, 'Invalid Value'));
@@ -75,6 +73,43 @@ describe('datetime-picker/Value', () => {
       expect(el.value).to.be.equal('');
       expect(el.calendarEl.value).to.be.equal('');
       expect(value).to.be.equal(true, 'error-changed event should be fired when user puts invalid value');
+    });
+    it('It should be able to clear input value when user type invalid format for normal mode', async () => {
+      const el = await fixture('<ef-datetime-picker lang="en-gb" opened></ef-datetime-picker>');
+      const input = el.inputEl;
+
+      await triggerFocusFor(input);
+      typeText(input, 'Invalid Value');
+      await elementUpdated(el);
+
+      expect(el.inputEl.value).to.be.equal('Invalid Value');
+
+      el.value = '';
+      await triggerFocusFor(el);
+      await elementUpdated(el);
+
+      expect(el.inputEl.value).to.be.equal('');
+    });
+    it('It should be able to clear input values when user type invalid format for range mode', async () => {
+      const el = await fixture('<ef-datetime-picker lang="en-gb" range opened></ef-datetime-picker>');
+      const input = el.inputEl;
+      const inputTo = el.inputToEl;
+
+      await triggerFocusFor(input);
+      await triggerFocusFor(inputTo);
+      typeText(input, 'Invalid Value 1');
+      typeText(inputTo, 'Invalid Value 2');
+      await elementUpdated(el);
+
+      expect(el.inputEl.value).to.be.equal('Invalid Value 1');
+      expect(el.inputToEl.value).to.be.equal('Invalid Value 2');
+
+      el.values = [];
+      await triggerFocusFor(el);
+      await elementUpdated(el);
+
+      expect(el.inputEl.value).to.be.equal('');
+      expect(el.inputToEl.value).to.be.equal('');
     });
     it('It should not be possible to set from value after to', async () => {
       const el = await fixture(

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -276,13 +276,7 @@ export class DatetimePicker extends ControlElement implements MultiValue {
   })
   public set values(values: string[]) {
     const oldValues = this._values;
-    // allow users to reset values when they put invalid value to input
-    if (!values.length) {
-      this.inputValues = [];
-      this.validateInput(); /* to reset error state */
-      this.requestUpdate();
-    }
-    if (String(oldValues) !== String(values)) {
+    if (String(oldValues) !== String(values) || !values.length) {
       this._values = values;
       this.valuesToSegments();
       this.requestUpdate('_values', oldValues); /* segments are populated in update */

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -279,6 +279,7 @@ export class DatetimePicker extends ControlElement implements MultiValue {
     // allow users to reset values when they put invalid value to input
     if (!values.length) {
       this.inputValues = [];
+      this.validateInput(); /* to reset error state */
       this.requestUpdate();
     }
     if (String(oldValues) !== String(values)) {

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -276,6 +276,11 @@ export class DatetimePicker extends ControlElement implements MultiValue {
   })
   public set values(values: string[]) {
     const oldValues = this._values;
+    // allow users to reset values when they put invalid value to input
+    if (!values.length) {
+      this.inputValues = [];
+      this.requestUpdate();
+    }
     if (String(oldValues) !== String(values)) {
       this._values = values;
       this.valuesToSegments();


### PR DESCRIPTION
## Description

To allow user to clear invalid input, we need to accept empty string for `value` and empty array for `values` to be assigned when current input is not valid.

Fixes # (issue) 
[ELF-1715](https://jira.refinitiv.com/browse/ELF-1715)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
