### PR TITLE
fix(overlay): make overlay close properly

### DIFF
--- a/packages/elements/src/overlay/managers/close-manager.ts
+++ b/packages/elements/src/overlay/managers/close-manager.ts
@@ -91,6 +91,7 @@ export class CloseManager {
 
     if (isOutsideClick && !overlay.noCancelOnOutsideClick) {
       closeCallback();
+      event.stopPropagation();
     }
   };
 


### PR DESCRIPTION
## Description
ef-select can not close dropdown when met thess conditions
1. ef-select has css overridden by `pointer-events: auto`
2. click on `trigger select` area (the one that use to open dropdown)

Expected that should close dropdown but it doesn't.

### Root cause
Actually dropdown is closing but `pointer-events: auto` that make `trigger select` can click to open dropdown again.

### Solution 
As overlay action, it should not do another actions when  closing. 
We put `event.stopPropagation()` to overlay tapstart event so that will not do another tapstart actions when closing.

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-2233

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
