### PR TITLE
fix(interactive-chart): change chart property access modifier from private to public

### DIFF
--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -143,11 +143,16 @@ export class InteractiveChart extends ResponsiveElement {
    */
   public seriesList: SeriesList[] = [];
 
+  /**
+   * lightweight-charts object
+   * @type {IChartApi | null}
+   */
+  public chart: IChartApi | null = null;
+
   private jumpButtonInitialized = false;
   private legendInitialized = false;
   private isCrosshairVisible = false;
 
-  protected chart: IChartApi | null = null;
   protected rowLegend: RowLegend = null;
   private timeScale: ITimeScaleApi | null = null;
 


### PR DESCRIPTION
## Description
 It sound more sense to make docs api align with doc example  and align with ef-chart 

### Solution:
Change chart instance access modifier to public 

Ref: 
https://github.com/Refinitiv/refinitiv-ui/pull/565

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-2214

## Type of change
- [x] New feature (non-breaking change which adds functionality)