### PR TITLE
fix(list, tree): stateless list and tree should have aria-readonly

### DIFF
--- a/packages/elements/src/list/elements/list.ts
+++ b/packages/elements/src/list/elements/list.ts
@@ -657,6 +657,14 @@ export class List<T extends DataItem = ItemData> extends ControlElement {
       this.renderTimestamp.clear(); // force render of all items
       this.setAttribute('aria-multiselectable', this.multiple ? 'true' : 'false');
     }
+
+    if (changeProperties.has('stateless')) {
+      if (this.stateless) {
+        this.setAttribute('aria-readonly', 'true');
+      } else {
+        this.removeAttribute('aria-readonly');
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

Adding `aria-reaonly=true` when list and tree are in stateless mode i.e., can be interacted but not updating value. `aria-readonly` is compatible with `role=listbox`.

Reference, https://www.w3.org/TR/wai-aria-1.2/#aria-readonly 


Fixes [ELF-2264](https://jira.refinitiv.com/browse/ELF-2264)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
