### PR TITLE
Feature/add max property to tree select

### DIFF
--- a/documents/src/pages/elements/tree-select.md
+++ b/documents/src/pages/elements/tree-select.md
@@ -388,7 +388,7 @@ setTimeout(() => { el.opened = true; }, 1000);
 ```
 ```html
 <div class="wrapper">
-  <ef-tree-select opened></ef-tree-select>
+  <ef-tree-select max="3" opened></ef-tree-select>
 </div>
 ```
 ::

--- a/documents/src/pages/elements/tree-select.md
+++ b/documents/src/pages/elements/tree-select.md
@@ -329,6 +329,74 @@ By clicking the `Selected` button, Tree Select allows the items to be filtered b
 
 For custom filtering, Tree Select provides an identical interface as Combo Box. You provide a predicate function that tests an item. Please consult the [Combo Box docs](./elements/combo-box) for details on how to construct a compatible filter.
 
+
+## Limiting Selected Items
+The Tree Select component offers a convenient way to limit the number of selected items using the `max` property. By setting the `max` property, you can define a maximum allowable number of selected items. If users attempt to select more items than the specified limit, the "Done" button will be automatically disabled.
+
+::
+```javascript
+::tree-select::
+const el = document.querySelector("ef-tree-select");
+el.data = [{
+  'value': 'AFR',
+  'label': 'Africa',
+  'expanded': true,
+  'items': [{
+    'value': 'DZA',
+    'label': 'Algeria',
+    'expanded': true,
+    'items': [{
+      'value': 'ADR',
+      'label': 'Adrar',
+      'selected': true,
+      'items': []
+    }, {
+      'value': 'TAM',
+      'label': 'Tamanghasset',
+      'selected': true,
+      'items': []
+    }, {
+      'value': 'GUE',
+      'label': 'Guelma',
+      'selected': false,
+      'items': []
+    }]
+  }, {
+    'value': 'AGO',
+    'label': 'Angola',
+    'selected': false,
+    'items': []
+  }, {
+    'value': 'BEN',
+    'label': 'Benin',
+    'selected': false,
+    'items': []
+  }, {
+    'value': 'BWA',
+    'label': 'Botswana',
+    'selected': false,
+    'items': []
+  }]
+}];
+setTimeout(() => { el.opened = true; }, 1000);
+```
+```css
+.wrapper {
+  padding: 5px;
+  height: 450px;
+}
+```
+```html
+<div class="wrapper">
+  <ef-tree-select opened></ef-tree-select>
+</div>
+```
+::
+
+```html
+<ef-tree-select max="3" opened></ef-tree-select>
+```
+
 ## UI Controls
 Tree Select has several controls.
 

--- a/documents/src/pages/elements/tree-select.md
+++ b/documents/src/pages/elements/tree-select.md
@@ -331,7 +331,7 @@ For custom filtering, Tree Select provides an identical interface as Combo Box. 
 
 
 ## Limiting Selected Items
-The Tree Select component offers a convenient way to limit the number of selected items using the `max` property. By setting the `max` property, you can define a maximum allowable number of selected items. If users attempt to select more items than the specified limit, the "Done" button will be automatically disabled.
+Tree Select offers a convenient way to limit the number of selected items using `max` property. If users attempt to select more items than the specified limit, "Done" button will be automatically disabled.
 
 ::
 ```javascript

--- a/packages/elements/src/tree-select/__demo__/index.html
+++ b/packages/elements/src/tree-select/__demo__/index.html
@@ -90,7 +90,7 @@
       </p>
       <p>
         <span>max = 10</span>
-        <ef-tree-select aria-label="Choose Country" max="2" show-pills></ef-tree-select>
+        <ef-tree-select aria-label="Choose Country" max="10" show-pills></ef-tree-select>
       </p>
     </demo-block>
 

--- a/packages/elements/src/tree-select/__demo__/index.html
+++ b/packages/elements/src/tree-select/__demo__/index.html
@@ -79,6 +79,21 @@
       <ef-tree-select show-pills></ef-tree-select>
     </demo-block>
 
+    <demo-block header="With max" layout="normal" tags="max">
+      <p>
+        <span>max = 0</span>
+        <ef-tree-select aria-label="Choose Country" max="0"></ef-tree-select>
+      </p>
+      <p>
+        <span>max = 2</span>
+        <ef-tree-select aria-label="Choose Country" max="2" show-pills></ef-tree-select>
+      </p>
+      <p>
+        <span>max = 10</span>
+        <ef-tree-select aria-label="Choose Country" max="2" show-pills></ef-tree-select>
+      </p>
+    </demo-block>
+
     <demo-block header="No Relation" layout="normal" tags="individual">
       <ef-tree-select no-relation></ef-tree-select>
     </demo-block>

--- a/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
@@ -298,5 +298,26 @@ describe('tree-select/Interaction', function () {
       );
       expect(el.shadowRoot.querySelector('[part="pills"]')).to.equal(null, 'pills should hide');
     });
+
+    it('has correct disabled state on confirm button when select an item', async function () {
+      const el = await fixture('<ef-tree-select lang="en-gb" max="4"></ef-tree-select>');
+      el.data = flatData;
+      el.opened = true;
+      await elementUpdated(el);
+      const treeItems = el.treeEl.querySelectorAll('[role=treeitem]');
+      const confirmButton = el.popupEl.querySelector('#done');
+      treeItems[0].click();
+      treeItems[1].click();
+      treeItems[2].click();
+      treeItems[3].click();
+      await elementUpdated(el);
+      expect(confirmButton.disabled).to.equal(false);
+      treeItems[4].click();
+      await elementUpdated(el);
+      expect(confirmButton.disabled).to.equal(true);
+      treeItems[4].click(); // uncheck item
+      await elementUpdated(el);
+      expect(confirmButton.disabled).to.equal(false);
+    });
   });
 });

--- a/packages/elements/src/tree-select/__test__/tree-select.value.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.value.test.js
@@ -4,12 +4,12 @@ import '@refinitiv-ui/elements/tree-select';
 import '@refinitiv-ui/elemental-theme/light/ef-tree-select';
 import { elementUpdated, expect, fixture } from '@refinitiv-ui/test-helpers';
 
-const data1 = [{ items: [{ selected: true, value: '1' }] }];
+const data1 = [{ items: [{ selected: true, value: '1', label: '1' }] }];
 const data2 = [
   {
     items: [
-      { selected: true, value: '1' },
-      { selected: true, value: '2' }
+      { selected: true, value: '1', label: '1' },
+      { selected: true, value: '2', label: '2' }
     ]
   }
 ];
@@ -45,6 +45,31 @@ describe('tree-select/Value', function () {
       el.data = [];
       await elementUpdated(el);
       expect(el.values).to.deep.equal([]);
+    });
+  });
+
+  describe('max', function () {
+    it('has correct disabled state on confirm button when values changed', async function () {
+      const el = await fixture('<ef-tree-select lang="en-gb" max="1"></ef-tree-select>');
+      el.data = data2;
+      el.opened = true;
+      await elementUpdated(el);
+      const confirmButton = el.popupEl.querySelector('#done');
+      expect(confirmButton.disabled).to.equal(true);
+      el.values = [];
+      await elementUpdated(el);
+      expect(confirmButton.disabled).to.equal(false);
+    });
+    it('has correct disabled state on confirm button when max value changed', async function () {
+      const el = await fixture('<ef-tree-select lang="en-gb" max="1"></ef-tree-select>');
+      el.data = data2;
+      el.opened = true;
+      await elementUpdated(el);
+      const confirmButton = el.popupEl.querySelector('#done');
+      expect(confirmButton.disabled).to.equal(true);
+      el.max = 2;
+      await elementUpdated(el);
+      expect(confirmButton.disabled).to.equal(false);
     });
   });
 });

--- a/packages/elements/src/tree-select/__test__/tree-select.value.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.value.test.js
@@ -67,9 +67,16 @@ describe('tree-select/Value', function () {
       await elementUpdated(el);
       const confirmButton = el.popupEl.querySelector('#done');
       expect(confirmButton.disabled).to.equal(true);
-      el.max = 2;
+      el.max = '2';
       await elementUpdated(el);
       expect(confirmButton.disabled).to.equal(false);
+    });
+    it('Should reset max to null when define negative max value', async function () {
+      const el = await fixture('<ef-tree-select lang="en-gb" max="-1"></ef-tree-select>');
+      await elementUpdated(el);
+      expect(el.max).to.equal(null);
+      el.max = '2';
+      expect(el.max).to.equal('2');
     });
   });
 });

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -23,6 +23,7 @@ import { VERSION } from '../version.js';
 import type { CheckChangedEvent } from '../events';
 import type { Overlay } from '../overlay';
 import type { Pill } from '../pill';
+import type { Tree } from '../tree/index.js';
 import type { TreeSelectData, TreeSelectDataItem } from './helpers/types';
 
 export { TreeSelectRenderer };
@@ -203,10 +204,22 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
   public override renderer = new TreeSelectRenderer(this);
 
   /**
+   * Set maximum number of selected items.
+   */
+  @property({ type: String, reflect: true })
+  public max: string | null = null;
+
+  /**
    * Internal reference to popup element
    */
   @query('[part=list]')
   protected popupEl?: Overlay;
+
+  /**
+   * Internal reference to tree element
+   */
+  @query('[part=tree]')
+  protected treeEl?: Tree;
 
   /**
    * Set resolved data
@@ -362,6 +375,15 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
     });
 
     return checkedGroupItems;
+  }
+
+  /**
+   * Determines whether the "Done" button element should be disabled,
+   * based on the current state and certain conditions.
+   * @returns {boolean} True if the "Done" button should be disabled, false otherwise.
+   */
+  protected get isConfirmDisabled(): boolean {
+    return Boolean(this.treeEl && this.max && this.treeEl.values.length > Number(this.max));
   }
 
   /**
@@ -928,7 +950,9 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
    */
   protected get commitControlsTemplate(): TemplateResult {
     return html`
-      <ef-button id="done" part="done-button" cta @tap="${this.save}">${this.t('DONE')}</ef-button>
+      <ef-button id="done" part="done-button" cta @tap="${this.save}" .disabled="${this.isConfirmDisabled}"
+        >${this.t('DONE')}</ef-button
+      >
       <ef-button id="cancel" part="cancel-button" @tap="${this.cancel}">${this.t('CANCEL')}</ef-button>
     `;
   }

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -203,11 +203,28 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
   @property({ type: Function, attribute: false })
   public override renderer = new TreeSelectRenderer(this);
 
+  private _max: string | null = null;
   /**
-   * Set maximum number of selected items.
+   * Set maximum number of selected items
+   * @param value max value
+   * @default -
    */
-  @property({ type: String, reflect: true })
-  public max: string | null = null;
+  @property({ type: String })
+  public set max(value: string | null) {
+    value = Number(value) >= 0 ? value : null;
+    const oldValue = this._max;
+    if (oldValue !== value) {
+      this._max = value;
+      this.requestUpdate('max', oldValue);
+    }
+  }
+  /**
+   * Set maximum number of selected items
+   * @returns max value
+   */
+  public get max(): string | null {
+    return this._max;
+  }
 
   /**
    * Internal reference to popup element


### PR DESCRIPTION
## Description
- Introduce `max` as a new prop/attr in Tree Select
- When users choose item that more than `max`, Done button will be disabled
- When users unselected item so the selected item is less than or equals to max, the Done button is activated again.
- Default value of `max` is null and if `max` is set with negative, revert to default.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
