### PR TITLE
docs: fix wrong table heading on api section

### DIFF
--- a/documents/resources/styles/table-api.css
+++ b/documents/resources/styles/table-api.css
@@ -42,13 +42,13 @@
   #properties ~ table td:nth-of-type(4):before { content: "Default"; }
   #properties ~ table td:nth-of-type(5):before { content: "Description"; }
 
+  #methods ~ table td:nth-of-type(1):before { content: "Method"; }
+  #methods ~ table td:nth-of-type(2):before { content: "Type"; }
+  #methods ~ table td:nth-of-type(3):before { content: "Description"; }
+
   #events ~ table td:nth-of-type(1):before { content: "Event"; }
   #events ~ table td:nth-of-type(2):before { content: "Description"; }
 
   #slots ~ table td:nth-of-type(1):before { content: "Name"; }
   #slots ~ table td:nth-of-type(2):before { content: "Description"; }
-
-  #methods ~ table td:nth-of-type(1):before { content: "Method"; }
-  #methods ~ table td:nth-of-type(2):before { content: "Type"; }
-  #methods ~ table td:nth-of-type(3):before { content: "Description"; }
 }


### PR DESCRIPTION
## Description
API section of an element will show wrong table heading when it have methods.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
