### PR TITLE
fix(combo-box): missing divider between list items in list

### DIFF
--- a/packages/halo-theme/src/custom-elements/ef-combo-box.less
+++ b/packages/halo-theme/src/custom-elements/ef-combo-box.less
@@ -108,4 +108,10 @@
       border-left-color: @input-focused-border-color;
     }
   }
+
+  [part='list'] {
+    ef-list-item:not(:first-child):not([type='divider']) {
+      box-shadow: 0px -1px 0 @separator-color;
+    }
+  }
 }


### PR DESCRIPTION
## Description

Missing divider between items.
![image](https://github.com/Refinitiv/refinitiv-ui/assets/86233706/2aa9586e-e036-4720-a539-80d0aec7f63b)

Fixes [ELF-2236](https://jira.refinitiv.com/browse/ELF-2236)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
