### PR TITLE
fix(*): add tooltip attribute to basic element

### DIFF
--- a/packages/core/src/elements/BasicElement.ts
+++ b/packages/core/src/elements/BasicElement.ts
@@ -90,6 +90,11 @@ export abstract class BasicElement extends LitElement {
   public readonly delegatesFocus: boolean = false;
 
   /**
+   * Default attribute for using by ef-tooltip
+   */
+  public tooltip: string | null = null;
+
+  /**
    * The element should be automatically focused after added to the DOM.
    * Only one element can be auto-focused at any time.
    */


### PR DESCRIPTION
## Description
React typescript  show error tooltip property not found when using tooltip element with any EF elements.
Our tooltip have a feature to selector elements from tooltip property but tooltip property didn't provide to elements in typescript

<img width="545" alt="Screenshot 2566-07-24 at 10 45 24" src="https://github.com/Refinitiv/refinitiv-ui/assets/102957966/f5e48015-3b22-4435-9f44-b29ea3e5a63a">

### Solution:
Add `tooltip` property to `BasicElement`

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-2115

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
