### PR TITLE
fix(overlay-menu): missing nested items property

### DIFF
--- a/packages/elements/src/item/helpers/types.ts
+++ b/packages/elements/src/item/helpers/types.ts
@@ -58,7 +58,7 @@ interface ItemDivider extends CommonItem {
 }
 type ItemDataUnion = ItemText | ItemHeader | ItemDivider;
 /**
- * Used to construct a collection of items
+ * Used to construct a nested union type of collection items;  this also allows parents to nest children with  different type from their own within the union type. e.g. allowing `ItemText` to be nested in `ItemHeader`
  */
 type ItemData = ItemDataUnion & NestedItems<ItemDataUnion>;
 

--- a/packages/elements/src/item/helpers/types.ts
+++ b/packages/elements/src/item/helpers/types.ts
@@ -56,10 +56,10 @@ interface ItemHeader extends CommonLabelItem {
 interface ItemDivider extends CommonItem {
   type: 'divider';
 }
-type ItemDataCombined = ItemText | ItemHeader | ItemDivider;
+type ItemDataUnion = ItemText | ItemHeader | ItemDivider;
 /**
  * Used to construct a collection of items
  */
-type ItemData<T extends ItemDataCombined = ItemDataCombined> = ItemDataCombined & NestedItems<T>;
+type ItemData = ItemDataUnion & NestedItems<ItemDataUnion>;
 
 export type { ItemType, ItemText, ItemHeader, ItemDivider, ItemData };

--- a/packages/elements/src/item/helpers/types.ts
+++ b/packages/elements/src/item/helpers/types.ts
@@ -1,4 +1,4 @@
-import type { DataItem } from '@refinitiv-ui/utils/collection.js';
+import type { DataItem, NestedItem } from '@refinitiv-ui/utils/collection.js';
 
 type ItemType = 'text' | 'header' | 'divider';
 
@@ -56,10 +56,10 @@ interface ItemHeader extends CommonLabelItem {
 interface ItemDivider extends CommonItem {
   type: 'divider';
 }
-
+type ItemDataCombined = ItemText | ItemHeader | ItemDivider;
 /**
  * Used to construct a collection of items
  */
-type ItemData = ItemText | ItemHeader | ItemDivider;
+type ItemData<T extends ItemDataCombined = ItemDataCombined> = ItemDataCombined & NestedItem<T>;
 
 export type { ItemType, ItemText, ItemHeader, ItemDivider, ItemData };

--- a/packages/elements/src/item/helpers/types.ts
+++ b/packages/elements/src/item/helpers/types.ts
@@ -1,4 +1,4 @@
-import type { DataItem, NestedItem } from '@refinitiv-ui/utils/collection.js';
+import type { DataItem, NestedItems } from '@refinitiv-ui/utils/collection.js';
 
 type ItemType = 'text' | 'header' | 'divider';
 
@@ -60,6 +60,6 @@ type ItemDataCombined = ItemText | ItemHeader | ItemDivider;
 /**
  * Used to construct a collection of items
  */
-type ItemData<T extends ItemDataCombined = ItemDataCombined> = ItemDataCombined & NestedItem<T>;
+type ItemData<T extends ItemDataCombined = ItemDataCombined> = ItemDataCombined & NestedItems<T>;
 
 export type { ItemType, ItemText, ItemHeader, ItemDivider, ItemData };

--- a/packages/elements/src/item/helpers/types.ts
+++ b/packages/elements/src/item/helpers/types.ts
@@ -58,7 +58,9 @@ interface ItemDivider extends CommonItem {
 }
 type ItemDataUnion = ItemText | ItemHeader | ItemDivider;
 /**
- * Used to construct a nested union type of collection items;  this also allows parents to nest children with  different type from their own within the union type. e.g. allowing `ItemText` to be nested in `ItemHeader`
+ * Used to construct a nested union type of collection items.
+ * This allows parents to nest children with different type from their own within the union type.
+ * For example, nesting `ItemText` under `ItemHeader`.
  */
 type ItemData = ItemDataUnion & NestedItems<ItemDataUnion>;
 

--- a/packages/utils/src/collection.ts
+++ b/packages/utils/src/collection.ts
@@ -1,3 +1,3 @@
 export { CollectionComposer } from './collection/collection-composer.js';
-export { CollectionItem, NestedItem } from './collection/collection-item.js';
+export { CollectionItem, NestedItems } from './collection/collection-item.js';
 export { DataItem } from './collection/data-item.js';

--- a/packages/utils/src/collection.ts
+++ b/packages/utils/src/collection.ts
@@ -1,3 +1,3 @@
 export { CollectionComposer } from './collection/collection-composer.js';
-export { CollectionItem } from './collection/collection-item.js';
+export { CollectionItem, NestedItem } from './collection/collection-item.js';
 export { DataItem } from './collection/data-item.js';

--- a/packages/utils/src/collection/collection-item.ts
+++ b/packages/utils/src/collection/collection-item.ts
@@ -3,15 +3,18 @@
  * This is the most basic type of object
  * that can be passed to the collection composer.
  */
-export interface CollectionItem {
+export interface CollectionItem extends NestedItem<CollectionItem> {
   /**
    * Additional keys which are forcefully injected into the item
    * will be allowed for flexibility, but will return an `unknown` type.
    */
   [key: string]: unknown;
+}
+
+export interface NestedItem<T extends CollectionItem> {
   /**
    * Child items collection.
    * Used for nested data structures.
    */
-  items?: this[];
+  items?: T[];
 }

--- a/packages/utils/src/collection/collection-item.ts
+++ b/packages/utils/src/collection/collection-item.ts
@@ -3,7 +3,7 @@
  * This is the most basic type of object
  * that can be passed to the collection composer.
  */
-export interface CollectionItem extends NestedItem<CollectionItem> {
+export interface CollectionItem extends NestedItems<CollectionItem> {
   /**
    * Additional keys which are forcefully injected into the item
    * will be allowed for flexibility, but will return an `unknown` type.
@@ -11,7 +11,7 @@ export interface CollectionItem extends NestedItem<CollectionItem> {
   [key: string]: unknown;
 }
 
-export interface NestedItem<T extends CollectionItem> {
+export interface NestedItems<T extends CollectionItem> {
   /**
    * Child items collection.
    * Used for nested data structures.


### PR DESCRIPTION
## Description
Typescript compiler show type error when trying to set value with a nested data.

Root cause:
-  Typescript compiler not understand Discriminated union types with nested. So it will guest one of a union types
For example:  https://codesandbox.io/s/nested-discriminated-unions-873c2x?file=/src/index.ts

Solution:
- Create NestedItems interface that can receive type of a nested item
- Sent explicit type to NestedItems
For example: https://codesandbox.io/s/nested-discriminated-unions-forked-fwz8xx?file=/src/index.ts


Fixes # (issue)
https://jira.refinitiv.com/browse/STG-191

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
