### PR TITLE
fix(interactive-chart): replace priceScale config with left and right priceScale due to api changed

### DIFF
--- a/packages/elements/src/interactive-chart/__demo__/index.html
+++ b/packages/elements/src/interactive-chart/__demo__/index.html
@@ -1238,7 +1238,10 @@
                 color: 'green'
               }
             },
-            priceScale: {
+            leftPriceScale: {
+              borderColor: 'red'
+            },
+            rightPriceScale: {
               borderColor: 'red'
             },
             timeScale: {

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -610,7 +610,10 @@ export class InteractiveChart extends ResponsiveElement {
           textColor: this.theme.textColor,
           fontFamily: defaultFontFamily
         },
-        priceScale: {
+        leftPriceScale: {
+          borderColor: this.theme.scalePriceBorderColor
+        },
+        rightPriceScale: {
           borderColor: this.theme.scalePriceBorderColor
         },
         timeScale: {


### PR DESCRIPTION
## Description
the interactive-chart has wrong price scale border color. Lightweight chart didn't document that priceScale option config is not working. We should using rightPriceScale and leftPriceScale config insteads.

Steps to Reproduce:
1. open https://ui.refinitiv.com/elements/interactive-chart
2. look at Interactive Chart live demo

Expected Results:
a normal interactive-chart same as v6

Fixes # (issue)
[ELF-2229](https://jira.refinitiv.com/browse/ELF-2229)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
