### PR TITLE
Update with new badges from SonarCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Element Framework (EF)
 
-[![Test](https://github.com/Refinitiv/refinitiv-ui/actions/workflows/test_coverage.yml/badge.svg)](https://github.com/Refinitiv/refinitiv-ui/actions/workflows/test_coverage.yml)
-[![Nightly Test](https://github.com/Refinitiv/refinitiv-ui/actions/workflows/test_nightly.yml/badge.svg?event=schedule)](https://github.com/Refinitiv/refinitiv-ui/actions/workflows/test_nightly.yml)
-[![Production Release](https://github.com/Refinitiv/refinitiv-ui/actions/workflows/prod_release.yml/badge.svg?branch=v7)](https://github.com/Refinitiv/refinitiv-ui/actions/workflows/prod_release.yml)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=refinitiv_refinitiv-ui&metric=coverage)](https://sonarcloud.io/summary/new_code?id=refinitiv_refinitiv-ui)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=refinitiv_refinitiv-ui&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=refinitiv_refinitiv-ui)
 
 Element Framework is LSEG Workspace's design system components that provides components and tooling to help product teams work faster and more efficiently.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Element Framework (EF)
 
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=refinitiv_refinitiv-ui&metric=coverage&branch=v7)](https://sonarcloud.io/summary/new_code?id=refinitiv_refinitiv-ui&branch=v7)
-[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=refinitiv_refinitiv-ui&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=refinitiv_refinitiv-ui)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=refinitiv_refinitiv-ui&metric=vulnerabilities&branch=v7)](https://sonarcloud.io/summary/new_code?id=refinitiv_refinitiv-ui&branch=v7)
 
 Element Framework is LSEG Workspace's design system components that provides components and tooling to help product teams work faster and more efficiently.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Element Framework (EF)
 
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=refinitiv_refinitiv-ui&metric=coverage)](https://sonarcloud.io/summary/new_code?id=refinitiv_refinitiv-ui)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=refinitiv_refinitiv-ui&metric=coverage&branch=v7)](https://sonarcloud.io/summary/new_code?id=refinitiv_refinitiv-ui&branch=v7)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=refinitiv_refinitiv-ui&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=refinitiv_refinitiv-ui)
 
 Element Framework is LSEG Workspace's design system components that provides components and tooling to help product teams work faster and more efficiently.


### PR DESCRIPTION
I feel that current badges doesn't seem to be matter for users / our team. 
Currently
Test Coverage : Failed -> don't even know why it's fail
Nightly Test : Passing -> not sure if users cares much about nightly test, they wouldn't know what it's tested
Production : Passing -> even me, I don't know what it mean.

Proposal
Test coverage : X%
Vulnerabilities : X

Both stats are what we recently fixed / part of OKR, I think it's more rationale and useful than the current one.