### PR TITLE
fix(slider): page freeze when from/to overflow max value

### DIFF
--- a/packages/elements/src/slider/__test__/slider.test.js
+++ b/packages/elements/src/slider/__test__/slider.test.js
@@ -347,7 +347,7 @@ describe('slider/Slider', function () {
     });
   });
   describe('Min-range', function () {
-    it('Set from/to overflow to nearly max', async function () {
+    it('Should reset from/to value to not exceed max value and ensure it keep min range correctly', async function () {
       el = await fixture(
         '<ef-slider range min="0" max="10" from="25" to="75"  min-range="1"></ef-slider></ef-slider>'
       );

--- a/packages/elements/src/slider/__test__/slider.test.js
+++ b/packages/elements/src/slider/__test__/slider.test.js
@@ -347,6 +347,16 @@ describe('slider/Slider', function () {
     });
   });
   describe('Min-range', function () {
+    it('Set from/to overflow to nearly max', async function () {
+      el = await fixture(
+        '<ef-slider range min="0" max="10" from="25" to="75"  min-range="1"></ef-slider></ef-slider>'
+      );
+      await elementUpdated(el);
+      expect(el.min).to.equal('0');
+      expect(el.max).to.equal('10');
+      expect(el.from).to.equal('9');
+      expect(el.to).to.equal('10');
+    });
     it('Set from and to wrong distance "to" nearly max', async function () {
       el = await fixture('<ef-slider range min="-10" max="10" from="8" to="9" min-range="5"></ef-slider>');
       await elementUpdated(el);

--- a/packages/elements/src/slider/index.ts
+++ b/packages/elements/src/slider/index.ts
@@ -1145,17 +1145,18 @@ export class Slider extends ControlElement {
    * @returns true if value and step inside a boundary
    */
   private isValueInBoundary(value: number, valueFor: string): boolean {
-    if (this.minNumber < this.maxNumber) {
-      // Check if value is in range
-      if (value < this.minNumber || value > this.maxNumber) {
+    if (this.minNumber > this.maxNumber) {
+      return false;
+    }
+    // Check if value is in range
+    if (value < this.minNumber || value > this.maxNumber) {
+      return false;
+    }
+    if (this.range) {
+      if (valueFor === SliderDataName.to && value < this.fromNumber + this.minRangeNumber) {
         return false;
-      }
-      if (this.range) {
-        if (valueFor === SliderDataName.to && value < this.fromNumber + this.minRangeNumber) {
-          return false;
-        } else if (value > this.toNumber - this.minRangeNumber) {
-          return false;
-        }
+      } else if (value > this.toNumber - this.minRangeNumber) {
+        return false;
       }
     }
     return true;
@@ -1203,8 +1204,6 @@ export class Slider extends ControlElement {
   private onMinRangeChange(): void {
     const valueMinRange = Math.abs(this.minRangeNumber);
     const maximumRangeMinMax = Math.abs(this.maxNumber - this.minNumber);
-    const maximumRangeFromTo = Math.abs(this.toNumber - this.fromNumber);
-
     if (valueMinRange && valueMinRange >= this.stepNumber) {
       if (valueMinRange <= maximumRangeMinMax) {
         this.minRange = valueMinRange.toString();

--- a/packages/elements/src/slider/index.ts
+++ b/packages/elements/src/slider/index.ts
@@ -1119,9 +1119,8 @@ export class Slider extends ControlElement {
       this.from = this.format(this.fromNumber);
     } else {
       // if value is outside boundary, set to boundary
-      if (this.fromNumber < this.minNumber) {
-        this.from = this.min;
-      } else if (this.fromNumber > this.toNumber) {
+      this.from = clamp(this.fromNumber, this.minNumber, this.maxNumber);
+      if (this.fromNumber > this.toNumber) {
         this.from = this.to;
       }
 
@@ -1148,21 +1147,15 @@ export class Slider extends ControlElement {
   private isValueInBoundary(value: number, valueFor: string): boolean {
     if (this.minNumber < this.maxNumber) {
       // Check if value is in range
-      if (this.range) {
-        if (valueFor === SliderDataName.to) {
-          if (value < this.fromNumber + this.minRangeNumber || value > this.maxNumber) {
-            return false;
-          }
-        } else if (value < this.minNumber || value > this.toNumber - this.minRangeNumber) {
-          return false;
-        }
-      } else if (value < this.minNumber || value > this.maxNumber) {
+      if (value < this.minNumber || value > this.maxNumber) {
         return false;
       }
-
-      // check step min and max in range
-      if (this.stepRange < this.minNumber || this.stepRange > this.maxNumber) {
-        return true;
+      if (this.range) {
+        if (valueFor === SliderDataName.to && value < this.fromNumber + this.minRangeNumber) {
+          return false;
+        } else if (value > this.toNumber - this.minRangeNumber) {
+          return false;
+        }
       }
     }
     return true;
@@ -1177,10 +1170,9 @@ export class Slider extends ControlElement {
       this.to = this.format(this.toNumber);
     } else {
       // if value is outside boundary, set to boundary
+      this.to = clamp(this.toNumber, this.minNumber, this.maxNumber);
       if (this.toNumber < this.fromNumber) {
         this.to = this.from;
-      } else if (this.toNumber > this.maxNumber) {
-        this.to = this.max;
       }
 
       if (this.minRangeNumber) {
@@ -1214,7 +1206,7 @@ export class Slider extends ControlElement {
     const maximumRangeFromTo = Math.abs(this.toNumber - this.fromNumber);
 
     if (valueMinRange && valueMinRange >= this.stepNumber) {
-      if (valueMinRange <= maximumRangeMinMax && valueMinRange <= maximumRangeFromTo) {
+      if (valueMinRange <= maximumRangeMinMax) {
         this.minRange = valueMinRange.toString();
       } else {
         this.minRange = maximumRangeMinMax.toString();


### PR DESCRIPTION
## Description

Slider range mode got loop hole when from/to overflow from max value

Root cause: 
loop hole happen when element trying to update from/to value under the max/min range but the new value still overflow from max/min range.

Solution: 
set compare values under max/min value before do any comparation 

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-2241

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
