### PR TITLE
feat(tooltip): add data-tooltip alias for tooltip attribute

### DIFF
--- a/packages/elements/src/tooltip/helpers/renderer.ts
+++ b/packages/elements/src/tooltip/helpers/renderer.ts
@@ -1,13 +1,13 @@
 import type { TooltipRenderer } from './types';
 
 /**
- * A default renderer that renders `tooltip` attribute
+ * A default renderer that renders `tooltip` or `data-tooltip` attributes
  * @param target Target to check
  * @returns tooltip or null or undefined
  */
 const tooltipRenderer: TooltipRenderer = (target: HTMLElement) => {
-  if (target.hasAttribute('tooltip')) {
-    return target.getAttribute('tooltip');
+  if (target.hasAttribute('tooltip') || target.hasAttribute('data-tooltip')) {
+    return target.getAttribute('tooltip') || target.getAttribute('data-tooltip');
   }
 };
 


### PR DESCRIPTION
## Description

React typescript show error tooltip property not found when using tooltip element with any EF elements.
Our tooltip have a feature to selector elements from tooltip property but tooltip property didn't provide to elements in typescript

<img width="545" alt="Screenshot 2566-07-24 at 10 45 24" src="https://github.com/Refinitiv/refinitiv-ui/assets/102957966/f5e48015-3b22-4435-9f44-b29ea3e5a63a">

### Solution:
tootip attribute doesn't support from HTML standard by default? Well, add `data-tooltip` alias for tooltip attribute that consume by tooltip renderer to avoid alien attribute error. also data attributes `data-*`  is following HTML standard 
Ref: https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes

<img width="414" alt="Screenshot 2566-07-25 at 14 15 27" src="https://github.com/Refinitiv/refinitiv-ui/assets/102957966/38840d7c-a8f5-48db-bc5e-d85acea66f23">


Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-2115

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
