### PR TITLE
chore: fix prettier format command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:docs:dev": "nx run @refinitiv-ui/docs:build:dev",
     "build:prod": "nx run-many --target build:prod --all",
     "clean": "npm run reset && nx run-many --target clean --parallel --all",
-    "format": "prettier --write . '**/*.{js,mjs,ts,css,less,json,html,yml,md}' --ignore-unknown",
+    "format": "prettier --write '**/*.{js,mjs,ts,css,less,json,html,yml,md}' --ignore-unknown",
     "start": "node cli start",
     "start:docs": "nx run @refinitiv-ui/docs:start",
     "test": "node cli test",


### PR DESCRIPTION
## Description

Prettier currently ignore files pattern provided because of there is a `.` in command. This PR is to remove it. 