### PR TITLE
test(tree-select): fix tree select test failed on safari v6

### DIFF
--- a/packages/elements/src/tree-select/__test__/tree-select.value.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.value.test.js
@@ -120,6 +120,7 @@ describe('tree-select/Value', function () {
       el.opened = true;
       await elementUpdated(el);
       await nextFrame();
+
       const confirmButton = el.popupEl.querySelector('#done');
       expect(confirmButton.disabled).to.equal(true);
       el.values = [];
@@ -132,6 +133,7 @@ describe('tree-select/Value', function () {
       el.opened = true;
       await elementUpdated(el);
       await nextFrame();
+
       const confirmButton = el.popupEl.querySelector('#done');
       expect(confirmButton.disabled).to.equal(true);
       el.max = '2';

--- a/packages/elements/src/tree-select/__test__/tree-select.value.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.value.test.js
@@ -119,6 +119,7 @@ describe('tree-select/Value', function () {
       el.data = data2;
       el.opened = true;
       await elementUpdated(el);
+      await nextFrame();
       const confirmButton = el.popupEl.querySelector('#done');
       expect(confirmButton.disabled).to.equal(true);
       el.values = [];
@@ -130,6 +131,7 @@ describe('tree-select/Value', function () {
       el.data = data2;
       el.opened = true;
       await elementUpdated(el);
+      await nextFrame();
       const confirmButton = el.popupEl.querySelector('#done');
       expect(confirmButton.disabled).to.equal(true);
       el.max = '2';

--- a/packages/elements/src/tree-select/__test__/tree-select.value.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.value.test.js
@@ -118,6 +118,7 @@ describe('tree-select/Value', function () {
       const el = await fixture('<ef-tree-select lang="en-gb" max="1"></ef-tree-select>');
       el.data = data2;
       el.opened = true;
+
       await elementUpdated(el);
       await nextFrame();
 


### PR DESCRIPTION
## Description
Tree select required nextFrame to waiting the popup open when testing on Safari and IOS.