### PR TITLE
fix: `ITimeScaleApi` type errors in `lightweight-charts` to 4.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14078,9 +14078,9 @@
       "dev": true
     },
     "node_modules/lightweight-charts": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-4.0.1.tgz",
-      "integrity": "sha512-p+j6w41PVzf9Vn7IrmpmCJacunpN0kKsl0IZoxMOySSkDcSagZ7Is9pb6pclIfN/usHdta0aYm9FktkYpAQe0g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-4.1.0.tgz",
+      "integrity": "sha512-O7RPoRLPPmwRNOTmBq1ne5eKgjdVZocd2TE77JCfaVJEwS+0meN9UwMKGNGiiRQBb2UkuhyBSiX7XrErBuL+CQ==",
       "dependencies": {
         "fancy-canvas": "2.1.0"
       }
@@ -22403,7 +22403,7 @@
         "chartjs-adapter-date-fns": "^3.0.0",
         "d3-interpolate": "^3.0.1",
         "date-fns": "^2.29.3",
-        "lightweight-charts": "^4.0.1",
+        "lightweight-charts": "^4.1.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -347,7 +347,7 @@
     "chartjs-adapter-date-fns": "^3.0.0",
     "d3-interpolate": "^3.0.1",
     "date-fns": "^2.29.3",
-    "lightweight-charts": "^4.0.1",
+    "lightweight-charts": "^4.1.0",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
+++ b/packages/elements/src/interactive-chart/__test__/interactive-chart.test.js
@@ -95,7 +95,7 @@ describe('interactive-chart/InteractiveChart', function () {
       expect(el.seriesList).to.lengthOf(0);
     });
 
-    it('series not contain data', async function () {
+    it('Should have no data when none is assigned', async function () {
       el.config = {
         series: [
           {
@@ -106,9 +106,8 @@ describe('interactive-chart/InteractiveChart', function () {
       await elementUpdated(el);
       await nextFrame(2);
 
-      expect(el.internalConfig.series).to.lengthOf(1);
       expect(el.seriesList).to.lengthOf(1);
-      expect(el.seriesList[0].data).to.be.undefined;
+      expect(el.seriesList[0].data()).to.be.empty;
     });
 
     it('Should support line chart', async function () {

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -1,4 +1,4 @@
-import { ColorType, Time, createChart as chart } from 'lightweight-charts';
+import { ColorType, createChart as chart } from 'lightweight-charts';
 
 import {
   CSSResultGroup,
@@ -43,7 +43,8 @@ import type {
   LineSeriesOptions,
   MouseEventParams,
   OhlcData,
-  SingleValueData
+  SingleValueData,
+  Time
 } from 'lightweight-charts';
 
 export type { InteractiveChartConfig, InteractiveChartSeries, Theme, SeriesOptions, SeriesDataItem };

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -1,4 +1,4 @@
-import { ColorType, createChart as chart } from 'lightweight-charts';
+import { ColorType, Time, createChart as chart } from 'lightweight-charts';
 
 import {
   CSSResultGroup,
@@ -136,7 +136,7 @@ export class InteractiveChart extends ResponsiveElement {
   private isCrosshairVisible = false;
 
   protected rowLegend: RowLegend = null;
-  private timeScale: ITimeScaleApi | null = null;
+  private timeScale: ITimeScaleApi<Time> | null = null;
 
   private width = 0;
   private height = 0;


### PR DESCRIPTION
## Description

Fixes build error caused by  `lightweight-charts@4.1.0`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
