### PR TITLE
chore: add .semgrepignore to fix its default ignore issue

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,23 @@
+# doc: https://semgrep.dev/docs/ignoring-files-folders-code/#understanding-semgrep-defaults
+# Common large paths
+node_modules/
+build/
+dist/
+vendor/
+.env/
+.venv/
+.tox/
+*.min.js
+.npm/
+.yarn/
+
+# Semgrep rules folder
+.semgrep
+
+# Semgrep-action log folder
+.semgrep_logs/
+
+# Custom paths
+__test__/
+__demo__/
+__snapshots__/


### PR DESCRIPTION
## Description

fix "some files are excluded from scan unitentionally due to semgrep's default ignore list."

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
