### PR TITLE
chore: update branding from Refinitiv to LSEG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Element Framework is using monorepo. This repository has elements, supporting mo
 - `packages/demo-block` - Use in demo page of each element to demonstrate element's features
 - `packages/elemental-theme` - Base theme to extend to design system theme e.g. Halo Theme
 - `packages/elements` - All elements in Element Framework
-- `packages/halo-theme` - Refinitiv Workspace design system theme
+- `packages/halo-theme` - LSEG Workspace design system theme
 - `packages/i18n` - Wrappers and APIs of formatjs
 - `packages/phrasebook` - All messages (english and non-english) that use within elements
 - `packages/solar-theme` - Legacy theme

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,6 +3,6 @@ License details can be found in the `LICENSE` file. It's available in each packa
 - `./packages/solar-theme`
 - `./packages/halo-theme`
 
-> The font "Proxima Nova Fin" shall only be used within Refinitiv products or services. The copyright owner must approve any use of such font outside of Refinitiv products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text
+> The font "Proxima Nova Fin" shall only be used within LSEG products or services. The copyright owner must approve any use of such font outside of LSEG products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text
 >
 > Do not use 'Italic' style due to the license on Proxima Nova Fin font.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Nightly Test](https://github.com/Refinitiv/refinitiv-ui/actions/workflows/test_nightly.yml/badge.svg?event=schedule)](https://github.com/Refinitiv/refinitiv-ui/actions/workflows/test_nightly.yml)
 [![Production Release](https://github.com/Refinitiv/refinitiv-ui/actions/workflows/prod_release.yml/badge.svg?branch=v7)](https://github.com/Refinitiv/refinitiv-ui/actions/workflows/prod_release.yml)
 
-Element Framework is Refinitiv Workspace's design system components that provides components and tooling to help product teams work faster and more efficiently.
+Element Framework is LSEG Workspace's design system components that provides components and tooling to help product teams work faster and more efficiently.
 
 # Documentation
 

--- a/documents/package.json
+++ b/documents/package.json
@@ -25,7 +25,7 @@
     "Element Framework",
     "EF"
   ],
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "devDependencies": {
     "esbuild": "^0.18.1",

--- a/documents/src/index.md
+++ b/documents/src/index.md
@@ -19,7 +19,7 @@ o> ![translate version](https://img.shields.io/npm/v/@refinitiv-ui/translate/%np
 o> ![utils version](https://img.shields.io/npm/v/@refinitiv-ui/utils/%npm_dist_tag%?color=%2339c46e&label=utils)
 o>
 
-Element Framework (EF) provides components and tooling, aligned with Refinitiv Workspace's design system, to help developers build applications faster and more efficiently.
+Element Framework (EF) provides components and tooling, aligned with LSEG Workspace's design system, to help developers build applications faster and more efficiently.
 
 Components are built using technology native to the browser, allowing them to be lightweight and work with any web framework.
 
@@ -29,19 +29,19 @@ Built on a solid foundation, Element Framework is able to adapt to the needs of 
 
 A library of foundational components are provided to kickstart your development and get products delivered faster and more efficiently.
 
-### Refinitiv Products
+### LSEG Products
 
-Halo is the official theme to use for building any Refinitiv Workspace products and is available in both light and dark variants.
+Halo is the official theme to use for building any LSEG Workspace products and is available in both light and dark variants.
 
 ![Halo](/resources/images/lseg-workspace.svg)
 
-### Non-Refinitiv Products
+### Non-LSEG Products
 
 Themes are designed to be extendable, allowing styling changes to fit branding and device specifications.
 
 ## License
 
-Element framework is open source under Apache License 2.0. However, Halo theme uses Proxima Nova Fin font which shall only be used within Refinitiv products or services. The copyright owner must approve any use of such font outside of Refinitiv products or services, which may be subject to a fee. If you would like to use the framework, [contact us](mailto:ef-support@lseg.com).
+Element framework is open source under Apache License 2.0. However, Halo theme uses Proxima Nova Fin font which shall only be used within LSEG products or services. The copyright owner must approve any use of such font outside of LSEG products or services, which may be subject to a fee. If you would like to use the framework, [contact us](mailto:ef-support@lseg.com).
 
 ## Contribute
 

--- a/documents/src/pages/accessibility.md
+++ b/documents/src/pages/accessibility.md
@@ -43,7 +43,7 @@ Nevertheless, UI developers are still encouraged to quality test color contrast 
 ## Keyboard accessibility
 People with motor disabilities may favour using the keyboard alone when interacting with computer software. Anecdotal evidence also suggests that financial professionals such as Traders prefer the rapidity and ease of keyboard navigation over using a mouse or other pointing device.  
 
-Consequently, the Element Framework components have been engineered for full compatibility with keyboard manipulation. They strive to provide a consistent user experience across Refinitiv products based on the keys diagrammed in figure 1 below. 
+Consequently, the Element Framework components have been engineered for full compatibility with keyboard manipulation. They strive to provide a consistent user experience across LSEG products based on the keys diagrammed in figure 1 below. 
 
 ![Figure 1: Basic keyboard interaction keys](https://user-images.githubusercontent.com/81604092/144179777-585af83e-37ca-45f3-abd1-6317093e8f43.png) "Figure 1: Basic keyboard interaction keys")
 
@@ -69,7 +69,7 @@ Studies show that when most people reach the age of 40, they have already begun 
 
 Those who must deal with more severe vision impairment may use specialized software that allows them to increase contrast, zoom and read out content that displays on the screen. In fact, standard operating systems often provide users with basic versions of such tools. 
 
-Developers should be aware that Refinitiv Workspace offers features to help users avoid the use of specialized software, such as text resizing, dark and light modes, and adjustable market movement colors. The best practices of software testing and release dictate that developers check the product UI’s ability to leverage these helpful features.
+Developers should be aware that LSEG Workspace offers features to help users avoid the use of specialized software, such as text resizing, dark and light modes, and adjustable market movement colors. The best practices of software testing and release dictate that developers check the product UI’s ability to leverage these helpful features.
 
 ## Screen reader accessibility
 

--- a/documents/src/pages/accessibility.md
+++ b/documents/src/pages/accessibility.md
@@ -8,7 +8,7 @@ layout: default
 # Accessibility
 [The World Report on Disability](https://www.who.int/disabilities/world_report/2011/report.pdf) revealed that over 15% of the global population experiences some form of disability, and a recent study by [The Valuable 500](https://www.tortoisemedia.com/disability100-report/) suggests that disability is more prevalent in the business world than most people realize.
 
-In keeping with this growing public awareness, Refinitiv has signed on as a member of The Valuable 500 and made a commitment to inclusion. 
+In keeping with this growing public awareness, LSEG has signed on as a member of The Valuable 500 and made a commitment to inclusion. 
 
 !>Just as importantly, our customers have been telling us that their own internal policies require us to deliver products that are as accessible as possible.
 

--- a/documents/src/pages/elements/efx-grid.md
+++ b/documents/src/pages/elements/efx-grid.md
@@ -13,7 +13,7 @@ EFX Grid provides simple ways to display and manipulate data in table layout. Al
 
 ## License
 
-Grid is only available to active Refinitiv Workspace Subscription License holders. For more information, check [Grid's license](https://refinitiv.github.io/efx-grid/book/en/license.html).
+Grid is only available to active LSEG Workspace Subscription License holders. For more information, check [Grid's license](https://refinitiv.github.io/efx-grid/book/en/license.html).
 
 ## Installation
 
@@ -23,7 +23,7 @@ EFX Grid element and extensions are published under single package.
 npm install @refinitiv-ui/efx-grid
 ```
 
-The element is required theme to instantiate itself in the app. Refinitiv Workspace's design system is called Halo theme and you can install it from npm command.
+The element is required theme to instantiate itself in the app. LSEG Workspace's design system is called Halo theme and you can install it from npm command.
 
 ```bash
 npm install @refinitiv-ui/halo-theme
@@ -35,7 +35,7 @@ See list of APIs, demo and more usage guide by visiting [EFX Grid document](http
 
 ## Usage
 
-Import EFX Grid and its themes into your application. To follow Refinitiv Workspace design system, it is required styles of some native elements e.g. typography.
+Import EFX Grid and its themes into your application. To follow LSEG Workspace design system, it is required styles of some native elements e.g. typography.
 
 ```javascript
 // import element and its Halo dark theme

--- a/documents/src/pages/elements/slider.md
+++ b/documents/src/pages/elements/slider.md
@@ -172,7 +172,7 @@ ef-slider {
 }
 ```
 ```html
-<!-- EF supports Pride at Refinitiv -->
+<!-- EF supports Pride at LSEG -->
 <ef-slider id="red" min="0" max="100" value="70"></ef-slider>
 <ef-slider id="orange" min="0" max="100" value="80"></ef-slider>
 <ef-slider id="yellow" min="0" max="100" value="95"></ef-slider>

--- a/documents/src/pages/start/quick-start.md
+++ b/documents/src/pages/start/quick-start.md
@@ -20,7 +20,7 @@ Components are published as a single package and provide all foundational buildi
 npm install @refinitiv-ui/elements
 ```
 
-Halo is the official theme for Refinitiv Workspace products. It's provided to correctly initialise your application with correct styling and typography.
+Halo is the official theme for LSEG Workspace products. It's provided to correctly initialise your application with correct styling and typography.
 
 ```bash
 npm install @refinitiv-ui/halo-theme

--- a/documents/src/pages/start/styling.md
+++ b/documents/src/pages/start/styling.md
@@ -7,7 +7,7 @@ layout: default
 
 # Applying Styles
 
-Applications in Refinitiv Workspace should use the Halo Design System theme to be fully compliant with branding guidelines. EF elements require their themes to be loaded in order to initialise successfully.
+Applications in LSEG Workspace should use the Halo Design System theme to be fully compliant with branding guidelines. EF elements require their themes to be loaded in order to initialise successfully.
 
 ## Halo Theme
 The Halo Design System theme is provided with two variants; light and dark. An application can use only one variant while the app is running. See [Theme Switching](/guides/theme-switching) to learn how to toggle between light and dark themes in your application.

--- a/documents/src/pages/styles/typography.md
+++ b/documents/src/pages/styles/typography.md
@@ -7,11 +7,11 @@ layout: default
 
 # Typography
 
-In accordance with Refinitiv Workspace's Halo Design System, the default font in your application should be Proxima Nova Fin. The font is a custom font created for Workspace that has been exhaustively researched and tested with users to support a superior reading experience. It will be applied automatically when you import native styles from EF themes.
+In accordance with LSEG Workspace's Halo Design System, the default font in your application should be Proxima Nova Fin. The font is a custom font created for Workspace that has been exhaustively researched and tested with users to support a superior reading experience. It will be applied automatically when you import native styles from EF themes.
 
 For Japanese, Traditional Chinese, and Simplified Chinese, Halo theme has defined a standard font to be used for those languages. However, if the font is not available on users machine, default font that managed by operation system on user's machine will be used.
 
-*>The font "Proxima Nova Fin" shall only be used within Refinitiv products or services. The copyright owner must approve any use of such font outside of Refinitiv products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text
+*>The font "Proxima Nova Fin" shall only be used within LSEG products or services. The copyright owner must approve any use of such font outside of LSEG products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text
 
 x> Font styles in Halo theme are only Regular and Semi Bold. Do not use 'Italic' style due to the license on Proxima Nova Fin font. Bold typeface will be mapped to Semi Bold as it is not customised to render numerical text correctly.
 

--- a/packages/configurations/LICENSE
+++ b/packages/configurations/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, Refinitiv.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/configurations/package.json
+++ b/packages/configurations/package.json
@@ -19,7 +19,7 @@
     "tsconfig",
     "eslintconfig"
   ],
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "peerDependencies": {
     "@trivago/prettier-plugin-sort-imports": "4.1.0",

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, Refinitiv.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
     "url": "git@github.com:Refinitiv/refinitiv-ui.git",
     "directory": "packages/core"
   },
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsc --sourceMap --declarationMap",

--- a/packages/create-efx/LICENSE
+++ b/packages/create-efx/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, Refinitiv.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/create-efx/package.json
+++ b/packages/create-efx/package.json
@@ -11,7 +11,7 @@
     "url": "git@github.com:Refinitiv/refinitiv-ui.git",
     "directory": "packages/create-efx"
   },
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=16.0"

--- a/packages/create-efx/template/LICENSE
+++ b/packages/create-efx/template/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, Refinitiv.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/create-efx/template/package.json.template
+++ b/packages/create-efx/template/package.json.template
@@ -7,7 +7,7 @@
   "types": "./lib/efx-element.d.ts",
   "type": "module",
   "repository": "",
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/demo-block/LICENSE
+++ b/packages/demo-block/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, Refinitiv.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/demo-block/package.json
+++ b/packages/demo-block/package.json
@@ -25,7 +25,7 @@
     "url": "git@github.com:Refinitiv/refinitiv-ui.git",
     "directory": "packages/demo-block"
   },
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "dependencies": {
     "@refinitiv-ui/elemental-theme": "^7.1.0",

--- a/packages/elemental-theme/LICENSE
+++ b/packages/elemental-theme/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, Refinitiv.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/elemental-theme/package.json
+++ b/packages/elemental-theme/package.json
@@ -2,7 +2,7 @@
   "name": "@refinitiv-ui/elemental-theme",
   "version": "7.1.0",
   "description": "Base theme for Element Framework Components",
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "main": "index.less",
   "repository": {

--- a/packages/elements/LICENSE
+++ b/packages/elements/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, Refinitiv.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -1,6 +1,6 @@
 # Element Framework
 
-Element Framework (EF) is a collection of elements that includes theming capability within the Refinitiv Workspace's design system. The elements are a set of web components which is a standard web technology and can be utilized across all browsers.
+Element Framework (EF) is a collection of elements that includes theming capability within the LSEG Workspace's design system. The elements are a set of web components which is a standard web technology and can be utilized across all browsers.
 
 ## Usage
 
@@ -10,13 +10,13 @@ EF elements are published under single package.
 npm install @refinitiv-ui/elements
 ```
 
-The elements are required theme to instantiate itself in the app. Refinitiv Workspace's design system is called Halo theme and you can install it from npm command.
+The elements are required theme to instantiate itself in the app. LSEG Workspace's design system is called Halo theme and you can install it from npm command.
 
 ```sh
 npm install @refinitiv-ui/halo-theme
 ```
 
-Finally, import both elements that you want to use and its themes into your application and it is ready to go. To follow Refinitiv Workspace's design system, it is required styles of some native elements e.g. typography.
+Finally, import both elements that you want to use and its themes into your application and it is ready to go. To follow LSEG Workspace's design system, it is required styles of some native elements e.g. typography.
 
 <br>
 

--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -20,7 +20,7 @@ Finally, import both elements that you want to use and its themes into your appl
 
 <br>
 
-> The font "Proxima Nova Fin" shall only be used within Refinitiv products or services. The copyright owner must approve any use of such font outside of Refinitiv products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text
+> The font "Proxima Nova Fin" shall only be used within LSEG products or services. The copyright owner must approve any use of such font outside of LSEG products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text
 
 <br>
 
@@ -57,4 +57,4 @@ See list of elements, demo and more tutorial by visiting [EF Documentation](http
 
 # License
 
-Apache License 2.0. However, Halo theme shall only be used within Refinitiv products or services due to license of the font "Proxima Nova Fin".
+Apache License 2.0. However, Halo theme shall only be used within LSEG products or services due to license of the font "Proxima Nova Fin".

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -2,7 +2,7 @@
   "name": "@refinitiv-ui/elements",
   "version": "7.4.0",
   "description": "Element Framework Elements",
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "main": "./lib/index.js",
   "module": "./lib/index.js",

--- a/packages/elements/src/dialog/__demo__/index.html
+++ b/packages/elements/src/dialog/__demo__/index.html
@@ -76,26 +76,26 @@
     <demo-block header="Custom Buttons" tags="custom">
       <ef-dialog id="d2" header="Privacy Policy" style="height: 400px">
         <p>
-          Refinitiv is a global organization and your personal information may be stored and processed outside
-          of your home country, including in countries that may not offer the same level of protection for
-          your personal information as your home country. We have measures in place to ensure that when your
+          LSEG is a global organization and your personal information may be stored and processed outside of
+          your home country, including in countries that may not offer the same level of protection for your
+          personal information as your home country. We have measures in place to ensure that when your
           personal information is transferred internationally, it is subject to appropriate safeguards in
           accordance with data protection laws. Often, these include contractual safeguards. More information
           about these safeguards (including copies, where relevant) can be obtained by contacting us here.
         </p>
         <p>
-          Refinitiv has networks, databases, servers, systems, support and helpdesks around the world. We
+          LSEG has networks, databases, servers, systems, support and helpdesks around the world. We
           collaborate with third parties like cloud hosting services, suppliers and technology support located
           around the world to serve the needs of our business, workforce and customers. We take appropriate
           steps to ensure that personal information is processed, secured and transferred according to
           applicable law. In some cases, we may need to disclose or transfer your personal information within
-          Refinitiv or to third parties in areas outside of your home country, including to countries that
-          have not been declared adequate for the purposes of data protection by the European Commission.
+          LSEG or to third parties in areas outside of your home country, including to countries that have not
+          been declared adequate for the purposes of data protection by the European Commission.
         </p>
         <p>
           The areas in which these recipients are located will vary from time to time, but include the United
-          States, Europe, Canada, Asia (including Australia and India), and other countries where Refinitiv
-          has a presence or uses contractors.
+          States, Europe, Canada, Asia (including Australia and India), and other countries where LSEG has a
+          presence or uses contractors.
         </p>
         <div slot="footer" style="padding: 15px 25px">
           <ef-button style="width: 100%" cta onclick="this.parentElement.parentElement.confirm()"
@@ -110,26 +110,26 @@
     <demo-block header="Draggable dialog" tags="draggable">
       <ef-dialog id="d3" header="Privacy Policy" style="height: 400px" draggable>
         <p>
-          Refinitiv is a global organization and your personal information may be stored and processed outside
-          of your home country, including in countries that may not offer the same level of protection for
-          your personal information as your home country. We have measures in place to ensure that when your
+          LSEG is a global organization and your personal information may be stored and processed outside of
+          your home country, including in countries that may not offer the same level of protection for your
+          personal information as your home country. We have measures in place to ensure that when your
           personal information is transferred internationally, it is subject to appropriate safeguards in
           accordance with data protection laws. Often, these include contractual safeguards. More information
           about these safeguards (including copies, where relevant) can be obtained by contacting us here.
         </p>
         <p>
-          Refinitiv has networks, databases, servers, systems, support and helpdesks around the world. We
+          LSEG has networks, databases, servers, systems, support and helpdesks around the world. We
           collaborate with third parties like cloud hosting services, suppliers and technology support located
           around the world to serve the needs of our business, workforce and customers. We take appropriate
           steps to ensure that personal information is processed, secured and transferred according to
           applicable law. In some cases, we may need to disclose or transfer your personal information within
-          Refinitiv or to third parties in areas outside of your home country, including to countries that
-          have not been declared adequate for the purposes of data protection by the European Commission.
+          LSEG or to third parties in areas outside of your home country, including to countries that have not
+          been declared adequate for the purposes of data protection by the European Commission.
         </p>
         <p>
           The areas in which these recipients are located will vary from time to time, but include the United
-          States, Europe, Canada, Asia (including Australia and India), and other countries where Refinitiv
-          has a presence or uses contractors.
+          States, Europe, Canada, Asia (including Australia and India), and other countries where LSEG has a
+          presence or uses contractors.
         </p>
       </ef-dialog>
       <ef-button onclick="openDialog('d3')">Open</ef-button>
@@ -252,26 +252,26 @@
     <demo-block header="Deprecated properties" tags="deprecated">
       <ef-dialog id="d7" header="Privacy Policy" style="height: 400px" modal auto-hide>
         <p>
-          Refinitiv is a global organization and your personal information may be stored and processed outside
-          of your home country, including in countries that may not offer the same level of protection for
-          your personal information as your home country. We have measures in place to ensure that when your
+          LSEG is a global organization and your personal information may be stored and processed outside of
+          your home country, including in countries that may not offer the same level of protection for your
+          personal information as your home country. We have measures in place to ensure that when your
           personal information is transferred internationally, it is subject to appropriate safeguards in
           accordance with data protection laws. Often, these include contractual safeguards. More information
           about these safeguards (including copies, where relevant) can be obtained by contacting us here.
         </p>
         <p>
-          Refinitiv has networks, databases, servers, systems, support and helpdesks around the world. We
+          LSEG has networks, databases, servers, systems, support and helpdesks around the world. We
           collaborate with third parties like cloud hosting services, suppliers and technology support located
           around the world to serve the needs of our business, workforce and customers. We take appropriate
           steps to ensure that personal information is processed, secured and transferred according to
           applicable law. In some cases, we may need to disclose or transfer your personal information within
-          Refinitiv or to third parties in areas outside of your home country, including to countries that
-          have not been declared adequate for the purposes of data protection by the European Commission.
+          LSEG or to third parties in areas outside of your home country, including to countries that have not
+          been declared adequate for the purposes of data protection by the European Commission.
         </p>
         <p>
           The areas in which these recipients are located will vary from time to time, but include the United
-          States, Europe, Canada, Asia (including Australia and India), and other countries where Refinitiv
-          has a presence or uses contractors.
+          States, Europe, Canada, Asia (including Australia and India), and other countries where LSEG has a
+          presence or uses contractors.
         </p>
       </ef-dialog>
       <ef-button onclick="openDialog('d7')">Open</ef-button>

--- a/packages/halo-theme/LICENSE
+++ b/packages/halo-theme/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2023 Refinitiv. All rights reserved.
+Copyright (C) 2023 LSEG. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
@@ -10,4 +10,4 @@ Redistribution and use in source and binary forms, with or without modification,
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-4. The font "Proxima Nova Fin" shall only be used within Refinitiv products or services. The copyright owner must approve any use of such font outside of Refinitiv products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text
+4. The font "Proxima Nova Fin" shall only be used within LSEG products or services. The copyright owner must approve any use of such font outside of LSEG products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text

--- a/packages/halo-theme/README.md
+++ b/packages/halo-theme/README.md
@@ -6,6 +6,6 @@ See list of elements, demo and more tutorial by visiting [EF Documentation](http
 
 # License
 
-Halo theme shall only be used within Refinitiv products or services due to license of the font "Proxima Nova Fin".
+Halo theme shall only be used within LSEG products or services due to license of the font "Proxima Nova Fin".
 
-The font "Proxima Nova Fin" shall only be used within Refinitiv products or services. The copyright owner must approve any use of such font outside of Refinitiv products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text
+The font "Proxima Nova Fin" shall only be used within LSEG products or services. The copyright owner must approve any use of such font outside of LSEG products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text

--- a/packages/halo-theme/README.md
+++ b/packages/halo-theme/README.md
@@ -1,6 +1,6 @@
 # Halo Theme
 
-This is the official theme for Refinitiv Workspace. The theme needs to use with EF elements.
+This is the official theme for LSEG Workspace. The theme needs to use with EF elements.
 
 See list of elements, demo and more tutorial by visiting [EF Documentation](https://ui.refinitiv.com).
 

--- a/packages/halo-theme/package.json
+++ b/packages/halo-theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@refinitiv-ui/halo-theme",
   "version": "7.1.0",
-  "description": "Official theme for Refinitiv Workspace",
+  "description": "Official theme for LSEG Workspace",
   "author": "LSEG",
   "license": "SEE LICENSE IN LICENSE",
   "main": "index.less",

--- a/packages/halo-theme/package.json
+++ b/packages/halo-theme/package.json
@@ -2,7 +2,7 @@
   "name": "@refinitiv-ui/halo-theme",
   "version": "7.1.0",
   "description": "Official theme for Refinitiv Workspace",
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "SEE LICENSE IN LICENSE",
   "main": "index.less",
   "repository": {

--- a/packages/i18n/LICENSE
+++ b/packages/i18n/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, Refinitiv.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -23,7 +23,7 @@
     "prepack": "npm run version",
     "version": "node ../../scripts/version/index.mjs"
   },
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "dependencies": {
     "@formatjs/ecma402-abstract": "1.14.3",

--- a/packages/phrasebook/LICENSE
+++ b/packages/phrasebook/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, Refinitiv.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/phrasebook/package.json
+++ b/packages/phrasebook/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.3",
   "type": "module",
   "description": "Collection of messages in EF components for translation",
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "main": "./lib/index.js",
   "module": "./lib/index.js",

--- a/packages/solar-theme/LICENSE
+++ b/packages/solar-theme/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2023 Refinitiv. All rights reserved.
+Copyright (C) 2023 LSEG. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
@@ -10,4 +10,4 @@ Redistribution and use in source and binary forms, with or without modification,
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-4. The font "Proxima Nova Fin" shall only be used within Refinitiv products or services. The copyright owner must approve any use of such font outside of Refinitiv products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text
+4. The font "Proxima Nova Fin" shall only be used within LSEG products or services. The copyright owner must approve any use of such font outside of LSEG products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text

--- a/packages/solar-theme/README.md
+++ b/packages/solar-theme/README.md
@@ -1,6 +1,6 @@
 # Solar Theme
 
-This is a legacy theme. It's only to use for Eikon products and services and shall not use within Refinitiv Workspace.
+This is a legacy theme. It's only to use for Eikon products and services and shall not use within LSEG Workspace.
 
 The theme needs to use with EF elements. See list of elements, demo and more tutorial by visiting [EF Documentation](https://ui.refinitiv.com).
 

--- a/packages/solar-theme/README.md
+++ b/packages/solar-theme/README.md
@@ -6,6 +6,6 @@ The theme needs to use with EF elements. See list of elements, demo and more tut
 
 # License
 
-Solar theme shall only be used within Refinitiv products or services due to license of the font "Proxima Nova Fin".
+Solar theme shall only be used within LSEG products or services due to license of the font "Proxima Nova Fin".
 
-The font "Proxima Nova Fin" shall only be used within Refinitiv products or services. The copyright owner must approve any use of such font outside of Refinitiv products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text
+The font "Proxima Nova Fin" shall only be used within LSEG products or services. The copyright owner must approve any use of such font outside of LSEG products or services, which may be subject to a fee. Please see https://www.fontspring.com/lic/fontspring/webfont#license_text

--- a/packages/solar-theme/package.json
+++ b/packages/solar-theme/package.json
@@ -2,7 +2,7 @@
   "name": "@refinitiv-ui/solar-theme",
   "version": "7.1.0",
   "description": "Solar theme for the Element Framework",
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "SEE LICENSE IN LICENSE",
   "main": "index.less",
   "repository": {

--- a/packages/test-helpers/LICENSE
+++ b/packages/test-helpers/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, Refinitiv.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -10,7 +10,7 @@
     "url": "git@github.com:Refinitiv/refinitiv-ui.git",
     "directory": "packages/test-helpers"
   },
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsc --sourceMap --declarationMap",

--- a/packages/theme-compiler/LICENSE
+++ b/packages/theme-compiler/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, Refinitiv.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/theme-compiler/package.json
+++ b/packages/theme-compiler/package.json
@@ -2,7 +2,7 @@
   "name": "@refinitiv-ui/theme-compiler",
   "version": "7.0.3",
   "description": "Compiles Element Framework themes into usable JavaScript",
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "bin": {
     "theme-compiler": "./bin/theme-compiler.js"

--- a/packages/translate/LICENSE
+++ b/packages/translate/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, Refinitiv.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/translate/package.json
+++ b/packages/translate/package.json
@@ -2,7 +2,7 @@
   "name": "@refinitiv-ui/translate",
   "version": "7.0.3",
   "description": "i18n implementation for Element Framework components",
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "main": "./lib/translate.js",
   "module": "./lib/translate.js",

--- a/packages/utils/LICENSE
+++ b/packages/utils/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, Refinitiv.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -37,7 +37,7 @@
     "url": "git@github.com:Refinitiv/refinitiv-ui.git",
     "directory": "packages/utils"
   },
-  "author": "Refinitiv",
+  "author": "LSEG",
   "license": "Apache-2.0",
   "scripts": {
     "lint": "eslint .",

--- a/vscode-extensions/snippets/LICENSE
+++ b/vscode-extensions/snippets/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2023, LSEG.
+Copyright © 2023, LSEG
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vscode-extensions/snippets/README.md
+++ b/vscode-extensions/snippets/README.md
@@ -12,7 +12,7 @@ You can use these snippets in 3 steps
 
 ## Documentation
 
-For more information about Refinitiv-UI, you can find the getting started and usage guide from this [documentation](https://ui.refinitiv.com).
+For more information about Element Framework, you can find the getting started and usage guide from this [documentation](https://ui.refinitiv.com).
 
 ## Contribute
 
@@ -20,7 +20,7 @@ We greatly welcome contributions. You can help make the snippets better by impro
 
 ## For more information
 
-- [Refinitiv UI - Documentation](https://ui.refinitiv.com/)
-- [Refinitiv UI - GitHub](https://github.com/Refinitiv/refinitiv-ui)
+- [Element Framework - Documentation](https://ui.refinitiv.com/)
+- [Element Framework - GitHub](https://github.com/Refinitiv/refinitiv-ui)
 
 **Happy coding!**


### PR DESCRIPTION
Update branding from Refinitiv to LSEG. It shouldn't have any 'Refinitiv' wording anywhere (except URL, technical name, API). Refinitiv Workspace to be LSEG Workspace.