### PR TITLE
fix(tree-select): show invalid values when click on cancel button on selected view

### DIFF
--- a/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
@@ -265,6 +265,49 @@ describe('tree-select/Interaction', function () {
       expect(pillValues).to.have.ordered.members(expectedSelection, 'Pill values do not match');
     });
 
+    it('Should revert selected item on click cancel button correctly when selection filter applied', async function () {
+      const el = await fixture('<ef-tree-select lang="en-gb"></ef-tree-select>');
+      const data = [
+        { label: '1', value: '1', selected: true },
+        { label: '2', value: '2', selected: true },
+        { label: '3', value: '3', selected: false }
+      ];
+      el.data = data;
+      el.opened = true;
+      await elementUpdated(el);
+      await nextFrame();
+
+      const treeItems = el.treeEl.querySelectorAll('[role=treeitem]');
+      const cancel = el.popupEl.querySelector('#cancel');
+      const selectedFilter = el.popupEl.querySelector('[part~=selected-filter]');
+
+      treeItems[0].click(); // unchecked item
+      await elementUpdated(el);
+      await nextFrame();
+
+      selectedFilter.click();
+      cancel.click();
+      await elementUpdated(el);
+      await nextFrame();
+
+      expect(el.treeManager.checkedItems.length).to.equal(2, 'Selected items do not reverted');
+
+      el.opened = true;
+      await elementUpdated(el);
+      await nextFrame();
+
+      treeItems[2].click(); // checked item
+      await elementUpdated(el);
+      await nextFrame();
+
+      selectedFilter.click();
+      cancel.click();
+      await elementUpdated(el);
+      await nextFrame();
+
+      expect(el.treeManager.checkedItems.length).to.equal(2, 'Selected items do not reverted');
+    });
+
     it('Adds selection to pills', async function () {
       const el = await fixture('<ef-tree-select show-pills lang="en-gb"></ef-tree-select>');
       el.data = flatData;

--- a/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.interaction.test.js
@@ -265,7 +265,7 @@ describe('tree-select/Interaction', function () {
       expect(pillValues).to.have.ordered.members(expectedSelection, 'Pill values do not match');
     });
 
-    it('Should revert selected item on click cancel button correctly when selection filter applied', async function () {
+    it('Should revert selected item on click cancel button when selection filter applied', async function () {
       const el = await fixture('<ef-tree-select lang="en-gb"></ef-tree-select>');
       const data = [
         { label: '1', value: '1', selected: true },

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -650,8 +650,8 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
   protected override onPopupClosed(): void {
     super.onPopupClosed();
     this.updateMemo();
+    this.exitEditSelection(); // Order is matter. should remove selection filter before revert modified selection
     this.revertModifiedSelection();
-    this.exitEditSelection();
   }
 
   /**

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -649,7 +649,6 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
    */
   protected override onPopupClosed(): void {
     super.onPopupClosed();
-    this.updateMemo();
     this.exitEditSelection(); // Order is matter. should remove selection filter before revert modified selection
     this.revertModifiedSelection();
   }

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -649,7 +649,7 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
    */
   protected override onPopupClosed(): void {
     super.onPopupClosed();
-    this.exitEditSelection(); // Order is matter. should remove selection filter before revert modified selection
+    this.exitEditSelection(); // selection filter should be removed before reverting modified selection
     this.revertModifiedSelection();
   }
 


### PR DESCRIPTION
## Description
`ef-tree-select` show invalid values when click cancel button on selected view

Step to reproduce:
1. go to https://ui.refinitiv.com/elements/tree-select#show-pills 
2. deselect "Ardar"
3. active selected view
4. click cancel

Expected result:
Value should be "Ardar, Taman.."

Actual result:
Value is "Ardar"

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
