### PR TITLE
fix(chart): use single color on bar and bubble chart

### DIFF
--- a/packages/elements/src/chart/__demo__/index.html
+++ b/packages/elements/src/chart/__demo__/index.html
@@ -346,38 +346,6 @@
       </script>
     </demo-block>
 
-    <demo-block layout="normal" header="Bar Chart - Single dataset (Mono Colour)">
-      <ef-chart id="singleSetBarMono"></ef-chart>
-      <script>
-        const singleSetBarMono = document.getElementById('singleSetBarMono');
-        // TODO: why we need this customElements? setTimeout?
-        customElements.whenDefined('ef-chart').then(() => {
-          setTimeout(() => {
-            singleSetBarMono.config = {
-              type: 'bar',
-              data: {
-                labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
-                datasets: [
-                  {
-                    label: 'Bounce Rate',
-                    data: [65, 59, 80, 81, 56, 55, 40],
-                    backgroundColor: singleSetBarMono.colors[0]
-                  }
-                ]
-              },
-              options: {
-                scales: {
-                  y: {
-                    beginAtZero: true
-                  }
-                }
-              }
-            };
-          });
-        });
-      </script>
-    </demo-block>
-
     <demo-block layout="normal" header="Stacked Bar Chart">
       <ef-chart id="stackedBar"></ef-chart>
       <script>

--- a/packages/elements/src/chart/__test__/chart.test.js
+++ b/packages/elements/src/chart/__test__/chart.test.js
@@ -296,14 +296,12 @@ describe('chart/Chart', () => {
       expect(check).to.equal(true, 'Number of colors and number of data should always be the same');
     });
 
-    it('Should apply color array to a single dataset bar chart', async () => {
+    it('Should apply single color array to a single dataset bar chart', async () => {
       el.config = config.singlesetbar;
       await chartRendered(el);
       let datasets = el.config.data.datasets;
       expect(datasets, 'Chart should only have one dataset').to.have.lengthOf(1);
-      expect(datasets[0].backgroundColor, 'Should have a color count equal to the data length')
-        .to.be.an('array')
-        .that.has.lengthOf(datasets[0].data.length);
+      expect(Array.isArray(datasets[0].backgroundColor)).to.equal(false);
     });
 
     it('Should render legend labels colors correctly', async () => {

--- a/packages/elements/src/chart/elements/chart.ts
+++ b/packages/elements/src/chart/elements/chart.ts
@@ -399,7 +399,6 @@ export class Chart extends BasicElement {
           }
           break;
 
-        // These types, Colors could be string or array
         case 'bar':
         case 'bubble':
           colors = this.generateColors(false, 1, datasetIndex);

--- a/packages/elements/src/chart/elements/chart.ts
+++ b/packages/elements/src/chart/elements/chart.ts
@@ -402,11 +402,7 @@ export class Chart extends BasicElement {
         // These types, Colors could be string or array
         case 'bar':
         case 'bubble':
-          colors = this.generateColors(
-            !isMultipleDatasets,
-            !isMultipleDatasets && dataset.data ? dataset.data.length : 1,
-            datasetIndex
-          );
+          colors = this.generateColors(false, 1, datasetIndex);
           borderColor = colors.solid;
           backgroundColor = this.config?.type === 'bubble' ? colors.opaque : colors.solid;
           if (!dataset.borderColor) {


### PR DESCRIPTION
## Description
When the dataset is single, the bar and bubble charts display incorrect background colors

Step to reproduce
1. Open https://codesandbox.io/s/bar-chart-with-a-single-dataset-k67zkf

Expected Results
All the bars should have the same colors.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
