### PR TITLE
fix: add packages list to lerna config for blackduck scanning

### DIFF
--- a/.github/workflows/blackduck_scan.yml
+++ b/.github/workflows/blackduck_scan.yml
@@ -42,10 +42,8 @@ jobs:
           --detect.code.location.name="${{ vars.BLACKDUCK_APP_ID }}-${{ vars.BLACKDUCK_PROJECT_ID }}-${VERSION_ID}" \
           --detect.source.path="." \
           --detect.clone.project.version.latest=true \
-          --detect.excluded.directories=appsec \
-          --detect.blackduck.signature.scanner.exclusion.name.patterns=appsec \
-          --detect.detector.search.exclusion=appsec \
           --blackduck.api.token="${{ secrets.BLACKDUCK_APP_TOKEN }}" \
           --blackduck.url="${{ vars.BLACKDUCK_URL }}" \
           --blackduck.trust.cert=true \
+          --detect.excluded.directories=appsec \
           --detect.lerna.path="./node_modules/.bin/lerna" # make sure blackduck use lerna from npm package rather than shell one

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,5 @@
 {
+  "packages": ["packages/*", "documents"],
   "npmClient": "npm",
   "useWorkspaces": true,
   "version": "independent",

--- a/lerna.json
+++ b/lerna.json
@@ -5,10 +5,9 @@
   "version": "independent",
   "command": {
     "publish": {
-      "ignoreChanges": ["**/__test__/**", "**/__demo__/**", "**/__snapshots__/**"],
       "message": "chore(release): publish [skip ci]",
       "registry": "https://registry.npmjs.org"
     }
   },
-  "ignoreChanges": ["**/__demo__/**", "**/__snapshots__/**"]
+  "ignoreChanges": ["**/__test__/**", "**/__demo__/**", "**/__snapshots__/**"]
 }

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -2,7 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc
-tsconfig.json
+tsconfig.*
 .gitlab/
 .gitlab-ci.yml
 *.lock

--- a/packages/create-efx/.npmignore
+++ b/packages/create-efx/.npmignore
@@ -2,7 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc
-tsconfig.json
+tsconfig.*
 .gitlab/
 .gitlab-ci.yml
 *.lock

--- a/packages/demo-block/.npmignore
+++ b/packages/demo-block/.npmignore
@@ -2,7 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc
-tsconfig.json
+tsconfig.*
 .gitlab/
 .gitlab-ci.yml
 *.lock

--- a/packages/elemental-theme/.npmignore
+++ b/packages/elemental-theme/.npmignore
@@ -2,7 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc
-tsconfig.json
+tsconfig.*
 .gitlab/
 .gitlab-ci.yml
 *.lock

--- a/packages/elements/.npmignore
+++ b/packages/elements/.npmignore
@@ -2,7 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc
-tsconfig.json
+tsconfig.*
 .gitlab/
 .gitlab-ci.yml
 *.lock

--- a/packages/halo-theme/.npmignore
+++ b/packages/halo-theme/.npmignore
@@ -2,7 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc
-tsconfig.json
+tsconfig.*
 .gitlab/
 .gitlab-ci.yml
 *.lock

--- a/packages/i18n/.npmignore
+++ b/packages/i18n/.npmignore
@@ -2,7 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc
-tsconfig.json
+tsconfig.*
 .gitlab/
 .gitlab-ci.yml
 *.lock

--- a/packages/phrasebook/.npmignore
+++ b/packages/phrasebook/.npmignore
@@ -2,7 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc
-tsconfig.json
+tsconfig.*
 .gitlab/
 .gitlab-ci.yml
 *.lock

--- a/packages/solar-theme/.npmignore
+++ b/packages/solar-theme/.npmignore
@@ -2,7 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc
-tsconfig.json
+tsconfig.*
 .gitlab/
 .gitlab-ci.yml
 *.lock

--- a/packages/test-helpers/.npmignore
+++ b/packages/test-helpers/.npmignore
@@ -2,7 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc
-tsconfig.json
+tsconfig.*
 .gitlab/
 .gitlab-ci.yml
 *.lock

--- a/packages/theme-compiler/.npmignore
+++ b/packages/theme-compiler/.npmignore
@@ -2,7 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc
-tsconfig.json
+tsconfig.*
 .gitlab/
 .gitlab-ci.yml
 *.lock

--- a/packages/translate/.npmignore
+++ b/packages/translate/.npmignore
@@ -2,7 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc
-tsconfig.json
+tsconfig.*
 .gitlab/
 .gitlab-ci.yml
 *.lock

--- a/packages/utils/.npmignore
+++ b/packages/utils/.npmignore
@@ -2,7 +2,7 @@
 .editorconfig
 .eslintignore
 .eslintrc
-tsconfig.json
+tsconfig.*
 .gitlab/
 .gitlab-ci.yml
 *.lock


### PR DESCRIPTION
## Description

fix missing Blackduck incorrectly list dependencies of our packages dubbed BOM (bill of material) in its dashboard. 

Fixes https://jira.refinitiv.com/browse/ELF-2245

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
