### PR TITLE
fix(number-field): add aria-valuetext to prevent VO announce percentage

### DIFF
--- a/packages/elements/src/number-field/__test__/__snapshots__/number-field.test.snap.js
+++ b/packages/elements/src/number-field/__test__/__snapshots__/number-field.test.snap.js
@@ -4,6 +4,7 @@ export const snapshots = {};
 snapshots["number-field/NumberField Dom Structure DOM structure is correct"] = 
 `<input
   aria-valuenow="0"
+  aria-valuetext="0"
   autocomplete="off"
   inputmode="decimal"
   part="input"
@@ -28,6 +29,7 @@ snapshots["number-field/NumberField Dom Structure DOM structure is correct"] =
 snapshots["number-field/NumberField Dom Structure DOM structure without spinner is correct"] = 
 `<input
   aria-valuenow="0"
+  aria-valuetext="0"
   autocomplete="off"
   inputmode="decimal"
   part="input"

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -869,6 +869,7 @@ export class NumberField extends FormFieldElement {
    * inputmode="decimal" - show decimals keyboard by default
    * role="spinbutton" - number field is actually a spinner
    * aria-valuenow - current value or 0
+   * aria-valuetext - current value or 0, need this to improve user-friendly and human-understandable when screen reader announce value
    * @keydown - Listener for `keydown` event. Runs `this.onInputKeyDown`
    * @beforeinput - Listener for `beforeinput` event. Runs `this.onBeforeInputChange`
    * @returns template map
@@ -881,6 +882,7 @@ export class NumberField extends FormFieldElement {
       inputmode: 'decimal',
       role: 'spinbutton',
       'aria-valuenow': `${this.value || 0}`,
+      'aria-valuetext': `${this.value || 0}`,
       '@keydown': this.onInputKeyDown,
       '@beforeinput': this.onBeforeInputChange
     };


### PR DESCRIPTION
## Description

VO always announce percentage value in number-field when open in Safari. To make VO+Safari announced correct value, the document in MDN suggests to include `aria-valuetext`  with `aria-valuenow` to prevent it from announced value as percentage when `aria-valuemin` and `aria-valuemax` are not defined.
REF: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow

Fixes # (issue)
[ELF-2192](https://jira.refinitiv.com/browse/ELF-2192)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
