### PR TITLE
refactor(phrasebook): cleanup unnecessary links to element doc

### DIFF
--- a/packages/phrasebook/src/locale/de/color-dialog.ts
+++ b/packages/phrasebook/src/locale/de/color-dialog.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/color-dialog.html
+// Component docs https://ui.refinitiv.com/elements/color-dialog
 import { Phrasebook } from '../../translation.js';
 import dialogTranslations from './dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/de/color-dialog.ts
+++ b/packages/phrasebook/src/locale/de/color-dialog.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/color-dialog
 import { Phrasebook } from '../../translation.js';
 import dialogTranslations from './dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/de/color-picker.ts
+++ b/packages/phrasebook/src/locale/de/color-picker.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/color-picker
 import { Phrasebook } from '../../translation.js';
 import './color-dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/de/pagination.ts
+++ b/packages/phrasebook/src/locale/de/pagination.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/pagination.html
+// Component docs https://ui.refinitiv.com/elements/pagination
 import { Phrasebook } from '../../translation.js';
 import './shared.js';
 

--- a/packages/phrasebook/src/locale/de/pagination.ts
+++ b/packages/phrasebook/src/locale/de/pagination.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/pagination
 import { Phrasebook } from '../../translation.js';
 import './shared.js';
 

--- a/packages/phrasebook/src/locale/de/tree-select.ts
+++ b/packages/phrasebook/src/locale/de/tree-select.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/tree-select.html
+// Component docs https://ui.refinitiv.com/elements/tree-select
 import { Phrasebook } from '../../translation.js';
 import comboboxTranslations from './combo-box.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/de/tree-select.ts
+++ b/packages/phrasebook/src/locale/de/tree-select.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/tree-select
 import { Phrasebook } from '../../translation.js';
 import comboboxTranslations from './combo-box.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/en/color-dialog.ts
+++ b/packages/phrasebook/src/locale/en/color-dialog.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/color-dialog.html
+// Component docs https://ui.refinitiv.com/elements/color-dialog
 import { Phrasebook } from '../../translation.js';
 import dialogTranslations from './dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/en/color-dialog.ts
+++ b/packages/phrasebook/src/locale/en/color-dialog.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/color-dialog
 import { Phrasebook } from '../../translation.js';
 import dialogTranslations from './dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/en/color-picker.ts
+++ b/packages/phrasebook/src/locale/en/color-picker.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/color-picker
 import { Phrasebook } from '../../translation.js';
 import './color-dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/en/pagination.ts
+++ b/packages/phrasebook/src/locale/en/pagination.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/pagination.html
+// Component docs https://ui.refinitiv.com/elements/pagination
 import { Phrasebook } from '../../translation.js';
 import './shared.js';
 

--- a/packages/phrasebook/src/locale/en/pagination.ts
+++ b/packages/phrasebook/src/locale/en/pagination.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/pagination
 import { Phrasebook } from '../../translation.js';
 import './shared.js';
 

--- a/packages/phrasebook/src/locale/en/tree-select.ts
+++ b/packages/phrasebook/src/locale/en/tree-select.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/tree-select.html
+// Component docs https://ui.refinitiv.com/elements/tree-select
 import { Phrasebook } from '../../translation.js';
 import comboboxTranslations from './combo-box.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/en/tree-select.ts
+++ b/packages/phrasebook/src/locale/en/tree-select.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/tree-select
 import { Phrasebook } from '../../translation.js';
 import comboboxTranslations from './combo-box.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/ja/color-dialog.ts
+++ b/packages/phrasebook/src/locale/ja/color-dialog.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/color-dialog.html
+// Component docs https://ui.refinitiv.com/elements/color-dialog
 import { Phrasebook } from '../../translation.js';
 import dialogTranslations from './dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/ja/color-dialog.ts
+++ b/packages/phrasebook/src/locale/ja/color-dialog.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/color-dialog
 import { Phrasebook } from '../../translation.js';
 import dialogTranslations from './dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/ja/color-picker.ts
+++ b/packages/phrasebook/src/locale/ja/color-picker.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/color-picker
 import { Phrasebook } from '../../translation.js';
 import './color-dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/ja/pagination.ts
+++ b/packages/phrasebook/src/locale/ja/pagination.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/pagination.html
+// Component docs https://ui.refinitiv.com/elements/pagination
 import { Phrasebook } from '../../translation.js';
 import './shared.js';
 

--- a/packages/phrasebook/src/locale/ja/pagination.ts
+++ b/packages/phrasebook/src/locale/ja/pagination.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/pagination
 import { Phrasebook } from '../../translation.js';
 import './shared.js';
 

--- a/packages/phrasebook/src/locale/ja/tree-select.ts
+++ b/packages/phrasebook/src/locale/ja/tree-select.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/tree-select.html
+// Component docs https://ui.refinitiv.com/elements/tree-select
 import { Phrasebook } from '../../translation.js';
 import comboboxTranslations from './combo-box.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/ja/tree-select.ts
+++ b/packages/phrasebook/src/locale/ja/tree-select.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/tree-select
 import { Phrasebook } from '../../translation.js';
 import comboboxTranslations from './combo-box.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/zh-hant/color-dialog.ts
+++ b/packages/phrasebook/src/locale/zh-hant/color-dialog.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/color-dialog.html
+// Component docs https://ui.refinitiv.com/elements/color-dialog
 import { Phrasebook } from '../../translation.js';
 import dialogTranslations from './dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/zh-hant/color-dialog.ts
+++ b/packages/phrasebook/src/locale/zh-hant/color-dialog.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/color-dialog
 import { Phrasebook } from '../../translation.js';
 import dialogTranslations from './dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/zh-hant/color-picker.ts
+++ b/packages/phrasebook/src/locale/zh-hant/color-picker.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/color-picker
 import { Phrasebook } from '../../translation.js';
 import './color-dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/zh-hant/pagination.ts
+++ b/packages/phrasebook/src/locale/zh-hant/pagination.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/pagination.html
+// Component docs https://ui.refinitiv.com/elements/pagination
 import { Phrasebook } from '../../translation.js';
 import './shared.js';
 

--- a/packages/phrasebook/src/locale/zh-hant/pagination.ts
+++ b/packages/phrasebook/src/locale/zh-hant/pagination.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/pagination
 import { Phrasebook } from '../../translation.js';
 import './shared.js';
 

--- a/packages/phrasebook/src/locale/zh-hant/tree-select.ts
+++ b/packages/phrasebook/src/locale/zh-hant/tree-select.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/tree-select.html
+// Component docs https://ui.refinitiv.com/elements/tree-select
 import { Phrasebook } from '../../translation.js';
 import comboboxTranslations from './combo-box.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/zh-hant/tree-select.ts
+++ b/packages/phrasebook/src/locale/zh-hant/tree-select.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/tree-select
 import { Phrasebook } from '../../translation.js';
 import comboboxTranslations from './combo-box.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/zh/color-dialog.ts
+++ b/packages/phrasebook/src/locale/zh/color-dialog.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/color-dialog.html
+// Component docs https://ui.refinitiv.com/elements/color-dialog
 import { Phrasebook } from '../../translation.js';
 import dialogTranslations from './dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/zh/color-dialog.ts
+++ b/packages/phrasebook/src/locale/zh/color-dialog.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/color-dialog
 import { Phrasebook } from '../../translation.js';
 import dialogTranslations from './dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/zh/color-picker.ts
+++ b/packages/phrasebook/src/locale/zh/color-picker.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/color-picker
 import { Phrasebook } from '../../translation.js';
 import './color-dialog.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/zh/pagination.ts
+++ b/packages/phrasebook/src/locale/zh/pagination.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/pagination.html
+// Component docs https://ui.refinitiv.com/elements/pagination
 import { Phrasebook } from '../../translation.js';
 import './shared.js';
 

--- a/packages/phrasebook/src/locale/zh/pagination.ts
+++ b/packages/phrasebook/src/locale/zh/pagination.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/pagination
 import { Phrasebook } from '../../translation.js';
 import './shared.js';
 

--- a/packages/phrasebook/src/locale/zh/tree-select.ts
+++ b/packages/phrasebook/src/locale/zh/tree-select.ts
@@ -1,4 +1,4 @@
-// Component docs https://elf.int.refinitiv.com/elements/tree-select.html
+// Component docs https://ui.refinitiv.com/elements/tree-select
 import { Phrasebook } from '../../translation.js';
 import comboboxTranslations from './combo-box.js';
 import './shared.js';

--- a/packages/phrasebook/src/locale/zh/tree-select.ts
+++ b/packages/phrasebook/src/locale/zh/tree-select.ts
@@ -1,4 +1,3 @@
-// Component docs https://ui.refinitiv.com/elements/tree-select
 import { Phrasebook } from '../../translation.js';
 import comboboxTranslations from './combo-box.js';
 import './shared.js';


### PR DESCRIPTION
## Description

correct links to element doc in phrasebook package

Fixes # https://jira.refinitiv.com/browse/ELF-2279

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
