### PR TITLE
CI fix nx publish all package by package-lock.json changed

### DIFF
--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -100,6 +100,8 @@ jobs:
         run: curl -X POST "https://api.cloudflare.com/client/v4/pages/webhooks/deploy_hooks/${{ secrets.CF_DEPLOY_HOOKS_ID_V7 }}"
 
       - name: Publish Visual Studio Code Extension
-        run: npx nx affected --targets vsce:publish --base=release-base --head=HEAD
+        run: |
+          echo package-lock.json >> .nxignore # Prevent this file affected for all packages, issue https://github.com/nrwl/nx/issues/15116
+          npx nx affected --targets vsce:publish --base=release-base --head=HEAD
         env:
           VSCE_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}


### PR DESCRIPTION
## Description

The default behavior of nx `affected` command is detect the files changed which it include the `package-lock.json` from root directory. This is unwanted behavior for publish detection, so we need to ignore the `package-lock.json` file to force this command detect the changes in sub directory of each package only.

Ref: https://github.com/nrwl/nx/issues/15116

## Type of change

- [ ] Refactor (improves code without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
