### PR TITLE
feat(datetime-picker): cascade custom cell slot to calendar

### DIFF
--- a/documents/src/pages/elements/datetime-picker.md
+++ b/documents/src/pages/elements/datetime-picker.md
@@ -248,6 +248,9 @@ section {
 ```
 
 ## Set content to slots
+Datetime Picker allows to add additional content to various placements around the calendar e.g. left, right. You can also slot your own content to any cells in calendar to do special styles on the cell.
+
+### Add contents around the calendar
 Use slots to add additional content into the Datetime Picker.
 
 ::
@@ -343,6 +346,273 @@ section {
 </ef-datetime-picker>
 ```
 
+### Custom cells
+Datetime Picker allows you to customise cells on the calendar using slots. Each date cell provides slot with name in `yyyy-MM-dd` format. In case of year or month cell, the format is `yyyy` or `yyyy-MM`.
+
+::
+```javascript
+::datetime-picker::
+const datetimePicker = document.querySelector('ef-datetime-picker');
+datetimePicker.view = '2023-04';
+```
+```html
+<section>
+  <div class="date-input">
+    <label for="date-time-picker">Select Date :</label>
+    <ef-datetime-picker id="datetime-picker" opened>
+      <div class="holiday" slot="2023-04-07">7</div>
+      <div class="holiday" slot="2023-04-10">10</div>
+      <div class="holiday" slot="2023-05-01">1</div>
+      <div class="holiday" slot="2023-05-18">18</div>
+      <div class="holiday" slot="2023-05-29">29</div>
+    </ef-datetime-picker>
+  </div>
+</section>
+```
+```css
+.date-input {
+  display: flex;
+  flex-direction: column;
+}
+
+section {
+  display: flex;
+  height: 300px;
+  padding: 0 3px;
+}
+
+ef-datetime-picker .holiday {
+  background-color: var(--color-scheme-negative);
+  color: var(--color-scheme-ticktext);
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+```
+::
+
+```html
+<ef-datetime-picker>
+  <div class="holiday" slot="2023-04-07">7</div>
+  <div class="holiday" slot="2023-04-10">10</div>
+  <div class="holiday" slot="2023-05-01">1</div>
+  <div class="holiday" slot="2023-05-18">18</div>
+  <div class="holiday" slot="2023-05-29">29</div>
+</ef-datetime-picker>
+```
+
+### Custom cells in duplex mode
+In duplex mode, there are 2 calendars on the UI. Slot name of left calendar is prefixed with `from-` and another one is prefixed with `to-`.
+
+```html
+<ef-datetime-picker id="duplex-datetime-picker" duplex range>
+  <div class="holiday" slot="from-2023-04-07">7</div>
+  <div class="holiday" slot="from-2023-04-10">10</div>
+  <div class="holiday" slot="from-2023-05-01">1</div>
+  <div class="holiday" slot="from-2023-05-18">18</div>
+  <div class="holiday" slot="from-2023-05-29">29</div>
+  <div class="holiday" slot="to-2023-04-07">7</div>
+  <div class="holiday" slot="to-2023-04-10">10</div>
+  <div class="holiday" slot="to-2023-05-01">1</div>
+  <div class="holiday" slot="to-2023-05-18">18</div>
+  <div class="holiday" slot="to-2023-05-29">29</div>
+</ef-datetime-picker>
+```
+
+### Advanced custom cells
+For more advanced use cases, you can use `before-cell-render` event to check states of each cell e.g. `range`, `selected`. See all cell states from [CalendarCell](https://github.com/Refinitiv/refinitiv-ui/blob/v6/packages/elements/src/calendar/types.ts).
+
+```javascript
+datetimePicker.addEventListener('before-cell-render', (event) => {
+  const { cell, calendar } = event.detail;
+  ...
+}
+```
+
+Event's `detail` object provides `cell` that being rendered and its parent calendar (in case of duplex). In duplex mode, the left calendar has id as `calendar-from` and the right calendar is `calendar-to`.
+
+The example below show calendar in duplex mode. You listen to `before-cell-render` event to query slot contents and uses state from `cell` and `calendar` to add CSS classes to the slot content properly.
+
+```html
+<ef-datetime-picker duplex range lang="de">
+  <div class="custom-cell" slot="from-2023-04-04"></div>
+  <div class="custom-cell" slot="from-2023-04-24"></div>
+  <div class="custom-cell" slot="from-2023-04-28"></div>
+  <div class="custom-cell" slot="from-2023-05-16"></div>
+  <div class="custom-cell" slot="from-2023-05-25"></div>
+  <div class="custom-cell" slot="from-2023-05-31"></div>
+  <div class="custom-cell" slot="from-2023-04"></div>
+  <div class="custom-cell" slot="from-2023-05"></div>
+  <div class="custom-cell" slot="from-2023"></div>
+  <div class="custom-cell" slot="to-2023-04-04"></div>
+  <div class="custom-cell" slot="to-2023-04-24"></div>
+  <div class="custom-cell" slot="to-2023-04-28"></div>
+  <div class="custom-cell" slot="to-2023-05-16"></div>
+  <div class="custom-cell" slot="to-2023-05-25"></div>
+  <div class="custom-cell" slot="to-2023-05-31"></div>
+  <div class="custom-cell" slot="to-2023-04"></div>
+  <div class="custom-cell" slot="to-2023-05"></div>
+</ef-datetime-picker>
+```
+```javascript
+const datetimePicker = document.querySelector('ef-datetime-picker');
+
+datetimePicker.addEventListener('before-cell-render', (event) => {
+  const sourceDatetimePicker = event.target;
+  const { cell, calendar } = event.detail;
+  const prefix = calendar.id === 'calendar-to' ? 'to-' : 'from-';
+  const customCell = sourceDatetimePicker.querySelector(`[slot="${prefix}${cell.value}"]`);
+  
+  // skip style overriding if there is no content for the cell
+  if (!customCell) { return; }
+
+  // use text from component as calendar has built-in locale support
+  // for instance, Mai instead of May in German
+  customCell.textContent = cell.text;
+
+  // modify classes that match to current cell state
+  const customCellClass = customCell.classList;
+  const keys = ['range', 'selected'];
+  for (const key of keys) {
+    cell[key] ? customCellClass.add(key) : customCellClass.remove(key);
+  }
+});
+```
+```css
+ef-datetime-picker .custom-cell {
+  ...
+}
+ef-datetime-picker .custom-cell.range {
+  ...
+}
+ef-datetime-picker .custom-cell.select {
+  ...
+}
+```
+
+::
+```javascript
+::datetime-picker::
+const datetimePicker = document.querySelector('ef-datetime-picker');
+datetimePicker.views = ['2023-04','2023-05'];
+
+datetimePicker?.addEventListener('before-cell-render', (event) => {
+  const sourceDatetimePicker = event.target;
+  const { cell, calendar } = event.detail;
+  const prefix = calendar.id === 'calendar-to' ? 'to-' : 'from-';
+  const customCell = sourceDatetimePicker.querySelector(`[slot="${prefix}${cell.value}"]`);
+  if (!customCell) {
+    return;
+  }
+  
+  // skip style overriding if there is no content for the cell
+  if (!customCell) { return; }
+
+  // use text from component as calendar has built-in locale support
+  // for instance, Mai instead of May in German
+  customCell.textContent = cell.text;
+
+  // modify classes that match to current cell state
+  const customCellClass = customCell.classList;
+  const keys = ['range', 'selected'];
+  for (const key of keys) {
+    cell[key] ? customCellClass.add(key) : customCellClass.remove(key);
+  }
+});
+```
+```html
+<section>
+  <div>
+    <h5>Germany Economic Events 2023</h5>
+    <h6>April</h6>
+    <p>
+      04: Balance of Trade<br>
+      24: Ifo Business Climate<br>
+      28: GDP Growth Rate YoY Flash
+    </p>
+    <h6>May</h6>
+    <p>
+      16: ZEW Economic Sentiment Index<br>
+      25: GfK Consumer Confidence<br>
+      31: Inflation Rate YoY Prel
+    </p>
+  </div>
+  <br>
+  <label for="input-date">Select Range :</label>
+  <ef-datetime-picker id="input-date" opened duplex range lang="de" values="2023-04-11,2023-05-20">
+    <div class="custom-cell" slot="from-2023-04-04"></div>
+    <div class="custom-cell" slot="from-2023-04-24"></div>
+    <div class="custom-cell" slot="from-2023-04-28"></div>
+    <div class="custom-cell" slot="from-2023-05-16"></div>
+    <div class="custom-cell" slot="from-2023-05-25"></div>
+    <div class="custom-cell" slot="from-2023-05-31"></div>
+    <div class="custom-cell" slot="from-2023-04"></div>
+    <div class="custom-cell" slot="from-2023-05"></div>
+    <div class="custom-cell" slot="from-2023"></div>
+    <div class="custom-cell" slot="to-2023-04-04"></div>
+    <div class="custom-cell" slot="to-2023-04-24"></div>
+    <div class="custom-cell" slot="to-2023-04-28"></div>
+    <div class="custom-cell" slot="to-2023-05-16"></div>
+    <div class="custom-cell" slot="to-2023-05-25"></div>
+    <div class="custom-cell" slot="to-2023-05-31"></div>
+    <div class="custom-cell" slot="to-2023-04"></div>
+    <div class="custom-cell" slot="to-2023-05"></div>
+  </ef-datetime-picker>
+</section>
+```
+```css
+html {
+  --custom-cell-selected-background-color: #334bff;
+  --custom-cell-hover-color: #1429bd;
+  --custom-cell-range-background-color: #334bff33;
+  --custom-cell-highlight-color: #F5475B;
+}
+
+html[prefers-color-scheme="light"] {
+  --custom-cell-background-color: #ffffff00;
+}
+
+html[prefers-color-scheme="dark"] {
+  --custom-cell-background-color: #0d0d0d00;
+}
+
+
+section {
+  display: flex;
+  flex-direction: column;
+  height: 550px;
+  padding: 0 3px;
+  margin: 20px;
+}
+
+h5, h6 {
+  margin-top: 0px;
+}
+
+ef-datetime-picker .custom-cell {
+  background: linear-gradient(-135deg, var(--custom-cell-highlight-color) 5px, var(--custom-cell-background-color) 0);
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+ef-datetime-picker .custom-cell:hover {
+  background: linear-gradient(-135deg, var(--custom-cell-highlight-color) 5px, var(--custom-cell-hover-color) 0);
+}
+
+ef-datetime-picker .custom-cell.range {
+  background: linear-gradient(-135deg, var(--custom-cell-highlight-color) 5px, #00000000 0);
+}
+ef-datetime-picker .custom-cell.selected {
+  background: linear-gradient(-135deg, var(--custom-cell-highlight-color) 5px, var(--custom-cell-selected-background-color) 0);
+}
+```
+::
 ## Accessibility
 ::a11y-intro::
 

--- a/packages/elements/src/calendar/index.ts
+++ b/packages/elements/src/calendar/index.ts
@@ -108,7 +108,7 @@ export type { CalendarFilter, BeforeCellRenderEvent };
  * @attr {boolean} disabled - Set disabled state
  * @prop {boolean} [disabled=false] - Set disabled state
  *
- * @slot yyyy-mm-dd - Adds slotted content into the specific date which use value in `ISO8601` date string format as a key e.g. `yyyy-MM-dd`, `yyyy-MM` and `yyyy`
+ * @slot yyyy-MM-dd - Adds slotted content into the specific date which use value in `ISO8601` date string format as a key e.g. `yyyy-MM-dd`, `yyyy-MM` and `yyyy`
  * @slot footer - Adds slotted content into the footer of the calendar control
  */
 @customElement('ef-calendar')
@@ -1423,7 +1423,8 @@ export class Calendar extends ControlElement implements MultiValue {
       cancelable: false,
       composed: true, // allow calendar customization within other elements e.g. datetime picker
       detail: {
-        cell: calendarCell
+        cell: calendarCell,
+        calendar: this
       }
     });
     this.dispatchEvent(event);

--- a/packages/elements/src/calendar/types.ts
+++ b/packages/elements/src/calendar/types.ts
@@ -1,6 +1,7 @@
 import { CellIndex } from '@refinitiv-ui/utils/navigation.js';
 
 import { CalendarRenderView } from './constants.js';
+import type { Calendar } from './index.js';
 
 export interface CellSelectionModel {
   selected?: boolean;
@@ -62,4 +63,5 @@ export type CalendarCell = {
 // public API
 export type BeforeCellRenderEvent = CustomEvent<{
   cell: CalendarCell;
+  calendar: Calendar;
 }>;

--- a/packages/elements/src/datetime-picker/__demo__/index.html
+++ b/packages/elements/src/datetime-picker/__demo__/index.html
@@ -49,6 +49,11 @@
       .custom-cell.disabled {
         background-color: #df2929ff;
       }
+      section {
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+      }
     </style>
   </head>
   <body>
@@ -516,30 +521,36 @@
           cell[key] ? classList.add(key) : classList.remove(key);
         }
       };
-      let timeoutID;
-      const specialDate = [
-        '2023-09-30',
-        '2023-10-07',
-        '2023-10-14',
-        '2023-10-21',
-        '2023-10-28',
-        '2023-11-04'
-      ];
+
+      let intervalId;
+      const randomDate = () => {
+        const month = 10;
+        const year = 2023;
+        const daysInMonth = new Date(2023, month, 0).getDate();
+        const randomDay = Math.floor(Math.random() * daysInMonth) + 1;
+        const date = new Date(year, month - 1, randomDay);
+        return date.toISOString().split('T')[0];
+      };
+
+      const createSlot = () => {
+        let div = document.createElement('div');
+        const date = randomDate();
+        div.classList.add('custom-cell');
+        div.slot = date;
+        div.innerText = date.slice(-2).replace(/^0+/, '');
+        dynamicSingleDatetimePicker.append(div);
+        dynamicSingleDatetimePicker.updateCalendarSlot();
+      };
+
       dynamicSingleDatetimePicker.addEventListener('opened-changed', (event) => {
         if (event.detail.value) {
-          const interval = 1000;
-          specialDate.forEach(function (date, index) {
-            timeoutID = setTimeout(() => {
-              let div = document.createElement('div');
-              div.classList.add('custom-cell');
-              div.slot = date;
-              div.innerText = date.slice(-2).replace(/^0+/, '');
-              dynamicSingleDatetimePicker.append(div);
-              dynamicSingleDatetimePicker.updateCalendarSlot();
-            }, index * interval);
-          });
+          createSlot();
+          intervalId = setInterval(() => {
+            dynamicSingleDatetimePicker.innerHTML = '';
+            createSlot();
+          }, 2000);
         } else {
-          clearTimeout(timeoutID);
+          clearInterval(intervalId);
           dynamicSingleDatetimePicker.innerHTML = '';
         }
       });
@@ -577,7 +588,13 @@
       </ef-datetime-picker>
     </demo-block>
     <demo-block header="Update calendar slot while popup is opened">
-      <ef-datetime-picker id="dynamic-single-datetime-picker" view="2023-10"> </ef-datetime-picker>
+      <section>
+        <p>
+          Every 2 second, custom cell slot will be moved to another day and call
+          <b>updateCalendarSlot()</b> to cascade custom slot to calendar.
+        </p>
+        <ef-datetime-picker id="dynamic-single-datetime-picker" view="2023-10"></ef-datetime-picker>
+      </section>
     </demo-block>
   </body>
 </html>

--- a/packages/elements/src/datetime-picker/__demo__/index.html
+++ b/packages/elements/src/datetime-picker/__demo__/index.html
@@ -26,8 +26,8 @@
         justify-content: center;
       }
       .custom-cell.selected-range-boundary {
-        background-color: violet;
-        border-color: purple;
+        background-color: #ee82eeff;
+        border-color: #800080ff;
       }
       .custom-cell:hover {
         background-color: #00c389;
@@ -40,13 +40,13 @@
         background-color: #1fa90a;
       }
       .custom-cell.now {
-        background-color: rgb(246, 233, 175);
+        background-color: #f6e9afff;
       }
       .custom-cell.now:hover {
-        background-color: rgb(244, 206, 39);
+        background-color: #f4ce27ff;
       }
       .custom-cell.disabled {
-        background-color: rgb(223, 41, 41);
+        background-color: #df2929ff;
       }
     </style>
   </head>

--- a/packages/elements/src/datetime-picker/__demo__/index.html
+++ b/packages/elements/src/datetime-picker/__demo__/index.html
@@ -16,6 +16,38 @@
       ef-select {
         width: 300px;
       }
+      .custom-cell {
+        background-color: #4e7349;
+        border: 1px solid #fb8a03;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .custom-cell.selected-range-boundary {
+        background-color: violet;
+        border-color: purple;
+      }
+      .custom-cell:hover {
+        background-color: #00c389;
+        border: 1px solid #00c389;
+      }
+      .custom-cell.active {
+        background-color: #0f1e8a;
+      }
+      .custom-cell.range {
+        background-color: #1fa90a;
+      }
+      .custom-cell.now {
+        background-color: rgb(246, 233, 175);
+      }
+      .custom-cell.now:hover {
+        background-color: rgb(244, 206, 39);
+      }
+      .custom-cell.disabled {
+        background-color: rgb(223, 41, 41);
+      }
     </style>
   </head>
   <body>
@@ -433,6 +465,118 @@
           });
         })();
       </script>
+    </demo-block>
+    <script type="module">
+      const duplexDatetimePicker = document.getElementById('duplex-datetime-picker');
+      const singleDatetimePicker = document.getElementById('single-datetime-picker');
+      const dynamicSingleDatetimePicker = document.getElementById('dynamic-single-datetime-picker');
+
+      const beforeCellRenderHandlerSingle = (event) => {
+        const sourceDatetimePicker = event.target;
+        const { cell } = event.detail;
+        const targetCell = sourceDatetimePicker.querySelector(`[slot="${cell.value}"]`);
+        if (!targetCell) {
+          return;
+        }
+        const classList = targetCell.classList;
+        //  show default text when is there no content
+        if (!targetCell.innerHTML.trim()) {
+          targetCell.textContent = cell.text;
+        }
+        // style update with dynamic cell model key
+        const keys = ['range', 'disabled', 'idle', 'now', 'active'];
+        for (const key of keys) {
+          cell[key] ? classList.add(key) : classList.remove(key);
+        }
+      };
+
+      const beforeCellRenderHandlerDuplex = (event) => {
+        const sourceDatetimePicker = event.target;
+        const { cell, calendar } = event.detail;
+        const id = calendar.id === 'calendar-to' ? 'to-' : 'from-';
+        const targetCell = sourceDatetimePicker.querySelector(`[slot="${id}${cell.value}"]`);
+        if (!targetCell) {
+          return;
+        }
+        const classList = targetCell.classList;
+        //  show default text when is there no content
+        if (!targetCell.innerHTML.trim()) {
+          targetCell.textContent = cell.text;
+        }
+        //  update style with class based on cell model
+        if (cell.selected || cell.rangeFrom || cell.rangeTo) {
+          classList.add('selected-range-boundary');
+        } else {
+          classList.remove('selected-range-boundary');
+        }
+        // style update with dynamic cell model key
+        const keys = ['range', 'disabled', 'idle', 'now', 'active'];
+        for (const key of keys) {
+          cell[key] ? classList.add(key) : classList.remove(key);
+        }
+      };
+      let timeoutID;
+      const specialDate = [
+        '2023-09-30',
+        '2023-10-07',
+        '2023-10-14',
+        '2023-10-21',
+        '2023-10-28',
+        '2023-11-04'
+      ];
+      dynamicSingleDatetimePicker.addEventListener('opened-changed', (event) => {
+        if (event.detail.value) {
+          const interval = 1000;
+          specialDate.forEach(function (date, index) {
+            timeoutID = setTimeout(() => {
+              let div = document.createElement('div');
+              div.classList.add('custom-cell');
+              div.slot = date;
+              div.innerText = date.slice(-2).replace(/^0+/, '');
+              dynamicSingleDatetimePicker.append(div);
+              dynamicSingleDatetimePicker.updateCalendarSlot();
+            }, index * interval);
+          });
+        } else {
+          clearTimeout(timeoutID);
+          dynamicSingleDatetimePicker.innerHTML = '';
+        }
+      });
+
+      duplexDatetimePicker.views = ['2023-10', '2023-11'];
+
+      duplexDatetimePicker.addEventListener('before-cell-render', beforeCellRenderHandlerDuplex);
+      singleDatetimePicker.addEventListener('before-cell-render', beforeCellRenderHandlerSingle);
+      dynamicSingleDatetimePicker.addEventListener('before-cell-render', beforeCellRenderHandlerSingle);
+    </script>
+    <demo-block header="Slotted Cell Content + before-cell-render Event">
+      <ef-datetime-picker id="single-datetime-picker" view="2023-10" value="2023-10-10 ">
+        <div class="custom-cell" slot="2023-10-10">10</div>
+        <div class="custom-cell" slot="2023-10-11">11</div>
+        <div class="custom-cell" slot="2023-10">Oct</div>
+        <div class="custom-cell" slot="2023">2023</div>
+      </ef-datetime-picker>
+      <ef-datetime-picker id="duplex-datetime-picker" duplex range>
+        <div class="custom-cell" slot="from-2023-10-10">10</div>
+        <div class="custom-cell" slot="from-2023-10-11">11</div>
+        <div class="custom-cell" slot="from-2023-10">Oct</div>
+        <div class="custom-cell" slot="from-2023">2023</div>
+        <div class="custom-cell" slot="from-2023-11-10">10</div>
+        <div class="custom-cell" slot="from-2023-11-11">11</div>
+        <div class="custom-cell" slot="from-2023-11">Nov</div>
+        <div class="custom-cell" slot="from-2023">2023</div>
+        <div class="custom-cell" slot="to-2023-10-10">10</div>
+        <div class="custom-cell" slot="to-2023-10-11">11</div>
+        <div class="custom-cell" slot="to-2023-10">Oct</div>
+        <div class="custom-cell" slot="to-2023">2023</div>
+        <div class="custom-cell" slot="to-2023-11-10">10</div>
+        <div class="custom-cell" slot="to-2023-11-11">11</div>
+        <div class="custom-cell" slot="to-2023-11">Nov</div>
+        <div class="custom-cell" slot="to-2023">2023</div>
+      </ef-datetime-picker>
+    </demo-block>
+    <demo-block header="Update calendar slot while popup is opened">
+      <ef-datetime-picker id="dynamic-single-datetime-picker" view="2023-10"> </ef-datetime-picker>
     </demo-block>
   </body>
 </html>

--- a/packages/elements/src/datetime-picker/__demo__/index.html
+++ b/packages/elements/src/datetime-picker/__demo__/index.html
@@ -35,6 +35,7 @@
       }
       .custom-cell.active {
         background-color: #0f1e8a;
+        color: #ffffff;
       }
       .custom-cell.range {
         background-color: #1fa90a;

--- a/packages/elements/src/datetime-picker/__snapshots__/DOMStructure.md
+++ b/packages/elements/src/datetime-picker/__snapshots__/DOMStructure.md
@@ -89,7 +89,7 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    id="input"
+    id="input-from"
     part="input"
     tabindex="0"
     transparent=""
@@ -196,7 +196,7 @@
     <div part="selectors-wrapper">
       <div part="calendar-wrapper">
         <ef-calendar
-          id="calendar"
+          id="calendar-from"
           lang="en-gb"
           part="calendar"
           role="group"
@@ -373,7 +373,7 @@
 ```html
 <div part="input-wrapper">
   <ef-text-field
-    id="input"
+    id="input-from"
     part="input"
     tabindex="0"
     transparent=""
@@ -428,7 +428,7 @@
       </div>
       <div part="timepicker-wrapper">
         <ef-time-picker
-          id="timepicker"
+          id="timepicker-from"
           part="time-picker"
           role="group"
           tabindex="0"
@@ -443,6 +443,299 @@
           tabindex="0"
         >
         </ef-time-picker>
+      </div>
+    </div>
+    <div>
+      <slot name="right">
+      </slot>
+    </div>
+  </div>
+  <div>
+    <slot name="footer">
+    </slot>
+  </div>
+</ef-overlay>
+
+```
+
+####   `DOM structure is correct when add custom cell slot of calendar without prefix`
+
+```html
+<div part="input-wrapper">
+  <ef-text-field
+    id="input"
+    part="input"
+    tabindex="0"
+    transparent=""
+  >
+  </ef-text-field>
+</div>
+<ef-icon
+  icon="calendar"
+  part="icon"
+>
+</ef-icon>
+<ef-overlay-viewport>
+</ef-overlay-viewport>
+<ef-overlay
+  first-resize-done=""
+  no-autofocus=""
+  no-cancel-on-esc-key=""
+  opened=""
+  part="list"
+  tabindex="0"
+  with-shadow=""
+>
+  <div>
+    <slot name="header">
+    </slot>
+  </div>
+  <div part="body">
+    <div>
+      <slot name="left">
+      </slot>
+    </div>
+    <div part="selectors-wrapper">
+      <div part="calendar-wrapper">
+        <ef-calendar
+          id="calendar"
+          lang="en-gb"
+          part="calendar"
+          role="group"
+          tabindex="0"
+        >
+          <slot
+            name="2020-04-01"
+            slot="2020-04-01"
+          >
+          </slot>
+        </ef-calendar>
+      </div>
+    </div>
+    <div>
+      <slot name="right">
+      </slot>
+    </div>
+  </div>
+  <div>
+    <slot name="footer">
+    </slot>
+  </div>
+</ef-overlay>
+
+```
+
+####   `DOM structure is correct when add custom cell slot of calendar with prefix`
+
+```html
+<div part="input-wrapper">
+  <ef-text-field
+    id="input"
+    part="input"
+    tabindex="0"
+    transparent=""
+  >
+  </ef-text-field>
+</div>
+<ef-icon
+  icon="calendar"
+  part="icon"
+>
+</ef-icon>
+<ef-overlay-viewport>
+</ef-overlay-viewport>
+<ef-overlay
+  first-resize-done=""
+  no-autofocus=""
+  no-cancel-on-esc-key=""
+  opened=""
+  part="list"
+  tabindex="0"
+  with-shadow=""
+>
+  <div>
+    <slot name="header">
+    </slot>
+  </div>
+  <div part="body">
+    <div>
+      <slot name="left">
+      </slot>
+    </div>
+    <div part="selectors-wrapper">
+      <div part="calendar-wrapper">
+        <ef-calendar
+          id="calendar-from"
+          lang="en-gb"
+          part="calendar"
+          role="group"
+          tabindex="0"
+        >
+          <slot
+            name="from-2020-04-01"
+            slot="2020-04-01"
+          >
+          </slot>
+        </ef-calendar>
+        <ef-calendar
+          id="calendar-to"
+          lang="en-gb"
+          part="calendar"
+          role="group"
+          tabindex="0"
+        >
+          <slot
+            name="to-2020-05-01"
+            slot="2020-05-01"
+          >
+          </slot>
+        </ef-calendar>
+      </div>
+    </div>
+    <div>
+      <slot name="right">
+      </slot>
+    </div>
+  </div>
+  <div>
+    <slot name="footer">
+    </slot>
+  </div>
+</ef-overlay>
+
+```
+
+####   `DOM structure is correct when add custom cell slot of calendar while overlay is opened`
+
+```html
+<div part="input-wrapper">
+  <ef-text-field
+    id="input"
+    part="input"
+    tabindex="0"
+    transparent=""
+  >
+  </ef-text-field>
+</div>
+<ef-icon
+  icon="calendar"
+  part="icon"
+>
+</ef-icon>
+<ef-overlay-viewport>
+</ef-overlay-viewport>
+<ef-overlay
+  first-resize-done=""
+  no-autofocus=""
+  no-cancel-on-esc-key=""
+  opened=""
+  part="list"
+  tabindex="0"
+  with-shadow=""
+>
+  <div>
+    <slot name="header">
+    </slot>
+  </div>
+  <div part="body">
+    <div>
+      <slot name="left">
+      </slot>
+    </div>
+    <div part="selectors-wrapper">
+      <div part="calendar-wrapper">
+        <ef-calendar
+          id="calendar-from"
+          lang="en-gb"
+          part="calendar"
+          role="group"
+          tabindex="0"
+        >
+          <slot
+            name="from-2020-04-01"
+            slot="2020-04-01"
+          >
+          </slot>
+        </ef-calendar>
+        <ef-calendar
+          id="calendar-to"
+          lang="en-gb"
+          part="calendar"
+          role="group"
+          tabindex="0"
+        >
+          <slot
+            name="to-2020-05-01"
+            slot="2020-05-01"
+          >
+          </slot>
+        </ef-calendar>
+      </div>
+    </div>
+    <div>
+      <slot name="right">
+      </slot>
+    </div>
+  </div>
+  <div>
+    <slot name="footer">
+    </slot>
+  </div>
+</ef-overlay>
+
+```
+
+####   `DOM structure should not contain added custom cell slot when overlay is closed`
+
+```html
+<div part="input-wrapper">
+  <ef-text-field
+    id="input"
+    part="input"
+    tabindex="0"
+    transparent=""
+  >
+  </ef-text-field>
+</div>
+<ef-icon
+  icon="calendar"
+  part="icon"
+>
+</ef-icon>
+<ef-overlay
+  no-autofocus=""
+  no-cancel-on-esc-key=""
+  part="list"
+  tabindex="0"
+  with-shadow=""
+>
+  <div>
+    <slot name="header">
+    </slot>
+  </div>
+  <div part="body">
+    <div>
+      <slot name="left">
+      </slot>
+    </div>
+    <div part="selectors-wrapper">
+      <div part="calendar-wrapper">
+        <ef-calendar
+          id="calendar-from"
+          lang="en-gb"
+          part="calendar"
+          role="group"
+          tabindex="0"
+        >
+        </ef-calendar>
+        <ef-calendar
+          id="calendar-to"
+          lang="en-gb"
+          part="calendar"
+          role="group"
+          tabindex="0"
+        >
+        </ef-calendar>
       </div>
     </div>
     <div>

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.default.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.default.test.js
@@ -126,7 +126,7 @@ describe('datetime-picker/DatetimePicker', function () {
       const el = await fixture('<ef-datetime-picker lang="en-gb" range></ef-datetime-picker>');
       el.placeholder = placeholder;
       await elementUpdated(el);
-      const inputFrom = el.inputEl;
+      const inputFrom = el.inputFromEl;
       const inputTo = el.inputToEl;
       expect(el.placeholder).to.be.equal(placeholder, 'Placeholder getter is wrong');
       expect(inputFrom.placeholder).to.be.equal(placeholder, 'Placeholder is not passed to to input');

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.snapshot.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.snapshot.test.js
@@ -2,9 +2,14 @@
 import '@refinitiv-ui/elements/datetime-picker';
 
 import '@refinitiv-ui/elemental-theme/light/ef-datetime-picker';
-import { expect, fixture, nextFrame } from '@refinitiv-ui/test-helpers';
+import { elementUpdated, expect, fixture, nextFrame } from '@refinitiv-ui/test-helpers';
 
 import { snapshotIgnore } from './utils.js';
+
+const slotFrom = document.createElement('div');
+const slotTo = document.createElement('div');
+slotFrom.setAttribute('slot', 'from-2020-04-01');
+slotTo.setAttribute('slot', 'to-2020-05-01');
 
 describe('datetime-picker/DOMStructure', function () {
   describe('DOM Structure', function () {
@@ -17,49 +22,91 @@ describe('datetime-picker/DOMStructure', function () {
       const el = await fixture(
         '<ef-datetime-picker lang="en-gb" view="2020-04" opened></ef-datetime-picker>'
       );
-      await nextFrame();
-      await nextFrame(); /* second frame required for IE11 as popup opened might not fit into one frame */
+      await nextFrame(2); /* second frame required for IE11 as popup opened might not fit into one frame */
       expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
     });
     it('DOM structure is correct when range', async function () {
       const el = await fixture(
         '<ef-datetime-picker lang="en-gb" view="2020-04" range opened></ef-datetime-picker>'
       );
-      await nextFrame();
-      await nextFrame();
+      await nextFrame(2);
       expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
     });
     it('DOM structure is correct when duplex', async function () {
       const el = await fixture(
         '<ef-datetime-picker lang="en-gb" view="2020-04" duplex opened></ef-datetime-picker>'
       );
-      await nextFrame();
-      await nextFrame();
+      await nextFrame(2);
       expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
     });
     it('DOM structure is correct when timepicker', async function () {
       const el = await fixture(
         '<ef-datetime-picker lang="en-gb" view="2020-04" timepicker opened></ef-datetime-picker>'
       );
-      await nextFrame();
-      await nextFrame();
+      await nextFrame(2);
       expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
     });
     it('DOM structure is correct when timepicker and with-seconds', async function () {
       const el = await fixture(
         '<ef-datetime-picker lang="en-gb" view="2020-04" timepicker with-seconds opened></ef-datetime-picker>'
       );
-      await nextFrame();
-      await nextFrame();
+      await nextFrame(2);
       expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
     });
     it('DOM structure is correct when range timepicker', async function () {
       const el = await fixture(
         '<ef-datetime-picker lang="en-gb" view="2020-04" timepicker range opened></ef-datetime-picker>'
       );
-      await nextFrame();
-      await nextFrame();
+      await nextFrame(2);
       expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
+    });
+    it('DOM structure is correct when add custom cell slot of calendar without prefix', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker lang="en-gb" view="2020-04">' +
+          '<div slot="2020-04-01"></div>' +
+          '</ef-datetime-picker>'
+      );
+      el.opened = true;
+
+      await elementUpdated(el);
+      await nextFrame(2);
+      await expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
+    });
+    it('DOM structure is correct when add custom cell slot of calendar with prefix', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker lang="en-gb" view="2020-04" duplex></ef-datetime-picker>'
+      );
+      el.appendChild(slotFrom);
+      el.appendChild(slotTo);
+      el.opened = true;
+
+      await elementUpdated(el);
+      await nextFrame(2);
+      await expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
+    });
+    it('DOM structure is correct when add custom cell slot of calendar while overlay is opened', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker lang="en-gb" view="2020-04" duplex opened></ef-datetime-picker>'
+      );
+      el.appendChild(slotFrom);
+      el.appendChild(slotTo);
+      el.updateCalendarSlot();
+
+      await elementUpdated(el);
+      await nextFrame(2);
+      await expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
+    });
+    it('DOM structure should not contain added custom cell slot when overlay is closed', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker lang="en-gb" view="2020-04" duplex opened></ef-datetime-picker>'
+      );
+      el.appendChild(slotFrom);
+      el.appendChild(slotTo);
+      el.opened = false;
+
+      await elementUpdated(el);
+      await nextFrame(2);
+      await expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
     });
   });
 });

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -59,7 +59,7 @@ describe('datetime-picker/Value', function () {
       el.values = ['2022-03-15', '2022-04-23'];
       await elementUpdated(el);
       expect(el.error).to.be.equal(true);
-      typeText(el.inputEl, '');
+      typeText(el.inputFromEl, '');
       await elementUpdated(el);
       expect(el.error).to.be.equal(false, 'input empty string must not make element error in range mode');
     });
@@ -94,23 +94,23 @@ describe('datetime-picker/Value', function () {
     });
     it('It should be able to clear input values when user type invalid format for range mode', async function () {
       const el = await fixture('<ef-datetime-picker lang="en-gb" range opened></ef-datetime-picker>');
-      const input = el.inputEl;
+      const inputFrom = el.inputFromEl;
       const inputTo = el.inputToEl;
 
-      await triggerFocusFor(input);
+      await triggerFocusFor(inputFrom);
       await triggerFocusFor(inputTo);
-      typeText(input, 'Invalid Value 1');
+      typeText(inputFrom, 'Invalid Value 1');
       typeText(inputTo, 'Invalid Value 2');
       await elementUpdated(el);
 
-      expect(el.inputEl.value).to.be.equal('Invalid Value 1');
+      expect(el.inputFromEl.value).to.be.equal('Invalid Value 1');
       expect(el.inputToEl.value).to.be.equal('Invalid Value 2');
 
       el.values = [];
       await triggerFocusFor(el);
       await elementUpdated(el);
 
-      expect(el.inputEl.value).to.be.equal('');
+      expect(el.inputFromEl.value).to.be.equal('');
       expect(el.inputToEl.value).to.be.equal('');
       expect(el.error).to.be.equal(false);
     });
@@ -182,8 +182,8 @@ describe('datetime-picker/Value', function () {
       await nextFrame();
       await nextFrame();
 
-      const calendarEl = el.calendarEl;
-      const fromCell = calendarEl.shadowRoot.querySelectorAll('div[tabindex]')[0]; // 2020-04-01
+      const calendarFromEl = el.calendarFromEl;
+      const fromCell = calendarFromEl.shadowRoot.querySelectorAll('div[tabindex]')[0]; // 2020-04-01
       fromCell.click();
       await elementUpdated(el);
       await nextFrame();
@@ -197,7 +197,7 @@ describe('datetime-picker/Value', function () {
       expect(el.values[0]).to.be.equal('2020-04-01', 'Value from has not been updated');
       expect(el.values[1]).to.be.equal('2020-05-01', 'Value to has not been update');
 
-      expect(el.inputEl.value).to.be.equal('01-Apr-2020', 'Input from value has not updated');
+      expect(el.inputFromEl.value).to.be.equal('01-Apr-2020', 'Input from value has not updated');
       expect(el.inputToEl.value).to.be.equal('01-May-2020', 'Input to value has not updated');
     });
     it('It should not be possible to deselect values in range duplex mode', async function () {
@@ -206,8 +206,8 @@ describe('datetime-picker/Value', function () {
       await elementUpdated(el);
       await nextFrame(2);
 
-      const calendarEl = el.calendarEl;
-      const fromCell = calendarEl.shadowRoot.querySelectorAll('div[tabindex]')[0]; // 2020-04-01
+      const calendarFromEl = el.calendarFromEl;
+      const fromCell = calendarFromEl.shadowRoot.querySelectorAll('div[tabindex]')[0]; // 2020-04-01
       fromCell.click();
       await elementUpdated(el);
       await nextFrame();
@@ -221,7 +221,7 @@ describe('datetime-picker/Value', function () {
       expect(el.values[0]).to.be.equal('2020-04-01', 'Value from has not been updated');
       expect(el.values[1]).to.be.equal('2020-05-01', 'Value to has not been update');
 
-      expect(el.inputEl.value).to.be.equal('01-Apr-2020', 'Input from value has not updated');
+      expect(el.inputFromEl.value).to.be.equal('01-Apr-2020', 'Input from value has not updated');
       expect(el.inputToEl.value).to.be.equal('01-May-2020', 'Input to value has not updated');
 
       toCell.click();

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.view.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.view.test.js
@@ -86,7 +86,7 @@ describe('datetime-picker/View', function () {
     });
     it('Duplex split range view changes when typing the value', async function () {
       const el = await fixture('<ef-datetime-picker lang="en-gb" duplex="split" range></ef-datetime-picker>');
-      const inputFrom = el.inputEl;
+      const inputFrom = el.inputFromEl;
       const inputTo = el.inputToEl;
       typeText(inputFrom, '21-Jan-2020');
       typeText(inputTo, '21-Apr-2020');
@@ -112,7 +112,7 @@ describe('datetime-picker/View', function () {
       );
       el.views = ['2020-01', '2020-04'];
       await elementUpdated(el);
-      const calendarFrom = el.calendarEl;
+      const calendarFrom = el.calendarFromEl;
       const calendarTo = el.calendarToEl;
       expect(calendarFrom.view).to.be.equal('2020-01', 'From view is not propagated to calendar');
       expect(calendarTo.view).to.be.equal('2020-04', 'To view is not propagated to calendar');
@@ -142,7 +142,7 @@ describe('datetime-picker/View', function () {
       const el = await fixture(
         '<ef-datetime-picker lang="en-gb" view="2020-04" duplex opened></ef-datetime-picker>'
       );
-      const calendarFrom = el.calendarEl;
+      const calendarFrom = el.calendarFromEl;
       const calendarTo = el.calendarToEl;
       await elementUpdated(calendarFrom);
       await elementUpdated(calendarTo);
@@ -169,7 +169,7 @@ describe('datetime-picker/View', function () {
       );
       el.views = ['2020-04', '2020-05'];
       await elementUpdated(el);
-      const calendarFrom = el.calendarEl;
+      const calendarFrom = el.calendarFromEl;
       const calendarTo = el.calendarToEl;
       calendarClickNext(calendarFrom);
       await elementUpdated(el);
@@ -207,7 +207,7 @@ describe('datetime-picker/View', function () {
         '<ef-datetime-picker lang="en-gb" range duplex="split" opened></ef-datetime-picker>'
       );
       el.values = ['1997-04-01'];
-      const calendarFrom = el.calendarEl;
+      const calendarFrom = el.calendarFromEl;
       const calendarTo = el.calendarToEl;
       await elementUpdated(el);
       expect(calendarFrom.view).to.equal('1997-04', 'Calendar from view is not updated to the value');


### PR DESCRIPTION
## Description

As datetime-picker attaches calendar inside, we also need to cascade the custom cell slot on from datetime-picker to calendar.

Fixes # (issue)
ELF-2267

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
