### PR TITLE
refactor(interactive-chart): revise internal chart type and type export

### DIFF
--- a/packages/elements/src/interactive-chart/helpers/types.ts
+++ b/packages/elements/src/interactive-chart/helpers/types.ts
@@ -8,7 +8,8 @@ import type {
   SeriesType
 } from 'lightweight-charts';
 
-// https://stackoverflow.com/a/50375286
+// convert `A | B | C` into `A & B & C`. For more info, check https://stackoverflow.com/a/50375286
+``
 type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (k: infer I) => void
   ? I
   : never;

--- a/packages/elements/src/interactive-chart/helpers/types.ts
+++ b/packages/elements/src/interactive-chart/helpers/types.ts
@@ -1,40 +1,23 @@
 import type { HSLColor, RGBColor } from '@refinitiv-ui/utils/color.js';
 import type {
-  AreaSeriesPartialOptions,
-  AreaStyleOptions,
-  BarData,
-  BarSeriesPartialOptions,
-  BarStyleOptions,
-  CandlestickSeriesPartialOptions,
-  CandlestickStyleOptions,
   ChartOptions,
   DeepPartial,
-  HistogramData,
-  HistogramSeriesPartialOptions,
-  HistogramStyleOptions,
   ISeriesApi,
-  LineData,
-  LineSeriesPartialOptions,
-  LineStyleOptions,
-  SeriesPartialOptions,
+  SeriesDataItemTypeMap,
+  SeriesOptionsMap,
   SeriesType
 } from 'lightweight-charts';
 
-type SeriesOptions =
-  | AreaSeriesPartialOptions
-  | BarSeriesPartialOptions
-  | CandlestickSeriesPartialOptions
-  | HistogramSeriesPartialOptions
-  | LineSeriesPartialOptions;
-type SeriesStyleOptions = LineStyleOptions &
-  AreaStyleOptions &
-  BarStyleOptions &
-  CandlestickStyleOptions &
-  HistogramStyleOptions;
+// https://stackoverflow.com/a/50375286
+type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (k: infer I) => void
+  ? I
+  : never;
 
-type SeriesData = LineData[] | BarData[] | HistogramData[];
+type SeriesOptions = UnionToIntersection<SeriesOptionsMap[keyof SeriesOptionsMap]>;
+
 type SeriesList = ISeriesApi<SeriesType>;
-type SeriesDataItem = BarData | LineData | HistogramData;
+
+type SeriesDataItem = SeriesDataItemTypeMap[keyof SeriesDataItemTypeMap];
 
 type RowLegend = NodeListOf<Element> | HTMLElement | null;
 
@@ -46,12 +29,6 @@ type ColorToStringFunction = (
 enum LegendStyle {
   vertical = 'vertical',
   horizontal = 'horizontal'
-}
-
-interface Time {
-  day: number;
-  month: number;
-  year: number;
 }
 
 interface InteractiveChartConfig {
@@ -80,21 +57,18 @@ interface InteractiveChartSeries {
   symbolName?: string;
   legendVisible?: boolean;
   legendPriceFormatter?: (price: string | number) => string | number;
-  data: SeriesData;
-  seriesOptions?: SeriesPartialOptions<SeriesOptions>;
+  data: SeriesDataItem[];
+  seriesOptions?: SeriesOptions;
 }
 
 export {
   InteractiveChartConfig,
   InteractiveChartSeries,
-  Time,
   Theme,
   RowLegend,
   SeriesList,
-  SeriesData,
   SeriesDataItem,
   SeriesOptions,
-  SeriesStyleOptions,
   ColorToStringFunction,
   LegendStyle
 };

--- a/packages/elements/src/interactive-chart/helpers/types.ts
+++ b/packages/elements/src/interactive-chart/helpers/types.ts
@@ -9,7 +9,6 @@ import type {
 } from 'lightweight-charts';
 
 // convert `A | B | C` into `A & B & C`. For more info, check https://stackoverflow.com/a/50375286
-``
 type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (k: infer I) => void
   ? I
   : never;

--- a/packages/elements/src/interactive-chart/helpers/types.ts
+++ b/packages/elements/src/interactive-chart/helpers/types.ts
@@ -16,7 +16,7 @@ type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) exten
 type SeriesOptions = UnionToIntersection<SeriesOptionsMap[keyof SeriesOptionsMap]>;
 
 type SeriesList = ISeriesApi<SeriesType>;
-
+// a type union of each prop in `SeriesDataItemTypeMap` interface i.e. `BarData |  CandlestickData | ...`
 type SeriesDataItem = SeriesDataItemTypeMap[keyof SeriesDataItemTypeMap];
 
 type RowLegend = NodeListOf<Element> | HTMLElement | null;

--- a/packages/elements/src/interactive-chart/helpers/types.ts
+++ b/packages/elements/src/interactive-chart/helpers/types.ts
@@ -26,10 +26,7 @@ type ColorToStringFunction = (
   ...arg: (string | number | undefined)[]
 ) => RGBColor | HSLColor | null;
 
-enum LegendStyle {
-  vertical = 'vertical',
-  horizontal = 'horizontal'
-}
+type LegendStyle = 'vertical' | 'horizontal';
 
 interface InteractiveChartConfig {
   series: InteractiveChartSeries[];

--- a/packages/elements/src/interactive-chart/helpers/types.ts
+++ b/packages/elements/src/interactive-chart/helpers/types.ts
@@ -34,7 +34,7 @@ type SeriesStyleOptions = LineStyleOptions &
 
 type SeriesData = LineData[] | BarData[] | HistogramData[];
 type SeriesList = ISeriesApi<SeriesType>;
-type SeriesDataItem = BarData | LineData;
+type SeriesDataItem = BarData | LineData | HistogramData;
 
 type RowLegend = NodeListOf<Element> | HTMLElement | null;
 

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -25,27 +25,21 @@ import type {
   InteractiveChartConfig,
   InteractiveChartSeries,
   RowLegend,
-  SeriesData,
   SeriesDataItem,
   SeriesList,
   SeriesOptions,
-  SeriesStyleOptions,
-  Theme,
-  Time
+  Theme
 } from './helpers/types.js';
 import type {
   AreaSeriesOptions,
-  BarData,
   BarSeriesOptions,
   CandlestickData,
   CandlestickSeriesOptions,
   ChartOptions,
-  SeriesOptions as ChartSeriesOptions,
   HistogramData,
   HistogramSeriesOptions,
   IChartApi,
   ITimeScaleApi,
-  LineData,
   LineSeriesOptions,
   MouseEventParams,
   OhlcData,
@@ -55,14 +49,9 @@ import type {
 export type {
   InteractiveChartConfig,
   InteractiveChartSeries,
-  Time,
   Theme,
-  RowLegend,
-  SeriesList,
-  SeriesData,
-  SeriesDataItem,
   SeriesOptions,
-  SeriesStyleOptions,
+  SeriesDataItem,
   LegendStyle
 };
 
@@ -261,7 +250,7 @@ export class InteractiveChart extends ResponsiveElement {
    * @returns {void}
    */
   private onLegendStyleChange(value: string | undefined, previousValue: string): void {
-    if (value === 'horizontal') {
+    if (value === LegendStyle.horizontal) {
       if (previousValue) {
         this.legendContainer.classList.remove(previousValue);
       }
@@ -337,7 +326,7 @@ export class InteractiveChart extends ResponsiveElement {
         this.createLegend();
       }
 
-      if (this.legendStyle === 'horizontal') {
+      if (this.legendStyle === LegendStyle.horizontal) {
         this.legendContainer.classList.add(this.legendStyle);
       }
 
@@ -453,7 +442,7 @@ export class InteractiveChart extends ResponsiveElement {
       }
 
       if (data && series) {
-        series.setData(data as LineData[] & BarData[] & HistogramData[]);
+        series.setData(data);
       }
     }
     return series;
@@ -506,8 +495,7 @@ export class InteractiveChart extends ResponsiveElement {
 
       for (let index = 0; index < this.internalConfig.series.length; index++) {
         // Get seriesOptions and type
-        const seriesOptions =
-          (this.internalConfig.series[index].seriesOptions as ChartSeriesOptions<SeriesStyleOptions>) || {};
+        const seriesOptions = (this.internalConfig.series[index].seriesOptions as SeriesOptions) || {};
         const type = this.internalConfig.series[index].type;
 
         let seriesThemeOptions = {};
@@ -578,8 +566,7 @@ export class InteractiveChart extends ResponsiveElement {
         }
         // Update config seriesOptions not have seriesOptions
         if (!this.internalConfig.series[index].seriesOptions) {
-          this.internalConfig.series[index].seriesOptions =
-            seriesThemeOptions as ChartSeriesOptions<SeriesStyleOptions>;
+          this.internalConfig.series[index].seriesOptions = seriesThemeOptions as SeriesOptions;
         } else {
           merge(seriesOptions as unknown as MergeObject, seriesThemeOptions);
         }

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -811,7 +811,7 @@ export class InteractiveChart extends ResponsiveElement {
   protected renderTextLegend(
     chartType: string,
     rowLegendElem: RowLegend,
-    value: SeriesDataItem | number | string,
+    value: SeriesDataItem | string,
     priceColor: string,
     index: number
   ): void {
@@ -833,13 +833,7 @@ export class InteractiveChart extends ResponsiveElement {
         this.createTextOHLC(rowLegendElem, value as OhlcData, priceColor, index);
       }
     } else {
-      let price: string | number;
-      if ((value as SingleValueData).value !== undefined) {
-        price = (value as SingleValueData).value;
-      } else {
-        price = value as number;
-      }
-
+      const price: number | string = (value as SingleValueData).value ?? value;
       this.createTextPrice(rowLegendElem, price, priceColor, index);
     }
   }

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -488,7 +488,7 @@ export class InteractiveChart extends ResponsiveElement {
 
       for (let index = 0; index < this.internalConfig.series.length; index++) {
         // Get seriesOptions and type
-        const seriesOptions = (this.internalConfig.series[index].seriesOptions as SeriesOptions) || {};
+        const seriesOptions: Partial<SeriesOptions> = this.internalConfig.series[index].seriesOptions || {};
         const type = this.internalConfig.series[index].type;
 
         let seriesThemeOptions = {};

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -767,7 +767,7 @@ export class InteractiveChart extends ResponsiveElement {
          * Don't need to be updated if chart has no data.
          */
         /* c8 ignore start */
-        let value: SeriesDataItem | string | number | undefined;
+        let value: SeriesDataItem | string | undefined;
         let priceColor = '';
         // When have price on event moved on the crosshair
         if (eventMove?.seriesData.get(this.seriesList[idx]) && eventMove.time) {

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -1,22 +1,4 @@
-import {
-  AreaData,
-  AreaSeriesOptions,
-  BarData,
-  BarSeriesOptions,
-  CandlestickData,
-  CandlestickSeriesOptions,
-  ChartOptions,
-  SeriesOptions as ChartSeriesOptions,
-  ColorType,
-  HistogramData,
-  HistogramSeriesOptions,
-  IChartApi,
-  ITimeScaleApi,
-  LineData,
-  LineSeriesOptions,
-  MouseEventParams,
-  createChart as chart
-} from 'lightweight-charts';
+import { ColorType, createChart as chart } from 'lightweight-charts';
 
 import {
   CSSResultGroup,
@@ -51,6 +33,24 @@ import type {
   Theme,
   Time
 } from './helpers/types.js';
+import type {
+  AreaSeriesOptions,
+  BarData,
+  BarSeriesOptions,
+  CandlestickData,
+  CandlestickSeriesOptions,
+  ChartOptions,
+  SeriesOptions as ChartSeriesOptions,
+  HistogramData,
+  HistogramSeriesOptions,
+  IChartApi,
+  ITimeScaleApi,
+  LineData,
+  LineSeriesOptions,
+  MouseEventParams,
+  OhlcData,
+  SingleValueData
+} from 'lightweight-charts';
 
 export type {
   InteractiveChartConfig,
@@ -770,10 +770,7 @@ export class InteractiveChart extends ResponsiveElement {
           this.hasDataPoint = true;
           const lastData = dataSet[dataSet.length - 1];
           const priceColor = this.getColorInSeries(lastData, chartType, idx);
-          const lastDataValue =
-            chartType === 'bar' || chartType === 'candlestick' ? lastData : (lastData as LineData).value;
-
-          this.renderTextLegend(chartType, rowLegendElem, lastDataValue, priceColor, idx);
+          this.renderTextLegend(chartType, rowLegendElem, lastData, priceColor, idx);
         } else {
           const span = document.createElement('span');
           span.className = 'price';
@@ -787,28 +784,11 @@ export class InteractiveChart extends ResponsiveElement {
          * Don't need to be updated if chart has no data.
          */
         /* c8 ignore start */
-        let value;
+        let value: SeriesDataItem | string | number | undefined;
         let priceColor = '';
         // When have price on event moved on the crosshair
         if (eventMove?.seriesData.get(this.seriesList[idx]) && eventMove.time) {
-          const data = eventMove.seriesData.get(this.seriesList[idx]);
-
-          switch (chartType) {
-            case 'line':
-            case 'area':
-            case 'volume':
-              value = (data as LineData | AreaData | HistogramData).value;
-              break;
-            case 'bar':
-            case 'candlestick': {
-              const { open, high, low, close } = data as BarData | CandlestickData;
-              value = { open, high, low, close };
-              break;
-            }
-            default:
-              break;
-          }
-
+          value = eventMove.seriesData.get(this.seriesList[idx]);
           priceColor = this.getColorInSeries(eventMove, chartType, idx);
           this.isCrosshairVisible = true;
           this.hasDataPoint = true;
@@ -822,18 +802,15 @@ export class InteractiveChart extends ResponsiveElement {
         // Get latest value when mouse move out of scope
         else {
           const latestData = dataSet[dataSet.length - 1];
-          if (latestData) {
-            priceColor = this.getColorInSeries(latestData, chartType, idx);
-            value =
-              chartType === 'bar' || chartType === 'candlestick'
-                ? latestData
-                : (latestData as LineData).value;
-            this.isCrosshairVisible = false;
-            this.hasDataPoint = true;
-          }
+          priceColor = this.getColorInSeries(latestData, chartType, idx);
+          value = latestData;
+          this.isCrosshairVisible = false;
+          this.hasDataPoint = true;
         }
         // Render legend by series type
-        this.renderTextLegend(chartType, rowLegend, value as number | string, priceColor, idx);
+        if (value) {
+          this.renderTextLegend(chartType, rowLegend, value, priceColor, idx);
+        }
       }
       /* c8 ignore stop */
     }
@@ -870,10 +847,17 @@ export class InteractiveChart extends ResponsiveElement {
         span.textContent = value as string;
         rowLegendElem[index].appendChild(span);
       } else {
-        this.createTextOHLC(rowLegendElem, value as BarData, priceColor, index);
+        this.createTextOHLC(rowLegendElem, value as OhlcData, priceColor, index);
       }
     } else {
-      this.createTextPrice(rowLegendElem, value as number | string, priceColor, index);
+      let price: string | number;
+      if ((value as SingleValueData).value !== undefined) {
+        price = (value as SingleValueData).value;
+      } else {
+        price = value as number;
+      }
+
+      this.createTextPrice(rowLegendElem, price, priceColor, index);
     }
   }
 
@@ -884,7 +868,7 @@ export class InteractiveChart extends ResponsiveElement {
    * @param priceColor Color of series
    * @returns {void}
    */
-  private createSpanOHLC(rowLegend: RowLegend, rowData: BarData, priceColor: string): void {
+  private createSpanOHLC(rowLegend: RowLegend, rowData: OhlcData, priceColor: string): void {
     if (rowLegend instanceof HTMLElement) {
       rowLegend.setAttribute('data-color', priceColor);
       this.createSpan(rowLegend, 'O', rowData.open, 'H', rowData.high, 'L', rowData.low, 'C', rowData.close);
@@ -899,18 +883,19 @@ export class InteractiveChart extends ResponsiveElement {
    * @param index Series index
    * @returns {void}
    */
-  private createTextOHLC(rowLegend: RowLegend, rowData: BarData, priceColor: string, index: number): void {
+  private createTextOHLC(rowLegend: RowLegend, rowData: OhlcData, priceColor: string, index: number): void {
     // Uses price formatter if provided
     const formatter = this.internalConfig.series[index].hasOwnProperty('legendPriceFormatter')
       ? this.internalConfig.series[index].legendPriceFormatter
       : null;
     if (formatter) {
       rowData = {
+        time: rowData.time,
         open: formatter(rowData.open) as number,
         high: formatter(rowData.high) as number,
         low: formatter(rowData.low) as number,
         close: formatter(rowData.close) as number
-      } as BarData;
+      };
     }
     // Create text price after chart has rendered
     if (rowLegend instanceof HTMLElement) {
@@ -1158,12 +1143,9 @@ export class InteractiveChart extends ResponsiveElement {
         const dataSet = series.data || [];
         const latestData = dataSet[dataSet.length - 1];
         if (latestData) {
-          const value =
-            chartType === 'bar' || chartType === 'candlestick' ? latestData : (latestData as LineData).value; // latestData
           const priceColor = this.getColorInSeries(latestData, chartType, idx);
-
           // Render legend by series type
-          this.renderTextLegend(chartType, this.rowLegend, value, priceColor, idx);
+          this.renderTextLegend(chartType, this.rowLegend, latestData, priceColor, idx);
         }
       }
     }

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -18,12 +18,12 @@ import { HSLColor, RGBColor, color as parseColor } from '@refinitiv-ui/utils/col
 import '../tooltip/index.js';
 import { VERSION } from '../version.js';
 import { MergeObject, merge } from './helpers/merge.js';
-import { LegendStyle } from './helpers/types.js';
 
 import type {
   ColorToStringFunction,
   InteractiveChartConfig,
   InteractiveChartSeries,
+  LegendStyle,
   RowLegend,
   SeriesDataItem,
   SeriesList,
@@ -46,14 +46,7 @@ import type {
   SingleValueData
 } from 'lightweight-charts';
 
-export type {
-  InteractiveChartConfig,
-  InteractiveChartSeries,
-  Theme,
-  SeriesOptions,
-  SeriesDataItem,
-  LegendStyle
-};
+export type { InteractiveChartConfig, InteractiveChartSeries, Theme, SeriesOptions, SeriesDataItem };
 
 const NOT_AVAILABLE_DATA = 'N/A';
 const NO_DATA_POINT = '--';
@@ -123,7 +116,7 @@ export class InteractiveChart extends ResponsiveElement {
   }
 
   public get legendStyle(): LegendStyle {
-    return this._legendStyle || LegendStyle.vertical;
+    return this._legendStyle || 'vertical';
   }
 
   /**
@@ -250,7 +243,7 @@ export class InteractiveChart extends ResponsiveElement {
    * @returns {void}
    */
   private onLegendStyleChange(value: string | undefined, previousValue: string): void {
-    if (value === LegendStyle.horizontal) {
+    if (value === 'horizontal') {
       if (previousValue) {
         this.legendContainer.classList.remove(previousValue);
       }
@@ -326,7 +319,7 @@ export class InteractiveChart extends ResponsiveElement {
         this.createLegend();
       }
 
-      if (this.legendStyle === LegendStyle.horizontal) {
+      if (this.legendStyle === 'horizontal') {
         this.legendContainer.classList.add(this.legendStyle);
       }
 


### PR DESCRIPTION
## Description
This changes will effect to
1. Typescript type import from ef-interactive-chart document
2. User who using some exported types from interactive-chart

This changes including 
1. Refactor custom types
2. Removed some public custom types  and using from lightweight-charts instead
   - Remove `Time` type user can use `BusinessDay` from lightweight-chart instead
   - Unpublish `RowLegend` type due to protected variable usage
   - Unpublish `LegendStyle` type
   - Unpublish `SeriesList` type user can import necessary types from lightweight-chart instead
   - Remove `SeriesData` type
   - Remove `SeriesStyleOptions` type
4. Improve casting type 

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-2215

## Type of change

- [x] Refactor (improves code without changing its functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
