### PR TITLE
Fix NX command publish VSCode extension.

### DIFF
--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -101,6 +101,7 @@ jobs:
 
       - name: Publish Visual Studio Code Extension
         run: |
+          npx nx reset # Workaround for the NX issue https://github.com/nrwl/nx/issues/17781 to prevent NX command below error.
           echo package-lock.json >> .nxignore # Prevent this file affected for all packages, issue https://github.com/nrwl/nx/issues/15116
           npx nx affected --targets vsce:publish --base=release-base --head=HEAD
         env:


### PR DESCRIPTION
## Description

On the CI, the NX command for publish VSCode extension throw error "NX   Failed to process project dependencies with nx-js-graph-plugin. Source project does not exist: npm:esbuild@0.18.11" so, we have to use the workaround temporary.

Fixes # (issue)

[ELF-2326](https://jira.refinitiv.com/browse/ELF-2326)

Reference:
- https://github.com/nrwl/nx/issues/17987
- https://github.com/nrwl/nx/issues/17781

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
