### PR TITLE
fix(number-field): stepUp/stepDown not fire input event

### DIFF
--- a/packages/elements/src/number-field/__demo__/index.html
+++ b/packages/elements/src/number-field/__demo__/index.html
@@ -10,6 +10,7 @@
       }
     </style>
   </head>
+
   <body>
     <script type="module">
       import '@refinitiv-ui/elements/number-field';
@@ -148,6 +149,18 @@
 
         element.addEventListener('value-changed', function (e) {
           valueChangedText.innerHTML = e.detail.value;
+        });
+      </script>
+    </demo-block>
+    <demo-block layout="normal" header="Input event" tags="event">
+      <ef-number-field id="input" placeholder="Input event"></ef-number-field>
+      <p>Value: <code id="input-text"></code></p>
+      <script>
+        var element = document.getElementById('input');
+        var inputText = document.getElementById('input-text');
+
+        element.addEventListener('input', function (e) {
+          inputText.innerHTML = e.detail.value;
         });
       </script>
     </demo-block>

--- a/packages/elements/src/number-field/__demo__/index.html
+++ b/packages/elements/src/number-field/__demo__/index.html
@@ -160,7 +160,7 @@
         var inputText = document.getElementById('input-text');
 
         element.addEventListener('input', function (e) {
-          inputText.innerHTML = e.detail.value;
+          inputText.innerHTML = e.target.value;
         });
       </script>
     </demo-block>

--- a/packages/elements/src/number-field/__test__/number-field.test.js
+++ b/packages/elements/src/number-field/__test__/number-field.test.js
@@ -139,19 +139,18 @@ describe('number-field/NumberField', function () {
       const spinnerUp = el.shadowRoot.querySelector('[part=spinner-up]');
       const spinnerDown = el.shadowRoot.querySelector('[part=spinner-down]');
 
-      let eventFired = false;
+      let eventFiredCounter = 0;
       el.addEventListener('input', () => {
-        eventFired = true;
+        eventFiredCounter += 1;
       });
 
       setTimeout(() => spinnerUp.click());
       await oneEvent(el, 'input');
-      expect(el.value).to.equal('1');
+      expect(eventFiredCounter).to.equal(1);
 
       setTimeout(() => spinnerDown.click());
       await oneEvent(el, 'input');
-      expect(el.value).to.equal('0');
-      expect(eventFired).to.be.true;
+      expect(eventFiredCounter).to.equal(2);
     });
     it('Should not fire input event when programmatically step up/down value', function () {
       let eventFired = false;

--- a/packages/elements/src/number-field/__test__/number-field.test.js
+++ b/packages/elements/src/number-field/__test__/number-field.test.js
@@ -135,14 +135,6 @@ describe('number-field/NumberField', function () {
 
       expect(el.value).to.equal('100');
     });
-    it("Should fire input event when input value by user's interactions", async function () {
-      const input = el.shadowRoot.querySelector('input');
-      input.value = '3';
-
-      setTimeout(() => input.dispatchEvent(new Event('input')));
-      const eventFired = await oneEvent(el, 'input');
-      expect(eventFired.detail.value).to.equal('3');
-    });
     it("Should fire input event when step up/down value by user's interactions", async function () {
       const spinnerUp = el.shadowRoot.querySelector('[part=spinner-up]');
       const spinnerDown = el.shadowRoot.querySelector('[part=spinner-down]');
@@ -153,12 +145,12 @@ describe('number-field/NumberField', function () {
       });
 
       setTimeout(() => spinnerUp.click());
-      const eventUpFired = await oneEvent(el, 'input');
-      expect(eventUpFired.detail.value).to.equal('1');
+      await oneEvent(el, 'input');
+      expect(el.value).to.equal('1');
 
       setTimeout(() => spinnerDown.click());
-      const eventDownFired = await oneEvent(el, 'input');
-      expect(eventDownFired.detail.value).to.equal('0');
+      await oneEvent(el, 'input');
+      expect(el.value).to.equal('0');
       expect(eventFired).to.be.true;
     });
     it('Should not fire input event when programmatically step up/down value', function () {

--- a/packages/elements/src/number-field/__test__/number-field.test.js
+++ b/packages/elements/src/number-field/__test__/number-field.test.js
@@ -135,6 +135,42 @@ describe('number-field/NumberField', function () {
 
       expect(el.value).to.equal('100');
     });
+    it("Should fire input event when input value by user's interactions", async function () {
+      const input = el.shadowRoot.querySelector('input');
+      input.value = '3';
+
+      setTimeout(() => input.dispatchEvent(new Event('input')));
+      const eventFired = await oneEvent(el, 'input');
+      expect(eventFired.detail.value).to.equal('3');
+    });
+    it("Should fire input event when step up/down value by user's interactions", async function () {
+      const spinnerUp = el.shadowRoot.querySelector('[part=spinner-up]');
+      const spinnerDown = el.shadowRoot.querySelector('[part=spinner-down]');
+
+      let eventFired = false;
+      el.addEventListener('input', () => {
+        eventFired = true;
+      });
+
+      setTimeout(() => spinnerUp.click());
+      const eventUpFired = await oneEvent(el, 'input');
+      expect(eventUpFired.detail.value).to.equal('1');
+
+      setTimeout(() => spinnerDown.click());
+      const eventDownFired = await oneEvent(el, 'input');
+      expect(eventDownFired.detail.value).to.equal('0');
+      expect(eventFired).to.be.true;
+    });
+    it('Should not fire input event when programmatically step up/down value', function () {
+      let eventFired = false;
+      el.addEventListener('input', () => {
+        eventFired = true;
+      });
+
+      el.stepUp();
+      el.stepDown();
+      expect(eventFired).to.be.false;
+    });
     it("Should fire event when value changes by user's interactions", async function () {
       const input = el.shadowRoot.querySelector('input');
       input.value = '3';

--- a/packages/elements/src/number-field/__test__/number-field.test.js
+++ b/packages/elements/src/number-field/__test__/number-field.test.js
@@ -152,7 +152,7 @@ describe('number-field/NumberField', function () {
       await oneEvent(el, 'input');
       expect(eventFiredCounter).to.equal(2);
     });
-    it('Should not fire input event when programmatically step up/down value', function () {
+    it('Should not fire input event when programmatically step up/down value', async function () {
       let eventFired = false;
       el.addEventListener('input', () => {
         eventFired = true;
@@ -160,6 +160,7 @@ describe('number-field/NumberField', function () {
 
       el.stepUp();
       el.stepDown();
+      await elementUpdated(el);
       expect(eventFired).to.be.false;
     });
     it("Should fire event when value changes by user's interactions", async function () {

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -425,6 +425,7 @@ export class NumberField extends FormFieldElement {
     }
 
     this.setSilentlyValueAndNotify();
+    event.stopPropagation();
   }
 
   /**
@@ -479,6 +480,7 @@ export class NumberField extends FormFieldElement {
     this.resetError();
 
     const value = this.valueAsNumberString(this.inputValue);
+    this.notifyPropertyInput('value', value);
     if (super.value !== value) {
       // here we must set the value silently to avoid re-rendering of input
       super.value = value;

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -390,6 +390,9 @@ export class NumberField extends FormFieldElement {
    */
   protected override onInputInput(event: InputEvent): void {
     this.onNativeInputChange(event);
+    const value = this.valueAsNumberString(this.inputValue);
+    this.notifyPropertyInput('value', value);
+    event.stopPropagation();
   }
 
   /**
@@ -425,7 +428,6 @@ export class NumberField extends FormFieldElement {
     }
 
     this.setSilentlyValueAndNotify();
-    event.stopPropagation();
   }
 
   /**
@@ -480,7 +482,6 @@ export class NumberField extends FormFieldElement {
     this.resetError();
 
     const value = this.valueAsNumberString(this.inputValue);
-    this.notifyPropertyInput('value', value);
     if (super.value !== value) {
       // here we must set the value silently to avoid re-rendering of input
       super.value = value;

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -332,7 +332,7 @@ export class NumberField extends FormFieldElement {
   protected onApplyStep(direction: Direction): void {
     try {
       this.applyStepDirection(direction);
-      this.notifyPropertyInput('value', this.valueAsNumberString(this.inputValue));
+      this.dispatchEvent(new InputEvent('input'));
       this.setSilentlyValueAndNotify();
     } catch (error) {
       // According to specs stepDown/stepUp may fail for some invalid inputs
@@ -391,8 +391,6 @@ export class NumberField extends FormFieldElement {
    */
   protected override onInputInput(event: InputEvent): void {
     this.onNativeInputChange(event);
-    this.notifyPropertyInput('value', this.valueAsNumberString(this.inputValue));
-    event.stopPropagation();
   }
 
   /**

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -332,6 +332,7 @@ export class NumberField extends FormFieldElement {
   protected onApplyStep(direction: Direction): void {
     try {
       this.applyStepDirection(direction);
+      this.notifyPropertyInput('value', this.valueAsNumberString(this.inputValue));
       this.setSilentlyValueAndNotify();
     } catch (error) {
       // According to specs stepDown/stepUp may fail for some invalid inputs
@@ -390,8 +391,7 @@ export class NumberField extends FormFieldElement {
    */
   protected override onInputInput(event: InputEvent): void {
     this.onNativeInputChange(event);
-    const value = this.valueAsNumberString(this.inputValue);
-    this.notifyPropertyInput('value', value);
+    this.notifyPropertyInput('value', this.valueAsNumberString(this.inputValue));
     event.stopPropagation();
   }
 

--- a/packages/elements/src/slider/index.ts
+++ b/packages/elements/src/slider/index.ts
@@ -1393,7 +1393,6 @@ export class Slider extends ControlElement {
         @blur=${this.onNumberFieldBlur}
         @keydown=${this.onNumberFieldKeyDown}
         @input=${this.onNumberFieldInput}
-        @value-changed=${this.onNumberFieldInput}
         part="input"
         name="${name}"
         no-spinner


### PR DESCRIPTION
## Description


Solution:
dispatch input event when input change from spinner

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-2226

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
