### PR TITLE
fix(interactive-chart): wrong legend color on candlestick chart

### DIFF
--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -1051,9 +1051,11 @@ export class InteractiveChart extends ResponsiveElement {
     if (chartType === 'line') {
       return this.getLegendPriceColor((this.seriesList[index].options() as LineSeriesOptions).color);
     } else if (chartType === 'candlestick') {
-      const { close, open } = seriesData as CandlestickData;
+      const priceValue = seriesData.hasOwnProperty('seriesData')
+        ? ((seriesData as MouseEventParams).seriesData.get(this.seriesList[index]) as CandlestickData)
+        : (seriesData as CandlestickData);
       const barStyle = this.seriesList[index].options() as CandlestickSeriesOptions;
-      const colorBar = close > open ? barStyle.borderUpColor : barStyle.borderDownColor;
+      const colorBar = priceValue.close > priceValue.open ? barStyle.borderUpColor : barStyle.borderDownColor;
       return colorBar;
     } else if (chartType === 'bar') {
       return this.getLegendPriceColor((this.seriesList[index].options() as BarSeriesOptions).upColor);

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -1062,38 +1062,16 @@ export class InteractiveChart extends ResponsiveElement {
     } else if (chartType === 'area') {
       return this.getLegendPriceColor((this.seriesList[index].options() as AreaSeriesOptions).lineColor);
     } else if (chartType === 'volume') {
-      const priceValue = seriesData.hasOwnProperty('seriesData')
-        ? (seriesData as MouseEventParams).seriesData.get(this.seriesList[index])
-        : (seriesData as HistogramData).value;
-
-      let dataItem = {};
-      this.internalConfig.series[index].data.forEach((dataConfig: BarData | HistogramData) => {
-        const data = dataConfig as HistogramData;
-        const time = data.time as Time;
-        const timeSeriesData = seriesData.time as Time;
-        //  if via time point data string format 'yyyy-mm-dd' or object '{ year: 2019, month: 6, day: 1 }'
-        if (time.hasOwnProperty('day') && time.hasOwnProperty('month') && time.hasOwnProperty('year')) {
-          if (
-            time.day === timeSeriesData.day &&
-            time.month === timeSeriesData.month &&
-            time.year === timeSeriesData.year &&
-            data.value === priceValue
-          ) {
-            dataItem = dataConfig;
-          }
-        }
-        // if via config time uses a UNIX Timestamp format for time point data.
-        else if (time === seriesData.time) {
-          dataItem = data;
-        }
-      });
-
+      const dataItem = seriesData.hasOwnProperty('seriesData')
+        ? ((seriesData as MouseEventParams).seriesData.get(this.seriesList[index]) as HistogramData)
+        : (seriesData as HistogramData);
       // check when each color is added, the item comes from the configuration
-      if (dataItem.hasOwnProperty('color')) {
-        const data = dataItem as HistogramData;
-        return this.getLegendPriceColor(data.color as string);
-      } else {
-        return this.getLegendPriceColor((this.seriesList[index].options() as HistogramSeriesOptions).color);
+      if (dataItem) {
+        if (dataItem.hasOwnProperty('color')) {
+          return this.getLegendPriceColor(dataItem.color as string);
+        } else {
+          return this.getLegendPriceColor((this.seriesList[index].options() as HistogramSeriesOptions).color);
+        }
       }
     }
     return '';


### PR DESCRIPTION
## Description
Candlestick chart showing incorrect 'OHLC' legend color

Steps to Reproduce:
1. Open https://ui.refinitiv.com/elements/interactive-chart
2. Hover green bar at the candlestick chart

Fixes # (issue)
[ELF-2230](https://jira.refinitiv.com/browse/ELF-2230)
[ELF-2231](https://jira.refinitiv.com/browse/ELF-2231)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
