### PR TITLE
test(tree-select): fix test failed on Safari minus 1

### DIFF
--- a/packages/elements/src/tree-select/__test__/tree-select.value.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.value.test.js
@@ -114,6 +114,7 @@ describe('tree-select/Value', function () {
       el.data = data2;
       el.opened = true;
       await elementUpdated(el);
+      await nextFrame();
       const confirmButton = el.popupEl.querySelector('#done');
       expect(confirmButton.disabled).to.equal(true);
       el.values = [];
@@ -125,6 +126,7 @@ describe('tree-select/Value', function () {
       el.data = data2;
       el.opened = true;
       await elementUpdated(el);
+      await nextFrame();
       const confirmButton = el.popupEl.querySelector('#done');
       expect(confirmButton.disabled).to.equal(true);
       el.max = '2';


### PR DESCRIPTION
Tree select required nextFrame to waiting the popup open when testing on Safari and IOS.