### PR TITLE
fix(interactive-chart): invalid legend render when add new seriesList

### DIFF
--- a/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
+++ b/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
@@ -563,6 +563,9 @@ describe('interactive-chart/InteractiveChart', function () {
       await elementUpdated(el);
       await nextFrame(3); // wait for resize observer & rendering completion
       expect(el.hasDataPoint).to.be.true;
+      const legendText = el.rowLegend[0].textContent;
+      const isIncludedPrices = [5679, 5694, 5544, 5547].every((price) => legendText.includes(price));
+      expect(isIncludedPrices).to.be.true;
     });
   });
 });

--- a/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
+++ b/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
@@ -558,7 +558,6 @@ describe('interactive-chart/InteractiveChart', function () {
       await nextFrame(3); // wait for resize observer & rendering completion
       expect(el.hasDataPoint).to.be.false;
 
-      await nextFrame();
       el.seriesList[0].setData(data);
       el.config.series[0].data = data;
       await elementUpdated(el);

--- a/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
+++ b/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
@@ -534,5 +534,36 @@ describe('interactive-chart/InteractiveChart', function () {
       expect(legendStyle.position).to.equal('absolute');
       expect(legendLeftPosition).to.equal(InteractiveChart.DEFAULT_LEGEND_LEFT_POSITION);
     });
+
+    it('Should render new Legend when add new seriesList.', async function () {
+      const data = [
+        {
+          time: 1678147200,
+          open: 5679,
+          high: 5694,
+          low: 5544,
+          close: 5547,
+          value: 5547
+        }
+      ];
+      el.config = {
+        series: [
+          {
+            symbol: 'Price',
+            type: 'candlestick'
+          }
+        ]
+      };
+      await elementUpdated(el);
+      await nextFrame(3); // wait for resize observer & rendering completion
+      expect(el.hasDataPoint).to.be.false;
+
+      await nextFrame();
+      el.seriesList[0].setData(data);
+      el.config.series[0].data = data;
+      await elementUpdated(el);
+      await nextFrame(3); // wait for resize observer & rendering completion
+      expect(el.hasDataPoint).to.be.true;
+    });
   });
 });

--- a/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
+++ b/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
@@ -564,7 +564,8 @@ describe('interactive-chart/InteractiveChart', function () {
       await nextFrame(3); // wait for resize observer & rendering completion
       expect(el.hasDataPoint).to.be.true;
       const legendText = el.rowLegend[0].textContent;
-      const isIncludedPrices = [5679, 5694, 5544, 5547].every((price) => legendText.includes(price));
+      const { open, high, low, close } = data[0];
+      const isIncludedPrices = [open, high, low, close].every((price) => legendText.includes(price));
       expect(isIncludedPrices).to.be.true;
     });
   });

--- a/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
+++ b/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
@@ -562,10 +562,10 @@ describe('interactive-chart/InteractiveChart', function () {
       el.config.series[0].data = data;
       await elementUpdated(el);
       await nextFrame(3); // wait for resize observer & rendering completion
-      expect(el.hasDataPoint).to.be.true;
       const legendText = el.rowLegend[0].textContent;
       const { open, high, low, close } = data[0];
       const isIncludedPrices = [open, high, low, close].every((price) => legendText.includes(price));
+      expect(el.hasDataPoint).to.be.true;
       expect(isIncludedPrices).to.be.true;
     });
   });

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -1100,6 +1100,7 @@ export class InteractiveChart extends ResponsiveElement {
         const dataSet = series.data || [];
         const latestData = dataSet[dataSet.length - 1];
         if (latestData) {
+          this.hasDataPoint = dataSet.length > 0;
           const priceColor = this.getColorInSeries(latestData, chartType, idx);
           // Render legend by series type
           this.renderTextLegend(chartType, this.rowLegend, latestData, priceColor, idx);


### PR DESCRIPTION
## Description
After add new seriesList to no data interactive-chart, a legend show invalid render such as `[object Object]`

### Root cause
`hasDataPoint` value is using in condition to render a legend but not update due to latest data. 

### Solution
update `hasDataPoint` when update legend with latest data.

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-2276

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
