### PR TITLE
fix(combo-box): remove redundant input border when disabled

### DIFF
--- a/packages/halo-theme/src/custom-elements/ef-combo-box.less
+++ b/packages/halo-theme/src/custom-elements/ef-combo-box.less
@@ -89,6 +89,12 @@
     }
   }
 
+  &[disabled] {
+    [part~='input'] {
+      border: none;
+    }
+  }
+
   &[readonly],
   &[disabled] {
     [part~='button-toggle'] {


### PR DESCRIPTION
## Description

Currently when `combo-box` and `tree-select` are disabled, there is border input itself and it is redundant. This makes border to be thicker than it should be.

![image](https://github.com/Refinitiv/refinitiv-ui/assets/86233706/14491798-a42f-4dd8-80b7-dcc670f19fa9)


Fixes https://jira.refinitiv.com/browse/ELF-2239

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
