### PR TITLE
fix(tree): parent label can't expand/collapse in stateless mode

### DIFF
--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -523,7 +523,7 @@ describe('tree/Tree', function () {
   });
 
   describe('Stateless Mode', function () {
-    it('Should expand or collapse when tapping on parent', async function () {
+    it('Should expand/collapse when tapping on single mode parent', async function () {
       const el = await fixture('<ef-tree stateless></ef-tree>');
       el.data = nestedData;
       await elementUpdated(el);
@@ -537,14 +537,18 @@ describe('tree/Tree', function () {
       expect(el.children[0].expanded).to.be.true;
     });
 
-    it('Should not expand or collapse when tapping on multiple mode parent', async function () {
+    it('Should not expand/collapse when tapping on multiple mode parent', async function () {
       const el = await fixture('<ef-tree multiple stateless></ef-tree>');
       el.data = nestedData;
       await elementUpdated(el);
 
       el.children[0].click();
       await elementUpdated(el);
-      expect(el.children[0].expanded).to.be.false;
+      expect(el.children[0].expanded).to.be.true;
+
+      el.children[0].click();
+      await elementUpdated(el);
+      expect(el.children[0].expanded).to.be.true;
     });
 
     it('Should not select value when tapping on multiple mode parent', async function () {

--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -522,6 +522,42 @@ describe('tree/Tree', function () {
     });
   });
 
+  describe('Stateless Mode', function () {
+    it('Should expand or collapse when tapping on parent', async function () {
+      const el = await fixture('<ef-tree stateless></ef-tree>');
+      el.data = nestedData;
+      await elementUpdated(el);
+
+      el.children[0].click();
+      await elementUpdated(el);
+      expect(el.children[0].expanded).to.be.false;
+
+      el.children[0].click();
+      await elementUpdated(el);
+      expect(el.children[0].expanded).to.be.true;
+    });
+
+    it('Should not expand or collapse when tapping on multiple mode parent', async function () {
+      const el = await fixture('<ef-tree multiple stateless></ef-tree>');
+      el.data = nestedData;
+      await elementUpdated(el);
+
+      el.children[0].click();
+      await elementUpdated(el);
+      expect(el.children[0].expanded).to.be.false;
+    });
+
+    it('Should not select value when tapping on multiple mode parent', async function () {
+      const el = await fixture('<ef-tree multiple stateless></ef-tree>');
+      el.data = nestedData;
+      await elementUpdated(el);
+
+      el.children[0].click();
+      await elementUpdated(el);
+      expect(el.values).to.deep.equal(['1.2'], 'should have only 1.2 as default seleted value');
+    });
+  });
+
   describe('Filter Tests', function () {
     it('Text filter applied, query attribute - multi level', async function () {
       const el = await fixture('<ef-tree query="-3" ></ef-tree>');

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -117,6 +117,9 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
   public override selectItem(item: T): boolean {
     // Stateless tree
     if (this.stateless) {
+      if (this.manager.isItemParent(item)) {
+        this.toggleExpandedState(item);
+      }
       return false;
     }
     // Multiple selection

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -117,7 +117,8 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
   public override selectItem(item: T): boolean {
     // Stateless tree
     if (this.stateless) {
-      if (this.manager.isItemParent(item)) {
+      // Single selection - expand/collapse group (parent)
+      if (!this.multiple && this.manager.isItemParent(item)) {
         this.toggleExpandedState(item);
       }
       return false;


### PR DESCRIPTION
## Description

`ef-tree-item` text cannot be tap to expand/collapse in stateless mode

Fixes # (issue)
https://jira.refinitiv.com/browse/ELF-2262

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
