### PR TITLE
ci: auto retry unit test step if failed

### DIFF
--- a/.github/actions/run-test/action.yml
+++ b/.github/actions/run-test/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Enable HTTPS on the test server'
     required: false
     default: 'true'
+  max-attempts:
+    description: 'Max attempts to retry test when test failed'
+    required: false
+    default: 0
 
 runs:
   using: 'composite'
@@ -44,18 +48,27 @@ runs:
 
     - name: Test
       if: ${{ inputs.target == '' || inputs.target == 'all' }}
-      shell: bash
-      # Prevent NX caching for mode `all` because it must run all testing, even though the code has not changed.
-      run: |
-        [[ "${{ inputs.mode }}" == "all" ]] && export NX_SKIP_NX_CACHE=true && unset NX_BASE
-        npm run test:${{ inputs.mode }} -- --browserstack ${{ inputs.browsers }} --includeCoverage=${{ inputs.coverage }} --output=minimal --parallel=${{ inputs.parallel }}
+      uses: nick-fields/retry@v2
+      with:
+        max_attempts: ${{ inputs.max-attempts }}
+        retry_on: error
+        timeout_minutes: 60
+        shell: bash
+        # Prevent NX caching for mode `all` because it must run all testing, even though the code has not changed.
+        command: |
+          [[ "${{ inputs.mode }}" == "all" ]] && export NX_SKIP_NX_CACHE=true && unset NX_BASE
+          npm run test:${{ inputs.mode }} -- --browserstack ${{ inputs.browsers }} --includeCoverage=${{ inputs.coverage }} --output=minimal --parallel=${{ inputs.parallel }}
       env:
         TEST_HTTPS: ${{ inputs.https }}
 
     - name: Test Package or Element
       if: ${{ inputs.target != '' && inputs.target != 'all' }}
-      shell: bash
-      run: |
-        npm run test ${{ inputs.target }} -- --browserstack ${{ inputs.browsers }} --includeCoverage=${{ inputs.coverage }}
+      uses: nick-fields/retry@v2
+      with:
+        max_attempts: ${{ inputs.max-attempts }}
+        retry_on: error
+        timeout_minutes: 60
+        shell: bash
+        command: npm run test ${{ inputs.target }} -- --browserstack ${{ inputs.browsers }} --includeCoverage=${{ inputs.coverage }}
       env:
         TEST_HTTPS: ${{ inputs.https }}

--- a/.github/workflows/test_all_browsers.yml
+++ b/.github/workflows/test_all_browsers.yml
@@ -13,6 +13,11 @@ on:
         description: 'Skip all tests'
         default: false
         type: boolean
+      max-attempts:
+        description: 'Max attempts to retry test when test failed'
+        required: false
+        default: '0'
+        type: string
 
 jobs:
   test-chrome:
@@ -24,6 +29,7 @@ jobs:
       browser: 'chrome'
       build-prefix: ${{ inputs.build-prefix }}
       skip: ${{ inputs.skip }}
+      max-attempts: ${{ inputs.max-attempts }}
 
   test-firefox:
     name: Browsers
@@ -34,6 +40,7 @@ jobs:
       browser: 'firefox'
       build-prefix: ${{ inputs.build-prefix }}
       skip: ${{ inputs.skip }}
+      max-attempts: ${{ inputs.max-attempts }}
 
   test-safari:
     name: Browsers
@@ -48,6 +55,7 @@ jobs:
       https: 'false'
       build-prefix: ${{ inputs.build-prefix }}
       skip: ${{ inputs.skip }}
+      max-attempts: ${{ inputs.max-attempts }}
 
   test-ios:
     name: Browsers
@@ -59,6 +67,7 @@ jobs:
       https: 'false' # Disable HTTPS with iOS for now, the same reason of Safari above.
       build-prefix: ${{ inputs.build-prefix }}
       skip: ${{ inputs.skip }}
+      max-attempts: ${{ inputs.max-attempts }}
 
   test-android:
     name: Browsers
@@ -69,3 +78,4 @@ jobs:
       browser: 'android'
       build-prefix: ${{ inputs.build-prefix }}
       skip: ${{ inputs.skip }}
+      max-attempts: ${{ inputs.max-attempts }}

--- a/.github/workflows/test_browser_versions.yml
+++ b/.github/workflows/test_browser_versions.yml
@@ -41,6 +41,11 @@ on:
         description: 'Prefix build name for Browserstack'
         default: 'GitHub '
         type: string
+      max-attempts:
+        description: 'Max attempts to retry test when test failed'
+        required: false
+        default: '0'
+        type: string
 env:
   BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
   BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
@@ -70,6 +75,7 @@ jobs:
           browsers: ${{ inputs.browser }}
           mode: ${{ inputs.mode }}
           https: ${{ inputs.https }}
+          max-attempts: ${{ inputs.max-attempts }}
 
       - name: '⚠️ Skip Test - Latest'
         if: ${{ !contains(inputs.versions, 'latest') || inputs.skip }}
@@ -93,6 +99,7 @@ jobs:
           browsers: '${{ inputs.browser }}_minus1'
           mode: ${{ inputs.mode }}
           https: ${{ inputs.https }}
+          max-attempts: ${{ inputs.max-attempts }}
 
       - name: '⚠️ Skip Test - Minus 1'
         if: ${{ !contains(inputs.versions, 'minus1') || inputs.skip }}
@@ -116,6 +123,7 @@ jobs:
           browsers: '${{ inputs.browser }}_minus2'
           mode: ${{ inputs.mode }}
           https: ${{ inputs.https }}
+          max-attempts: ${{ inputs.max-attempts }}
 
       - name: '⚠️ Skip Test - Minus 2'
         if: ${{ !contains(inputs.versions, 'minus2') || inputs.skip }}

--- a/.github/workflows/test_nightly.yml
+++ b/.github/workflows/test_nightly.yml
@@ -56,3 +56,4 @@ jobs:
     secrets: inherit
     with:
       build-prefix: 'Nightly Test '
+      max-attempts: '3'


### PR DESCRIPTION
## Description

Currently, we have the unit test runs on BrowserStack and we found it quite not stable, and we always press the button in GitHub to retry the failed jobs to make it pass. To make it better we decided to make it retry the running unit test autometically

## Type of change
- [ ] Refactor (improves code without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
