### PR TITLE
fix(tree): parent label can't expand/collapse in stateless mode

### DIFF
--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -533,7 +533,7 @@ describe('tree/Tree', function () {
   });
 
   describe('Stateless Mode', function () {
-    it('Should expand or collapse when tapping on parent', async function () {
+    it('Should expand/collapse when tapping on single mode parent', async function () {
       const el = await fixture('<ef-tree stateless></ef-tree>');
       el.data = nestedData;
       await elementUpdated(el);
@@ -547,14 +547,18 @@ describe('tree/Tree', function () {
       expect(el.children[0].expanded).to.be.true;
     });
 
-    it('Should not expand or collapse when tapping on multiple mode parent', async function () {
+    it('Should not expand/collapse when tapping on multiple mode parent', async function () {
       const el = await fixture('<ef-tree multiple stateless></ef-tree>');
       el.data = nestedData;
       await elementUpdated(el);
 
       el.children[0].click();
       await elementUpdated(el);
-      expect(el.children[0].expanded).to.be.false;
+      expect(el.children[0].expanded).to.be.true;
+
+      el.children[0].click();
+      await elementUpdated(el);
+      expect(el.children[0].expanded).to.be.true;
     });
 
     it('Should not select value when tapping on multiple mode parent', async function () {

--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -532,6 +532,42 @@ describe('tree/Tree', function () {
     });
   });
 
+  describe('Stateless Mode', function () {
+    it('Should expand or collapse when tapping on parent', async function () {
+      const el = await fixture('<ef-tree stateless></ef-tree>');
+      el.data = nestedData;
+      await elementUpdated(el);
+
+      el.children[0].click();
+      await elementUpdated(el);
+      expect(el.children[0].expanded).to.be.false;
+
+      el.children[0].click();
+      await elementUpdated(el);
+      expect(el.children[0].expanded).to.be.true;
+    });
+
+    it('Should not expand or collapse when tapping on multiple mode parent', async function () {
+      const el = await fixture('<ef-tree multiple stateless></ef-tree>');
+      el.data = nestedData;
+      await elementUpdated(el);
+
+      el.children[0].click();
+      await elementUpdated(el);
+      expect(el.children[0].expanded).to.be.false;
+    });
+
+    it('Should not select value when tapping on multiple mode parent', async function () {
+      const el = await fixture('<ef-tree multiple stateless></ef-tree>');
+      el.data = nestedData;
+      await elementUpdated(el);
+
+      el.children[0].click();
+      await elementUpdated(el);
+      expect(el.values).to.deep.equal(['1.2'], 'should have only 1.2 as default seleted value');
+    });
+  });
+
   describe('Filter Tests', function () {
     it('Text filter applied, query attribute - multi level', async function () {
       const el = await fixture('<ef-tree query="-3" ></ef-tree>');

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -117,6 +117,9 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
   public override selectItem(item: T): boolean {
     // Stateless tree
     if (this.stateless) {
+      if (this.manager.isItemParent(item)) {
+        this.toggleExpandedState(item);
+      }
       return false;
     }
     // Multiple selection

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -117,7 +117,8 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
   public override selectItem(item: T): boolean {
     // Stateless tree
     if (this.stateless) {
-      if (this.manager.isItemParent(item)) {
+      // Single selection - expand/collapse group (parent)
+      if (!this.multiple && this.manager.isItemParent(item)) {
         this.toggleExpandedState(item);
       }
       return false;


### PR DESCRIPTION
Sync from v7: https://github.com/Refinitiv/refinitiv-ui/pull/967