### PR TITLE
docs(fields): add missing validation methods in jsdoc and improve fields documentation

### DIFF
--- a/documents/src/pages/elements/email-field.md
+++ b/documents/src/pages/elements/email-field.md
@@ -165,12 +165,7 @@ const emailField = document.querySelector("ef-email-field");
 const errorText = document.getElementById('error-text');
 
 emailField.addEventListener("blur", (event) => {
-  if (emailField.error) {
-    errorText.innerHTML = "Must be in standard email format with between 8-14 characters.";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = emailField.error ? "Must be in standard email format with between 8-14 characters." : "";
 });
 
 emailField.addEventListener("input", () => {
@@ -190,12 +185,7 @@ emailField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if (emailField?.error) {
-    errorText.innerHTML = "Must be in standard email format with between 8-14 characters.";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = emailField?.error ? "Must be in standard email format with between 8-14 characters." : "";
 });
 
 emailField?.addEventListener("input", () => {
@@ -218,12 +208,7 @@ const emailField = document.querySelector("ef-email-field");
 const errorText = document.getElementById("error-text");
 
 emailField.addEventListener("blur", () => {
-  if (emailField.error) {
-    errorText.innerHTML = "Email must end with '@mail.com'.";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = emailField.error ? "Email must end with '@mail.com'." : "";
 });
 
 emailField.addEventListener("input", () => {
@@ -262,12 +247,7 @@ const emailField = document.querySelector("ef-email-field");
 const errorText = document.getElementById("error-text");
 
 emailField.addEventListener("blur", () => {
-  if (emailField.error) {
-    errorText.innerHTML = "Email must end with '@mail.com'.";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = emailField.error ? "Email must end with '@mail.com'." : "";
 });
 
 emailField.addEventListener("input", () => {

--- a/documents/src/pages/elements/email-field.md
+++ b/documents/src/pages/elements/email-field.md
@@ -304,11 +304,8 @@ emailField.addEventListener('icon-click', (e) => {
 });
 emailField.addEventListener("blur", () => {
   if (emailField.error) {
-    errorText.innerHTML = "Invalid email format.";
+    errorText.innerHTML = emailField.error ? "Invalid email format." : "";
     emailList.innerHTML = "";
-  }
-  else {
-    errorText.innerHTML = "";
   }
 });
 emailField.addEventListener("input", () => {

--- a/documents/src/pages/elements/email-field.md
+++ b/documents/src/pages/elements/email-field.md
@@ -118,6 +118,8 @@ See the [Input Length](/elements/email-field#input-length) example below for mor
 ## Input length
 The `maxlength` attribute limits the number of characters that users can type into the input and the `minlength` attribute is used to set the minimum of characters required. `ef-email-field` will show error styles if the condition is not met.
 
+@> Constraint validation is only applied when the value is changed by the user. [See input email](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#maxlength).
+
 ::
 ```javascript
 ::email-field::

--- a/documents/src/pages/elements/email-field.md
+++ b/documents/src/pages/elements/email-field.md
@@ -111,14 +111,14 @@ button.addEventListener('tap', () => {
 
 ### Displaying error messages
 
-Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
+Whenever input is invalid, the `error` attribute will be added to the element. You can use the `error` property to check if input is currently in the error state. Note that, if input is initialised with invalid value, `reportValidity()` must be called first as described in [Input Validation](/elements/email-field#input-validation).
 
 See the [Input Length](/elements/email-field#input-length) example below for more detail.
 
 ## Input length
 The `maxlength` attribute limits the number of characters that users can type into the input and the `minlength` attribute is used to set the minimum of characters required. `ef-email-field` will show error styles if the condition is not met.
 
-@> Constraint validation is only applied when the value is changed by the user. [See input email](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#maxlength).
+@> `maxlength` and `minlength` constraint validations are only applied when the value is changed by the user. [See input email](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#maxlength).
 
 ::
 ```javascript
@@ -127,12 +127,9 @@ const emailField = document.querySelector("ef-email-field");
 const errorText = document.getElementById('error-text');
 
 emailField.addEventListener("blur", (event) => {
-  if (emailField.error) {
-    errorText.innerHTML = "Must be in standard email format with between 8-14 characters.";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML =  emailField.error
+    ? "Must be in standard email format with between 8-14 characters."
+    :  "";
 });
 emailField.addEventListener("input", () => {
   if (!emailField.error) {
@@ -186,7 +183,7 @@ emailField.addEventListener("input", () => {
 ```typescript
 import { EmailField } from '@refinitiv-ui/elements/email-field';
 
-const emailField = document.querySelector("ef-email-field") as EmailField;
+const emailField = document.querySelector<EmailField>("ef-email-field");
 const errorText = document.getElementById('error-text');
 
 emailField?.addEventListener("blur", () => {
@@ -283,19 +280,14 @@ emailField.addEventListener("input", () => {
 ```typescript
 import { EmailField } from "@refinitiv-ui/elements/email-field";
 
-const emailField = document.querySelector("ef-email-field") as EmailField;
+const emailField = document.querySelector<EmailField>("ef-email-field");
 const errorText = document.getElementById("error-text");
 
 emailField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if (emailField?.error) {
-    errorText.innerHTML = "Email must end with '@mail.com'.";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML =  emailField?.error ? "Email must end with '@mail.com'." :  "";
 });
 
 emailField?.addEventListener("input", () => {

--- a/documents/src/pages/elements/email-field.md
+++ b/documents/src/pages/elements/email-field.md
@@ -93,9 +93,25 @@ emailField?.addEventListener("value-changed", (event) => {
 
 `ef-email-field` has validation logic similar to a native input. When a user types the invalid value into the control, error style will be shown to notify the user. However, if the control is being initialised with an invalid value, `reportValidity()` must be called to ensure the error style is applied.
 
-Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
+::
+```javascript
+::email-field::
+const emailField = document.querySelector('ef-email-field');
+const button = document.querySelector("ef-button");
 
-You can add the event listener `error-changed` to the element and it will dispatch whenever the error state changes.
+button.addEventListener('tap', () => {
+  emailField.reportValidity();
+})
+```
+```html
+<ef-email-field value="1"></ef-email-field>
+<ef-button>Submit</ef-button>
+```
+::
+
+### Displaying error messages
+
+Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
 
 See the [Input Length](/elements/email-field#input-length) example below for more detail.
 
@@ -106,14 +122,20 @@ The `maxlength` attribute limits the number of characters that users can type in
 ```javascript
 ::email-field::
 const emailField = document.querySelector("ef-email-field");
-const errorChangedText = document.getElementById('error-text');
-emailField.addEventListener("error-changed", (event) => {
-    if (event.detail.value) {
-      errorChangedText.innerHTML = "Must be in standard email format with between 8-14 characters.";
-    }
-    else {
-      errorChangedText.innerHTML = "";
-    }
+const errorText = document.getElementById('error-text');
+
+emailField.addEventListener("blur", (event) => {
+  if (emailField.error) {
+    errorText.innerHTML = "Must be in standard email format with between 8-14 characters.";
+  }
+  else {
+    errorText.innerHTML = "";
+  }
+});
+emailField.addEventListener("input", () => {
+  if (!emailField.error) {
+    errorText.innerHTML = "";
+  }
 });
 ```
 ```css
@@ -141,29 +163,48 @@ ef-email-field {
 
 ```javascript
 const emailField = document.querySelector("ef-email-field");
-const errorChangedText = document.getElementById("error-text");
-emailField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
-    errorChangedText.innerHTML = "Must be in standard email format with between 8-14 characters.";
+const errorText = document.getElementById('error-text');
+
+emailField.addEventListener("blur", (event) => {
+  if (emailField.error) {
+    errorText.innerHTML = "Must be in standard email format with between 8-14 characters.";
   }
   else {
-    errorChangedText.innerHTML = "";
+    errorText.innerHTML = "";
+  }
+});
+
+emailField.addEventListener("input", () => {
+  if (!emailField.error) {
+    errorText.innerHTML = "";
   }
 });
 ```
 
 ```typescript
-import { ErrorChangedEvent } from '@refinitiv-ui/elements';
 import { EmailField } from '@refinitiv-ui/elements/email-field';
 
-const emailField = document.querySelector("ef-email-field");
-const errorChangedText = document.getElementById("error-text");
-emailField?.addEventListener("error-changed", (event) => {
-  if ((event as ErrorChangedEvent).detail.value) {
-    errorChangedText.innerHTML = "Must be in standard email format with between 8-14 characters.";
+const emailField = document.querySelector("ef-email-field") as EmailField;
+const errorText = document.getElementById('error-text');
+
+emailField?.addEventListener("blur", () => {
+  if (!errorText) {
+    return;
+  }
+  if (emailField?.error) {
+    errorText.innerHTML = "Must be in standard email format with between 8-14 characters.";
   }
   else {
-    errorChangedText.innerHTML = "";
+    errorText.innerHTML = "";
+  }
+});
+
+emailField?.addEventListener("input", () => {
+  if (!errorText) {
+    return;
+  }
+  if (!emailField?.error) {
+    errorText.innerHTML = "";
   }
 });
 ```
@@ -175,13 +216,20 @@ You can use a regular expression to validate the input value by adding the `patt
 ```javascript
 ::email-field::
 const emailField = document.querySelector("ef-email-field");
-const errorChangedText = document.getElementById("error-text");
-emailField.addEventListener("error-changed", (e) => {
-  if (e.detail.value) {
-    errorChangedText.innerHTML = "Email must end with '@mail.com'.";
+const errorText = document.getElementById("error-text");
+
+emailField.addEventListener("blur", () => {
+  if (emailField.error) {
+    errorText.innerHTML = "Email must end with '@mail.com'.";
   }
   else {
-    errorChangedText.innerHTML = "";
+    errorText.innerHTML = "";
+  }
+});
+
+emailField.addEventListener("input", () => {
+  if (!emailField.error) {
+    errorText.innerHTML = "";
   }
 });
 ```
@@ -212,31 +260,48 @@ ef-email-field {
 
 ```javascript
 const emailField = document.querySelector("ef-email-field");
-const errorChangedText = document.getElementById("error-text");
-emailField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
-    errorChangedText.innerHTML = "Email must end with '@mail.com'.";
+const errorText = document.getElementById("error-text");
+
+emailField.addEventListener("blur", () => {
+  if (emailField.error) {
+    errorText.innerHTML = "Email must end with '@mail.com'.";
   }
   else {
-    errorChangedText.innerHTML = "";
+    errorText.innerHTML = "";
+  }
+});
+
+emailField.addEventListener("input", () => {
+  if (!emailField.error) {
+    errorText.innerHTML = "";
   }
 });
 ```
 
 ```typescript
-import { ErrorChangedEvent } from '@refinitiv-ui/elements';
+import { EmailField } from "@refinitiv-ui/elements/email-field";
 
-const emailField = document.querySelector('ef-email-field');
-const errorChangedText = document.getElementById('error-text');
-emailField?.addEventListener('error-changed', (event) => {
-  if (!errorChangedText) {
+const emailField = document.querySelector("ef-email-field") as EmailField;
+const errorText = document.getElementById("error-text");
+
+emailField?.addEventListener("blur", () => {
+  if (!errorText) {
     return;
   }
-  
-  if ((event as ErrorChangedEvent).detail.value) {
-    errorChangedText.innerHTML = "Email must end with '@mail.com'.";
-  } else {
-    errorChangedText.innerHTML = '';
+  if (emailField?.error) {
+    errorText.innerHTML = "Email must end with '@mail.com'.";
+  }
+  else {
+    errorText.innerHTML = "";
+  }
+});
+
+emailField?.addEventListener("input", () => {
+  if (!errorText) {
+    return;
+  }
+  if (!emailField?.error) {
+    errorText.innerHTML = "";
   }
 });
 ```
@@ -256,20 +321,25 @@ An icon can become actionable by adding the `icon-has-action` attribute to the e
 ::email-field::
 const emailField = document.querySelector('ef-email-field');
 const emailList = document.getElementById('email-added');
-const errorChangedText = document.getElementById("error-text");
+const errorText = document.getElementById("error-text");
 
 emailField.addEventListener('icon-click', (e) => {
   if (!emailField.error && emailField.value.length > 0) {
     emailList.innerHTML = emailField.value + " is added.";
   }
 });
-emailField.addEventListener("error-changed", (e) => {
-  if (e.detail.value) {
-    errorChangedText.innerHTML = "Invalid email format.";
+emailField.addEventListener("blur", () => {
+  if (emailField.error) {
+    errorText.innerHTML = "Invalid email format.";
     emailList.innerHTML = "";
   }
   else {
-    errorChangedText.innerHTML = "";
+    errorText.innerHTML = "";
+  }
+});
+emailField.addEventListener("input", () => {
+  if (!emailField.error) {
+    errorText.innerHTML = "";
   }
 });
 ```

--- a/documents/src/pages/elements/number-field.md
+++ b/documents/src/pages/elements/number-field.md
@@ -161,7 +161,7 @@ button.addEventListener('tap', () => {
 ```
 ```html
 <ef-number-field placeholder="Max value is 5" max="5" value="10"></ef-number-field>
-<ef-button>validate</ef-button>
+<ef-button>Validate</ef-button>
 ```
 ::
 
@@ -180,7 +180,7 @@ numberField.addEventListener('blur', () => {
     errorText.innerHTML = '';
   }
 });
-numberField.addEventListener('value-changed', () => {
+numberField.addEventListener('input', () => {
   if (!numberField.error) {
     errorText.innerHTML = '';
   }
@@ -210,14 +210,14 @@ numberField.addEventListener('blur', () => {
   }
 });
 
-numberField.addEventListener('value-changed', () => {
+numberField.addEventListener('input', () => {
   if (!numberField.error) {
     errorText.innerHTML = '';
   }
 });
 ```
 ```typescript
-import { NumberField } from "@refinitiv-ui/elements/ef-number-field";
+import type { NumberField } from "@refinitiv-ui/elements/ef-number-field";
 
 const numberField = document.querySelector('ef-number-field') as NumberField;
 const errorText = document.getElementById('error-text');
@@ -235,7 +235,7 @@ numberField?.addEventListener('blur', () => {
   }
 });
 
-numberField?.addEventListener('value-changed', () => {
+numberField?.addEventListener('input', () => {
   if (!numberField.error) {
     errorText.innerHTML = '';
   }

--- a/documents/src/pages/elements/number-field.md
+++ b/documents/src/pages/elements/number-field.md
@@ -149,44 +149,34 @@ The step attribute specifies the interval between valid numbers. For instance, w
 
 @> Validation of user input of `ef-number-field` is consistent with a native input. [See native input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number).
 
+::
+```javascript
+::number-field::
+const numberField = document.querySelector('ef-number-field');
+numberField.reportValidity();
+```
+```html
+<ef-number-field placeholder="Even numbers only" step="2" value="5"></ef-number-field>
+```
+::
+
 Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
 
-You can add the event listener `error-changed` to the element and it will dispatch whenever the error state changes.
-
-```html
-<ef-number-field min="0"max="10"></ef-number-field>
-<p id="error-text"></p>
-```
-
+::
 ```javascript
+::number-field::
 const numberField = document.querySelector('ef-number-field');
 const errorText = document.getElementById('error-text');
-
-numberField.addEventListener('error-changed', (event) => {
-  if (event.detail.value) {
+numberField.addEventListener('blur', () => {
+  if (numberField.error) {
     errorText.innerHTML = 'Value must be between 0 - 10.';
   }
   else {
     errorText.innerHTML = '';
   }
 });
-```
-
-```typescript
-import { ErrorChangedEvent } from '@refinitiv-ui/elements';
-
-const numberField = document.querySelector('ef-number-field');
-const errorText = document.getElementById('error-text');
-
-numberField?.addEventListener('error-changed', (event) => {
-  if (!errorText) {
-    return;
-  }
-  
-  if ((event as ErrorChangedEvent).detail.value) {
-    errorText.innerHTML = 'Value must be between 0 - 10.';
-  }
-  else {
+numberField.addEventListener('value-changed', () => {
+  if (!numberField.error) {
     errorText.innerHTML = '';
   }
 });

--- a/documents/src/pages/elements/number-field.md
+++ b/documents/src/pages/elements/number-field.md
@@ -180,7 +180,7 @@ button.addEventListener('tap', () => {
 
 ### Displaying error messages
 
-Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
+Whenever input is invalid, the `error` attribute will be added to the element. You can use the `error` property to check if input is currently in the error state. Note that, if input is initialised with invalid value, `reportValidity()` must be called first as described in [Input Validation](/elements/number-field#input-validation).
 
 ::
 ```javascript
@@ -189,12 +189,7 @@ const numberField = document.querySelector('ef-number-field');
 const errorText = document.getElementById('error-text');
 
 numberField.addEventListener('blur', () => {
-  if (numberField.error) {
-    errorText.innerHTML = 'Value must be between 0 - 10.';
-  }
-  else {
-    errorText.innerHTML = '';
-  }
+ errorText.innerHTML = numberField.error ? 'Value must be between 0 - 10.' : '';
 });
 numberField.addEventListener('input', () => {
   if (!numberField.error) {
@@ -218,12 +213,7 @@ const numberField = document.querySelector('ef-number-field');
 const errorText = document.getElementById('error-text');
 
 numberField.addEventListener('blur', () => {
-  if (numberField.error) {
-    errorText.innerHTML = 'Value must be between 0 - 10.';
-  }
-  else {
-    errorText.innerHTML = '';
-  }
+  errorText.innerHTML = numberField.error ? 'Value must be between 0 - 10.' : '';
 });
 
 numberField.addEventListener('input', () => {
@@ -235,7 +225,7 @@ numberField.addEventListener('input', () => {
 ```typescript
 import type { NumberField } from "@refinitiv-ui/elements/number-field";
 
-const numberField = document.querySelector('ef-number-field') as NumberField;
+const numberField = document.querySelector<NumberField>('ef-number-field');
 const errorText = document.getElementById('error-text');
 
 if (!errorText) {
@@ -243,12 +233,7 @@ if (!errorText) {
 }
 
 numberField?.addEventListener('blur', () => {
-  if (numberField.error) {
-    errorText.innerHTML = 'Value must be between 0 - 10.';
-  }
-  else {
-    errorText.innerHTML = '';
-  }
+ errorText.innerHTML = numberField.error ? 'Value must be between 0 - 10.' : '';
 });
 
 numberField?.addEventListener('input', () => {

--- a/documents/src/pages/elements/number-field.md
+++ b/documents/src/pages/elements/number-field.md
@@ -161,9 +161,24 @@ button.addEventListener('tap', () => {
 ```
 ```html
 <ef-number-field placeholder="Max value is 5" max="5" value="10"></ef-number-field>
-<ef-button>Validate</ef-button>
+<ef-button>Submit</ef-button>
 ```
 ::
+
+```javascript
+const numberField = document.querySelector('ef-number-field');
+const button = document.querySelector("ef-button");
+
+button.addEventListener('tap', () => {
+  numberField.reportValidity();
+})
+```
+```html
+<ef-number-field placeholder="Max value is 5" max="5" value="10"></ef-number-field>
+<ef-button>Submit</ef-button>
+```
+
+### Displaying error messages
 
 Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
 
@@ -172,6 +187,7 @@ Whenever input is invalid, the error attribute will be added to the element. You
 ::number-field::
 const numberField = document.querySelector('ef-number-field');
 const errorText = document.getElementById('error-text');
+
 numberField.addEventListener('blur', () => {
   if (numberField.error) {
     errorText.innerHTML = 'Value must be between 0 - 10.';
@@ -217,7 +233,7 @@ numberField.addEventListener('input', () => {
 });
 ```
 ```typescript
-import type { NumberField } from "@refinitiv-ui/elements/ef-number-field";
+import type { NumberField } from "@refinitiv-ui/elements/number-field";
 
 const numberField = document.querySelector('ef-number-field') as NumberField;
 const errorText = document.getElementById('error-text');

--- a/documents/src/pages/elements/number-field.md
+++ b/documents/src/pages/elements/number-field.md
@@ -228,15 +228,17 @@ import type { NumberField } from "@refinitiv-ui/elements/number-field";
 const numberField = document.querySelector<NumberField>('ef-number-field');
 const errorText = document.getElementById('error-text');
 
-if (!errorText) {
-  return;
-}
-
 numberField?.addEventListener('blur', () => {
- errorText.innerHTML = numberField.error ? 'Value must be between 0 - 10.' : '';
+  if (!errorText) {
+    return;
+  }
+  errorText.innerHTML = numberField.error ? 'Value must be between 0 - 10.' : '';
 });
 
 numberField?.addEventListener('input', () => {
+  if (!errorText) {
+    return;
+  }
   if (!numberField.error) {
     errorText.innerHTML = '';
   }

--- a/documents/src/pages/elements/number-field.md
+++ b/documents/src/pages/elements/number-field.md
@@ -153,10 +153,15 @@ The step attribute specifies the interval between valid numbers. For instance, w
 ```javascript
 ::number-field::
 const numberField = document.querySelector('ef-number-field');
-numberField.reportValidity();
+const button = document.querySelector("ef-button");
+
+button.addEventListener('tap', () => {
+  numberField.reportValidity();
+})
 ```
 ```html
-<ef-number-field placeholder="Even numbers only" step="2" value="5"></ef-number-field>
+<ef-number-field placeholder="Max value is 5" max="5" value="10"></ef-number-field>
+<ef-button>validate</ef-button>
 ```
 ::
 
@@ -176,6 +181,61 @@ numberField.addEventListener('blur', () => {
   }
 });
 numberField.addEventListener('value-changed', () => {
+  if (!numberField.error) {
+    errorText.innerHTML = '';
+  }
+});
+```
+```html
+<ef-number-field placeholder="0 - 10" min="0" max="10"></ef-number-field>
+<p id="error-text"></p>
+```
+::
+
+```html
+<ef-number-field placeholder="0 - 10" min="0" max="10"></ef-number-field>
+<p id="error-text"></p>
+```
+
+```javascript
+const numberField = document.querySelector('ef-number-field');
+const errorText = document.getElementById('error-text');
+
+numberField.addEventListener('blur', () => {
+  if (numberField.error) {
+    errorText.innerHTML = 'Value must be between 0 - 10.';
+  }
+  else {
+    errorText.innerHTML = '';
+  }
+});
+
+numberField.addEventListener('value-changed', () => {
+  if (!numberField.error) {
+    errorText.innerHTML = '';
+  }
+});
+```
+```typescript
+import { NumberField } from "@refinitiv-ui/elements/ef-number-field";
+
+const numberField = document.querySelector('ef-number-field') as NumberField;
+const errorText = document.getElementById('error-text');
+
+if (!errorText) {
+  return;
+}
+
+numberField?.addEventListener('blur', () => {
+  if (numberField.error) {
+    errorText.innerHTML = 'Value must be between 0 - 10.';
+  }
+  else {
+    errorText.innerHTML = '';
+  }
+});
+
+numberField?.addEventListener('value-changed', () => {
   if (!numberField.error) {
     errorText.innerHTML = '';
   }

--- a/documents/src/pages/elements/password-field.md
+++ b/documents/src/pages/elements/password-field.md
@@ -173,7 +173,7 @@ button.addEventListener('tap', () => {
 
 ### Displaying error messages
 
-Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
+Whenever input is invalid, the `error` attribute will be added to the element. You can use the `error` property to check if input is currently in the error state. Note that, if input is initialised with invalid value, `reportValidity()` must be called first as described in [Input Validation](/elements/pssword-field#input-validation).
 
 See the [Input Length](/elements/password-field#input-length) example below for more detail.
 
@@ -181,7 +181,7 @@ See the [Input Length](/elements/password-field#input-length) example below for 
 
 The `maxlength` attribute limits the number of characters that can be typed into the input, and the `minlength` attribute sets the minimum of characters. `ef-password-field` will show error styles if a condition is not met.
 
-@> Constraint validation is only applied when the value is changed by the user. [See input password](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password#maxlength).
+@> `maxlength` and `minlength` constraint validations are only applied when the value is changed by the user. [See input password](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password#maxlength).
 
 ::
 ```javascript
@@ -190,12 +190,7 @@ const passwordField = document.querySelector("ef-password-field");
 const errorText = document.getElementById('error-text');
 
 passwordField.addEventListener("blur", () => {
-  if (passwordField.error) {
-    errorText.innerHTML = "Password length must be between 8 - 16 characters";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = passwordField.error ? "Password length must be between 8 - 16 characters." : "";
 });
 
 passwordField.addEventListener("input", () => {
@@ -228,12 +223,7 @@ const passwordField = document.querySelector("ef-password-field");
 const errorText = document.getElementById('error-text');
 
 passwordField.addEventListener("blur", () => {
-  if (passwordField.error) {
-    errorText.innerHTML = "Password length must be between 8 - 16 characters";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = passwordField.error ? "Password length must be between 8 - 16 characters." : "";
 });
 
 passwordField.addEventListener("input", () => {
@@ -246,19 +236,14 @@ passwordField.addEventListener("input", () => {
 ```typescript
 import { PasswordField } from '@refinitiv-ui/elements/password-field';
 
-const passwordField = document.querySelector("ef-password-field") as PasswordField;
-const errorText = document.getElementById('error-text');
+const passwordField = document.querySelector<PasswordField>("ef-password-field");
+const errorText = document.getElementById("error-text");
 
 passwordField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if (passwordField?.error) {
-    errorText.innerHTML = "Password length must be between 8 - 16 characters";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = passwordField.error ? "Password length must be between 8 - 16 characters." : "";
 });
 
 passwordField?.addEventListener("input", () => {
@@ -282,11 +267,7 @@ const passwordField = document.querySelector("ef-password-field");
 const errorText = document.getElementById("error-text");
 
 passwordField.addEventListener("blur", (event) => {
-  if (passwordField.error) {
-    errorText.innerHTML = "Password is too weak.";
-  } else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = passwordField.error ? "Password is too weak." : "";
 });
 
 passwordField.addEventListener("input", (event) => {
@@ -326,11 +307,7 @@ const passwordField = document.querySelector("ef-password-field");
 const errorText = document.getElementById("error-text");
 
 passwordField.addEventListener("blur", () => {
-  if (passwordField.error) {
-    errorText.innerHTML = "Password is too weak.";
-  } else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = passwordField.error ? "Password is too weak." : "";
 });
 
 passwordField.addEventListener("input", () => {
@@ -343,7 +320,7 @@ passwordField.addEventListener("input", () => {
 ```typescript
 import { PasswordField } from '@refinitiv-ui/elements/password-field';
 
-const passwordField = document.querySelector("ef-password-field") as PasswordField;
+const passwordField = document.querySelector<PasswordField>("ef-password-field");
 const errorText = document.getElementById("error-text");
 
 passwordField?.addEventListener("blur", () => {

--- a/documents/src/pages/elements/password-field.md
+++ b/documents/src/pages/elements/password-field.md
@@ -155,9 +155,25 @@ passwordField?.addEventListener("value-changed", (event) => {
 
 `ef-password-field` has validation logic similar to a native input. When a user types the invalid value into the control, error style will be shown to notify the user. However, if the control is being initialised with an invalid value, `reportValidity()` must be called to ensure the error style is applied.
 
-Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
+::
+```javascript
+::password-field::
+const passwordField = document.querySelector('ef-password-field');
+const button = document.querySelector("ef-button");
 
-You can add the event listener `error-changed` to the element and it will dispatch whenever the error state changes.
+button.addEventListener('tap', () => {
+  passwordField.reportValidity();
+})
+```
+```html
+<ef-password-field pattern="[a-z]" value="1"></ef-password-field>
+<ef-button>Submit</ef-button>
+```
+::
+
+### Displaying error messages
+
+Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
 
 See the [Input Length](/elements/password-field#input-length) example below for more detail.
 
@@ -165,16 +181,25 @@ See the [Input Length](/elements/password-field#input-length) example below for 
 
 The `maxlength` attribute limits the number of characters that can be typed into the input, and the `minlength` attribute sets the minimum of characters. `ef-password-field` will show error styles if a condition is not met.
 
+@> Constraint validation is only applied when the value is changed by the user. [See input password](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password#maxlength).
+
 ::
 ```javascript
 ::password-field::
 const passwordField = document.querySelector("ef-password-field");
 const errorText = document.getElementById('error-text');
-passwordField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
+
+passwordField.addEventListener("blur", () => {
+  if (passwordField.error) {
     errorText.innerHTML = "Password length must be between 8 - 16 characters";
   }
   else {
+    errorText.innerHTML = "";
+  }
+});
+
+passwordField.addEventListener("input", () => {
+  if (!passwordField.error) {
     errorText.innerHTML = "";
   }
 });
@@ -200,32 +225,47 @@ ef-password-field {
 
 ```javascript
 const passwordField = document.querySelector("ef-password-field");
-const errorText = document.getElementById("error-text");
+const errorText = document.getElementById('error-text');
 
-passwordField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
-    errorText.innerHTML = "Password length must be between 8 - 16 characters.";
+passwordField.addEventListener("blur", () => {
+  if (passwordField.error) {
+    errorText.innerHTML = "Password length must be between 8 - 16 characters";
   }
   else {
+    errorText.innerHTML = "";
+  }
+});
+
+passwordField.addEventListener("input", () => {
+  if (!passwordField.error) {
     errorText.innerHTML = "";
   }
 });
 ```
 
 ```typescript
-import { ErrorChangedEvent } from '@refinitiv-ui/elements';
+import { PasswordField } from '@refinitiv-ui/elements/password-field';
 
-const passwordField = document.querySelector("ef-password-field");
-const errorText = document.getElementById("error-text");
+const passwordField = document.querySelector("ef-password-field") as PasswordField;
+const errorText = document.getElementById('error-text');
 
-passwordField?.addEventListener("error-changed", (event) => {
+passwordField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if ((event as ErrorChangedEvent).detail.value) {
-    errorText.innerHTML = "Password length must be between 8 - 16 characters.";
+  if (passwordField?.error) {
+    errorText.innerHTML = "Password length must be between 8 - 16 characters";
   }
   else {
+    errorText.innerHTML = "";
+  }
+});
+
+passwordField?.addEventListener("input", () => {
+  if (!errorText) {
+    return;
+  }
+  if (!passwordField?.error) {
     errorText.innerHTML = "";
   }
 });
@@ -240,10 +280,17 @@ You can use a regular expression to validate the input value by setting it to th
 ::password-field::
 const passwordField = document.querySelector("ef-password-field");
 const errorText = document.getElementById("error-text");
-passwordField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
+
+passwordField.addEventListener("blur", (event) => {
+  if (passwordField.error) {
     errorText.innerHTML = "Password is too weak.";
   } else {
+    errorText.innerHTML = "";
+  }
+});
+
+passwordField.addEventListener("input", (event) => {
+  if (!passwordField.error) {
     errorText.innerHTML = "";
   }
 });
@@ -277,29 +324,44 @@ ef-password-field {
 ```javascript
 const passwordField = document.querySelector("ef-password-field");
 const errorText = document.getElementById("error-text");
-passwordField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
+
+passwordField.addEventListener("blur", () => {
+  if (passwordField.error) {
     errorText.innerHTML = "Password is too weak.";
+  } else {
+    errorText.innerHTML = "";
   }
-  else {
+});
+
+passwordField.addEventListener("input", () => {
+  if (!passwordField.error) {
     errorText.innerHTML = "";
   }
 });
 ```
 
 ```typescript
-import { ErrorChangedEvent } from '@refinitiv-ui/elements';
+import { PasswordField } from '@refinitiv-ui/elements/password-field';
 
-const passwordField = document.querySelector("ef-password-field");
+const passwordField = document.querySelector("ef-password-field") as PasswordField;
 const errorText = document.getElementById("error-text");
-passwordField?.addEventListener("error-changed", (event) => {
+
+passwordField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if ((event as ErrorChangedEvent).detail.value) {
+  if (passwordField?.error) {
     errorText.innerHTML = "Password is too weak.";
+  } else {
+    errorText.innerHTML = "";
   }
-  else {
+});
+
+passwordField?.addEventListener("input", () => {
+  if (!errorText) {
+    return;
+  }
+  if (!passwordField?.error) {
     errorText.innerHTML = "";
   }
 });

--- a/documents/src/pages/elements/password-field.md
+++ b/documents/src/pages/elements/password-field.md
@@ -327,11 +327,7 @@ passwordField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if (passwordField?.error) {
-    errorText.innerHTML = "Password is too weak.";
-  } else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = passwordField?.error ? "Password is too weak." : "";
 });
 
 passwordField?.addEventListener("input", () => {

--- a/documents/src/pages/elements/search-field.md
+++ b/documents/src/pages/elements/search-field.md
@@ -109,7 +109,7 @@ button.addEventListener('tap', () => {
 
 ### Displaying error messages
 
-Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
+Whenever input is invalid, the `error` attribute will be added to the element. You can use the `error` property to check if input is currently in the error state. Note that, if input is initialised with invalid value, `reportValidity()` must be called first as described in [Input Validation](/elements/search-field#input-validation).
 
 See the [Input Length](/elements/search-field#input-length) example below for more detail.
 
@@ -117,7 +117,7 @@ See the [Input Length](/elements/search-field#input-length) example below for mo
 
 The `maxlength` attribute limits the number of characters that users can enter and the `minlength` attribute sets the minimum number of characters required. `ef-search-field` will show error styles if a condition is not met.
 
-@> Constraint validation is only applied when the value is changed by the user. [See input search](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search#maxlength).
+@> `maxlength` and `minlength` constraint validations are only applied when the value is changed by the user. [See input search](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search#maxlength).
 
 ::
 ```javascript
@@ -126,12 +126,7 @@ const searchField = document.querySelector("ef-search-field");
 const errorText = document.getElementById("error-text");
 
 searchField.addEventListener("blur", () => {
-  if (searchField.error) {
-    errorText.innerHTML = "Value length must be between 2 - 4 characters";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = searchField.error ? "Value length must be between 2 - 4 characters." : "";
 });
 
 searchField.addEventListener("input", () => {
@@ -168,12 +163,7 @@ const searchField = document.querySelector("ef-search-field");
 const errorText = document.getElementById("error-text");
 
 searchField.addEventListener("blur", () => {
-  if (searchField.error) {
-    errorText.innerHTML = "Value length must be between 2 - 4 characters";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = searchField.error ? "Value length must be between 2 - 4 characters." : "";
 });
 
 searchField.addEventListener("input", () => {
@@ -186,19 +176,14 @@ searchField.addEventListener("input", () => {
 ```typescript
 import { SearchField } from '@refinitiv-ui/elements/search-field';
 
-const searchField = document.querySelector("ef-search-field") as SearchField;
+const searchField = document.querySelector<SearchField>("ef-search-field");
 const errorText = document.getElementById("error-text");
 
 searchField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if (searchField?.error) {
-    errorText.innerHTML = "Value length must be between 2 - 4 characters";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = searchField.error ? "Value length must be between 2 - 4 characters." : "";
 });
 
 searchField?.addEventListener("input", () => {
@@ -222,12 +207,7 @@ const searchField = document.querySelector("ef-search-field");
 const errorText = document.getElementById("error-text");
 
 searchField.addEventListener("blur", () => {
-  if (searchField.error) {
-    errorText.innerHTML = "Value must be uppercase letters and has 2 - 5 characters.";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = searchField.error ? "Value must be uppercase letters and has 2 - 5 characters." : "";
 });
 
 searchField.addEventListener("input", () => {
@@ -262,12 +242,7 @@ const searchField = document.querySelector("ef-search-field");
 const errorText = document.getElementById("error-text");
 
 searchField.addEventListener("blur", () => {
-  if (searchField.error) {
-    errorText.innerHTML = "Value must be uppercase letters and has 2 - 5 characters.";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = searchField.error ? "Value must be uppercase letters and has 2 - 5 characters." : "";
 });
 
 searchField.addEventListener("input", () => {
@@ -280,7 +255,7 @@ searchField.addEventListener("input", () => {
 ```typescript
 import { SearchField } from '@refinitiv-ui/elements/search-field';
 
-const searchField = document.querySelector("ef-search-field") as SearchField;
+const searchField = document.querySelector<SearchField>("ef-search-field");
 const errorText = document.getElementById("error-text");
 
 searchField?.addEventListener("blur", () => {

--- a/documents/src/pages/elements/search-field.md
+++ b/documents/src/pages/elements/search-field.md
@@ -262,12 +262,7 @@ searchField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if (searchField?.error) {
-    errorText.innerHTML = "Value must be uppercase letters and has 2 - 5 characters.";
-  }
-  else {
-    errorText.innerHTML = "";
-  }
+  errorText.innerHTML = searchField?.error ? "Value must be uppercase letters and has 2 - 5 characters." : "";
 });
 
 searchField?.addEventListener("input", () => {

--- a/documents/src/pages/elements/search-field.md
+++ b/documents/src/pages/elements/search-field.md
@@ -91,9 +91,25 @@ searchField?.addEventListener("value-changed", (event) => {
 
 `ef-search-field` has validation logic similar to a native input. When a user types the invalid value into the control, error style will be shown to notify the user. However, if the control is being initialised with an invalid value, `reportValidity()` must be called to ensure the error style is applied.
 
-Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
+::
+```javascript
+::search-field::
+const searchField = document.querySelector('ef-search-field');
+const button = document.querySelector("ef-button");
 
-You can add the event listener `error-changed` to the element and it will dispatch whenever the error state changes.
+button.addEventListener('tap', () => {
+  searchField.reportValidity();
+})
+```
+```html
+<ef-search-field pattern="[a-z]" value="1"></ef-search-field>
+<ef-button>Submit</ef-button>
+```
+::
+
+### Displaying error messages
+
+Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
 
 See the [Input Length](/elements/search-field#input-length) example below for more detail.
 
@@ -101,16 +117,25 @@ See the [Input Length](/elements/search-field#input-length) example below for mo
 
 The `maxlength` attribute limits the number of characters that users can enter and the `minlength` attribute sets the minimum number of characters required. `ef-search-field` will show error styles if a condition is not met.
 
+@> Constraint validation is only applied when the value is changed by the user. [See input search](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search#maxlength).
+
 ::
 ```javascript
 ::search-field::
 const searchField = document.querySelector("ef-search-field");
 const errorText = document.getElementById("error-text");
-searchField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
+
+searchField.addEventListener("blur", () => {
+  if (searchField.error) {
     errorText.innerHTML = "Value length must be between 2 - 4 characters";
   }
   else {
+    errorText.innerHTML = "";
+  }
+});
+
+searchField.addEventListener("input", () => {
+  if (!searchField.error) {
     errorText.innerHTML = "";
   }
 });
@@ -142,30 +167,45 @@ ef-search-field {
 const searchField = document.querySelector("ef-search-field");
 const errorText = document.getElementById("error-text");
 
-searchField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
-    errorText.innerHTML = "Value length must be between 2 - 4 characters.";
+searchField.addEventListener("blur", () => {
+  if (searchField.error) {
+    errorText.innerHTML = "Value length must be between 2 - 4 characters";
   }
   else {
+    errorText.innerHTML = "";
+  }
+});
+
+searchField.addEventListener("input", () => {
+  if (!searchField.error) {
     errorText.innerHTML = "";
   }
 });
 ```
 
 ```typescript
-import { ErrorChangedEvent } from '@refinitiv-ui/elements';
+import { SearchField } from '@refinitiv-ui/elements/search-field';
 
-const searchField = document.querySelector("ef-search-field");
+const searchField = document.querySelector("ef-search-field") as SearchField;
 const errorText = document.getElementById("error-text");
 
-searchField?.addEventListener("error-changed", (event) => {
+searchField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if ((event as ErrorChangedEvent).detail.value) {
-    errorText.innerHTML = "Value length must be between 2 - 4 characters.";
+  if (searchField?.error) {
+    errorText.innerHTML = "Value length must be between 2 - 4 characters";
   }
   else {
+    errorText.innerHTML = "";
+  }
+});
+
+searchField?.addEventListener("input", () => {
+  if (!errorText) {
+    return;
+  }
+  if (!searchField?.error) {
     errorText.innerHTML = "";
   }
 });
@@ -180,11 +220,18 @@ You can use a regular expression to validate the input value by setting it to th
 ::search-field::
 const searchField = document.querySelector("ef-search-field");
 const errorText = document.getElementById("error-text");
-searchField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
+
+searchField.addEventListener("blur", () => {
+  if (searchField.error) {
     errorText.innerHTML = "Value must be uppercase letters and has 2 - 5 characters.";
   }
   else {
+    errorText.innerHTML = "";
+  }
+});
+
+searchField.addEventListener("input", () => {
+  if (!searchField.error) {
     errorText.innerHTML = "";
   }
 });
@@ -213,29 +260,46 @@ ef-search-field {
 ```javascript
 const searchField = document.querySelector("ef-search-field");
 const errorText = document.getElementById("error-text");
-searchField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
+
+searchField.addEventListener("blur", () => {
+  if (searchField.error) {
     errorText.innerHTML = "Value must be uppercase letters and has 2 - 5 characters.";
   }
   else {
     errorText.innerHTML = "";
   }
 });
+
+searchField.addEventListener("input", () => {
+  if (!searchField.error) {
+    errorText.innerHTML = "";
+  }
+});
 ```
 
 ```typescript
-import { ErrorChangedEvent } from '@refinitiv-ui/elements';
+import { SearchField } from '@refinitiv-ui/elements/search-field';
 
-const searchField = document.querySelector("ef-search-field");
+const searchField = document.querySelector("ef-search-field") as SearchField;
 const errorText = document.getElementById("error-text");
-searchField?.addEventListener("error-changed", (event) => {
+
+searchField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if ((event as ErrorChangedEvent).detail.value) {
+  if (searchField?.error) {
     errorText.innerHTML = "Value must be uppercase letters and has 2 - 5 characters.";
   }
   else {
+    errorText.innerHTML = "";
+  }
+});
+
+searchField?.addEventListener("input", () => {
+  if (!errorText) {
+    return;
+  }
+  if (!searchField?.error) {
     errorText.innerHTML = "";
   }
 });

--- a/documents/src/pages/elements/text-field.md
+++ b/documents/src/pages/elements/text-field.md
@@ -122,9 +122,24 @@ button.addEventListener('tap', () => {
 ```
 ```html
 <ef-text-field pattern="[a-z]" placeholder="Must be a character" value="1"></ef-text-field>
-<ef-button>Validate</ef-button>
+<ef-button>Submit</ef-button>
 ```
 ::
+
+```javascript
+const textField = document.querySelector('ef-text-field');
+const button = document.querySelector("ef-button");
+
+button.addEventListener('tap', () => {
+  textField.reportValidity();
+})
+```
+```html
+<ef-text-field pattern="[a-z]" placeholder="Must be a character" value="1"></ef-text-field>
+<ef-button>Submit</ef-button>
+```
+
+### Displaying error messages
 
 Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
 
@@ -212,7 +227,7 @@ textField.addEventListener("input", () => {
 ```
 
 ```typescript
-import type { TextField } from "@refinitiv-ui/elements/ef-text-field";
+import type { TextField } from "@refinitiv-ui/elements/text-field";
 
 const textField = document.getElementById("username") as TextField;
 const errorText = document.getElementById("error-text");
@@ -322,7 +337,7 @@ textField.addEventListener("input", () => {
 ```
 
 ```typescript
-import type { TextField } from '@refinitiv-ui/elements/ef-text-field';
+import type { TextField } from '@refinitiv-ui/elements/text-field';
 
 const textField = document.getElementById("nickname") as TextField;
 const errorText = document.getElementById("error-text");

--- a/documents/src/pages/elements/text-field.md
+++ b/documents/src/pages/elements/text-field.md
@@ -110,9 +110,23 @@ textField?.addEventListener("value-changed", (event) => {
 
 @> Validation of user input of `ef-text-field` is consistent with a native input. [See native input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text).
 
-Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
+::
+```javascript
+::text-field::
+const textField = document.querySelector('ef-text-field');
+const button = document.querySelector("ef-button");
 
-You can add the event listener `error-changed` to the element and it will dispatch whenever the error state changes.
+button.addEventListener('tap', () => {
+  textField.reportValidity();
+})
+```
+```html
+<ef-text-field pattern="[a-z]" placeholder="Must be a character" value="1"></ef-text-field>
+<ef-button>Validate</ef-button>
+```
+::
+
+Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
 
 See the [Input Length](/elements/text-field#input-length) example below for more detail.
 
@@ -120,16 +134,24 @@ See the [Input Length](/elements/text-field#input-length) example below for more
 
 The `maxlength` attribute limits the number of characters that users can type into the input, and the `minlength` attribute sets the minimum number of characters required. `ef-text-field` will show error styles if a condition is not met.
 
-::
+@> Constraint validation is only applied when the value is changed by the user. [See input text](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text#maxlength).
 
+::
 ```javascript
 ::text-field::
 const textField = document.getElementById("username");
 const errorText = document.getElementById("error-text");
-textField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
+
+textField.addEventListener("blur", () => {
+  if (textField.error) {
     errorText.textContent = "Value length must be between 5-8 characters";
   } else {
+    errorText.textContent = "";
+  }
+});
+
+textField.addEventListener("input", () => {
+  if (!textField.error) {
     errorText.textContent = "";
   }
 });
@@ -173,27 +195,44 @@ ef-text-field {
 ```javascript
 const textField = document.getElementById("username");
 const errorText = document.getElementById("error-text");
-textField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
+
+textField.addEventListener("blur", () => {
+  if (textField.error) {
     errorText.textContent = "Value length must be between 5-8 characters";
   } else {
+    errorText.textContent = "";
+  }
+});
+
+textField.addEventListener("input", () => {
+  if (!textField.error) {
     errorText.textContent = "";
   }
 });
 ```
 
 ```typescript
-import { ErrorChangedEvent } from '@refinitiv-ui/elements';
+import type { TextField } from "@refinitiv-ui/elements/ef-text-field";
 
-const textField = document.getElementById("username");
+const textField = document.getElementById("username") as TextField;
 const errorText = document.getElementById("error-text");
-textField?.addEventListener("error-changed", (event) => {
+
+textField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if ((event as ErrorChangedEvent).detail.value) {
+  if (textField.error) {
     errorText.textContent = "Value length must be between 5-8 characters";
   } else {
+    errorText.textContent = "";
+  }
+});
+
+textField?.addEventListener("input", () => {
+  if (!errorText) {
+    return;
+  }
+  if (!textField.error) {
     errorText.textContent = "";
   }
 });
@@ -209,11 +248,18 @@ You can use a regular expression to validate the input value by setting it with 
 ::text-field::
 const textField = document.getElementById("nickname");
 const errorText = document.getElementById("error-text");
-textField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
+
+textField.addEventListener("blur", () => {
+  if (textField.error) {
     errorText.textContent = "Nickname must be lowercase letters between 4-8 characters.";
   }
   else {
+    errorText.textContent = "";
+  }
+});
+
+textField.addEventListener("input", () => {
+  if (!textField.error) {
     errorText.textContent = "";
   }
 });
@@ -258,29 +304,46 @@ label {
 ```javascript
 const textField = document.getElementById("nickname");
 const errorText = document.getElementById("error-text");
-textField.addEventListener("error-changed", (event) => {
-  if (event.detail.value) {
+
+textField.addEventListener("blur", () => {
+  if (textField.error) {
     errorText.textContent = "Nickname must be lowercase letters between 4-8 characters.";
   }
   else {
     errorText.textContent = "";
   }
 });
+
+textField.addEventListener("input", () => {
+  if (!textField.error) {
+    errorText.textContent = "";
+  }
+});
 ```
 
 ```typescript
-import { ErrorChangedEvent } from '@refinitiv-ui/elements';
+import type { TextField } from '@refinitiv-ui/elements/ef-text-field';
 
-const textField = document.getElementById("nickname");
+const textField = document.getElementById("nickname") as TextField;
 const errorText = document.getElementById("error-text");
-textField?.addEventListener("error-changed", (event) => {
+
+textField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if ((event as ErrorChangedEvent).detail.value) {
+  if (textField.error) {
     errorText.textContent = "Nickname must be lowercase letters between 4-8 characters.";
   }
   else {
+    errorText.textContent = "";
+  }
+});
+
+textField?.addEventListener("input", () => {
+  if (!errorText) {
+    return;
+  }
+  if (!textField.error) {
     errorText.textContent = "";
   }
 });

--- a/documents/src/pages/elements/text-field.md
+++ b/documents/src/pages/elements/text-field.md
@@ -141,7 +141,7 @@ button.addEventListener('tap', () => {
 
 ### Displaying error messages
 
-Whenever input is invalid, the error attribute will be added to the element. You can use the `error` property to check if input is currently in the error state.
+Whenever input is invalid, the `error` attribute will be added to the element. You can use the `error` property to check if input is currently in the error state. Note that, if input is initialised with invalid value, `reportValidity()` must be called first as described in [Input Validation](/elements/text-field#input-validation)
 
 See the [Input Length](/elements/text-field#input-length) example below for more detail.
 
@@ -149,7 +149,7 @@ See the [Input Length](/elements/text-field#input-length) example below for more
 
 The `maxlength` attribute limits the number of characters that users can type into the input, and the `minlength` attribute sets the minimum number of characters required. `ef-text-field` will show error styles if a condition is not met.
 
-@> Constraint validation is only applied when the value is changed by the user. [See input text](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text#maxlength).
+@> `maxlength` and `minlength` constraint validations are only applied when the value is changed by the user. [See input text](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text#maxlength).
 
 ::
 ```javascript
@@ -158,11 +158,7 @@ const textField = document.getElementById("username");
 const errorText = document.getElementById("error-text");
 
 textField.addEventListener("blur", () => {
-  if (textField.error) {
-    errorText.textContent = "Value length must be between 5-8 characters";
-  } else {
-    errorText.textContent = "";
-  }
+  errorText.textContent = textField.error ? "Value length must be between 5-8 characters." : "";
 });
 
 textField.addEventListener("input", () => {
@@ -212,11 +208,7 @@ const textField = document.getElementById("username");
 const errorText = document.getElementById("error-text");
 
 textField.addEventListener("blur", () => {
-  if (textField.error) {
-    errorText.textContent = "Value length must be between 5-8 characters";
-  } else {
-    errorText.textContent = "";
-  }
+  errorText.textContent = textField.error ? "Value length must be between 5-8 characters." : "";
 });
 
 textField.addEventListener("input", () => {
@@ -236,11 +228,7 @@ textField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if (textField.error) {
-    errorText.textContent = "Value length must be between 5-8 characters";
-  } else {
-    errorText.textContent = "";
-  }
+  errorText.textContent = textField.error ? "Value length must be between 5-8 characters." : "";
 });
 
 textField?.addEventListener("input", () => {
@@ -265,12 +253,7 @@ const textField = document.getElementById("nickname");
 const errorText = document.getElementById("error-text");
 
 textField.addEventListener("blur", () => {
-  if (textField.error) {
-    errorText.textContent = "Nickname must be lowercase letters between 4-8 characters.";
-  }
-  else {
-    errorText.textContent = "";
-  }
+  errorText.textContent = textField.error ? "Nickname must be lowercase letters between 4-8 characters." : "";
 });
 
 textField.addEventListener("input", () => {
@@ -321,12 +304,7 @@ const textField = document.getElementById("nickname");
 const errorText = document.getElementById("error-text");
 
 textField.addEventListener("blur", () => {
-  if (textField.error) {
-    errorText.textContent = "Nickname must be lowercase letters between 4-8 characters.";
-  }
-  else {
-    errorText.textContent = "";
-  }
+  errorText.textContent = textField.error ? "Nickname must be lowercase letters between 4-8 characters." : "";
 });
 
 textField.addEventListener("input", () => {
@@ -346,12 +324,7 @@ textField?.addEventListener("blur", () => {
   if (!errorText) {
     return;
   }
-  if (textField.error) {
-    errorText.textContent = "Nickname must be lowercase letters between 4-8 characters.";
-  }
-  else {
-    errorText.textContent = "";
-  }
+  errorText.textContent = textField.error ? "Nickname must be lowercase letters between 4-8 characters." : "";
 });
 
 textField?.addEventListener("input", () => {

--- a/packages/elements/src/email-field/index.ts
+++ b/packages/elements/src/email-field/index.ts
@@ -56,6 +56,22 @@ export class EmailField extends TextField {
   public multiple = false;
 
   /**
+   * Returns true if an input element contains valid data
+   * @returns true if input is valid
+   */
+  public override checkValidity(): boolean {
+    return super.checkValidity();
+  }
+
+  /**
+   * Validate input. Mark as error if input is invalid
+   * @returns false if there is an error
+   */
+  public override reportValidity(): boolean {
+    return super.reportValidity();
+  }
+
+  /**
    * Decorate `<input>` element with common properties extended from text-field:
    * type="email" - always `email`
    * multiple - defined if supports multiple emails

--- a/packages/elements/src/email-field/index.ts
+++ b/packages/elements/src/email-field/index.ts
@@ -56,16 +56,16 @@ export class EmailField extends TextField {
   public multiple = false;
 
   /**
-   * Returns true if an input element contains valid data
-   * @returns true if input is valid
+   * Returns `true` if the element input is valid; otherwise, returns `false`.
+   * @returns element input validity
    */
   public override checkValidity(): boolean {
     return super.checkValidity();
   }
 
   /**
-   * Validate input. Mark as error if input is invalid
-   * @returns false if there is an error
+   * Validate the element input and mark it as error if its input is invalid.
+   * @returns `true` if the element input is valid; otherwise, returns `false`.
    */
   public override reportValidity(): boolean {
     return super.reportValidity();

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -725,7 +725,15 @@ export class NumberField extends FormFieldElement {
   }
 
   /**
-   * Returns true if an input element contains valid data.
+   * Validate input. Mark as error if input is invalid
+   * @returns false if there is an error
+   */
+  public override reportValidity(): boolean {
+    return super.reportValidity();
+  }
+
+  /**
+   * Returns true if an input element contains valid data
    * @returns true if input is valid
    */
   public override checkValidity(): boolean {

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -347,6 +347,9 @@ export class NumberField extends FormFieldElement {
     if (event) {
       try {
         this.applyStepDirection(direction);
+        /**
+         * @ignore
+         */
         this.dispatchEvent(new InputEvent('input'));
         this.setSilentlyValueAndNotify();
       } catch (error) {

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -349,6 +349,7 @@ export class NumberField extends FormFieldElement {
         this.applyStepDirection(direction);
         /**
          * @ignore
+         * exclude native event from the documentation
          */
         this.dispatchEvent(new InputEvent('input'));
         this.setSilentlyValueAndNotify();

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -725,16 +725,16 @@ export class NumberField extends FormFieldElement {
   }
 
   /**
-   * Validate input. Mark as error if input is invalid
-   * @returns false if there is an error
+   * Validate the element input and mark it as error if its input is invalid.
+   * @returns `true` if the element input is valid; otherwise, returns `false`.
    */
   public override reportValidity(): boolean {
     return super.reportValidity();
   }
 
   /**
-   * Returns true if an input element contains valid data
-   * @returns true if input is valid
+   * Returns `true` if the element input is valid; otherwise, returns `false`.
+   * @returns element input validity
    */
   public override checkValidity(): boolean {
     const value = this.internalValue;

--- a/packages/elements/src/password-field/index.ts
+++ b/packages/elements/src/password-field/index.ts
@@ -71,16 +71,16 @@ export class PasswordField extends TextField {
   }
 
   /**
-   * Returns true if an input element contains valid data
-   * @returns true if input is valid
+   * Returns `true` if the element input is valid; otherwise, returns `false`.
+   * @returns element input validity
    */
   public override checkValidity(): boolean {
     return super.checkValidity();
   }
 
   /**
-   * Validate input. Mark as error if input is invalid
-   * @returns false if there is an error
+   * Validate the element input and mark it as error if its input is invalid.
+   * @returns `true` if the element input is valid; otherwise, returns `false`.
    */
   public override reportValidity(): boolean {
     return super.reportValidity();

--- a/packages/elements/src/password-field/index.ts
+++ b/packages/elements/src/password-field/index.ts
@@ -71,6 +71,22 @@ export class PasswordField extends TextField {
   }
 
   /**
+   * Returns true if an input element contains valid data
+   * @returns true if input is valid
+   */
+  public override checkValidity(): boolean {
+    return super.checkValidity();
+  }
+
+  /**
+   * Validate input. Mark as error if input is invalid
+   * @returns false if there is an error
+   */
+  public override reportValidity(): boolean {
+    return super.reportValidity();
+  }
+
+  /**
    * Decorate `<input>` element with common properties extended from text-field:
    * type="text|password" - text if password is visible
    * @returns template map

--- a/packages/elements/src/search-field/index.ts
+++ b/packages/elements/src/search-field/index.ts
@@ -77,8 +77,8 @@ export class SearchField extends TextField {
   }
 
   /**
-   * Validate input. Mark as error if input is invalid
-   * @returns false if there is an error
+   * Validate the element input and mark it as error if its input is invalid.
+   * @returns `true` if the element input is valid; otherwise, returns `false`.
    */
   public override reportValidity(): boolean {
     return super.reportValidity();

--- a/packages/elements/src/search-field/index.ts
+++ b/packages/elements/src/search-field/index.ts
@@ -69,6 +69,22 @@ export class SearchField extends TextField {
   }
 
   /**
+   * Returns true if an input element contains valid data
+   * @returns true if input is valid
+   */
+  public override checkValidity(): boolean {
+    return super.checkValidity();
+  }
+
+  /**
+   * Validate input. Mark as error if input is invalid
+   * @returns false if there is an error
+   */
+  public override reportValidity(): boolean {
+    return super.reportValidity();
+  }
+
+  /**
    * Renders icon element
    * @returns {void}
    */

--- a/packages/elements/src/search-field/index.ts
+++ b/packages/elements/src/search-field/index.ts
@@ -69,8 +69,8 @@ export class SearchField extends TextField {
   }
 
   /**
-   * Returns true if an input element contains valid data
-   * @returns true if input is valid
+   * Returns `true` if the element input is valid; otherwise, returns `false`.
+   * @returns element input validity
    */
   public override checkValidity(): boolean {
     return super.checkValidity();

--- a/packages/elements/src/text-field/index.ts
+++ b/packages/elements/src/text-field/index.ts
@@ -165,6 +165,22 @@ export class TextField extends FormFieldElement {
   }
 
   /**
+   * Returns true if an input element contains valid data
+   * @returns true if input is valid
+   */
+  public override checkValidity(): boolean {
+    return super.checkValidity();
+  }
+
+  /**
+   * Validate input. Mark as error if input is invalid
+   * @returns false if there is an error
+   */
+  public override reportValidity(): boolean {
+    return super.reportValidity();
+  }
+
+  /**
    * Check if input value should be synchronised with component value
    * @param changedProperties Properties that has changed
    * @returns True if input should be synchronised

--- a/packages/elements/src/text-field/index.ts
+++ b/packages/elements/src/text-field/index.ts
@@ -173,8 +173,8 @@ export class TextField extends FormFieldElement {
   }
 
   /**
-   * Validate input. Mark as error if input is invalid
-   * @returns false if there is an error
+   * Validate the element input and mark it as error if its input is invalid.
+   * @returns `true` if the element input is valid; otherwise, returns `false`.
    */
   public override reportValidity(): boolean {
     return super.reportValidity();

--- a/packages/elements/src/text-field/index.ts
+++ b/packages/elements/src/text-field/index.ts
@@ -165,8 +165,8 @@ export class TextField extends FormFieldElement {
   }
 
   /**
-   * Returns true if an input element contains valid data
-   * @returns true if input is valid
+   * Returns `true` if the element input is valid; otherwise, returns `false`.
+   * @returns element input validity
    */
   public override checkValidity(): boolean {
     return super.checkValidity();


### PR DESCRIPTION
## Description
All fields element has the FormField as base class but API analyzer can't access base class so we need to add method placeholders in an element itself.

This PR also include improve validation section in all fields document.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
