### PR TITLE
feat(slider): improve screen reader

### DIFF
--- a/packages/elemental-theme/src/custom-elements/ef-slider-marker.less
+++ b/packages/elemental-theme/src/custom-elements/ef-slider-marker.less
@@ -2,6 +2,7 @@
   width: @slider-step-width;
   height: (@slider-step-width * 2);
   top: (@slider-step-width * 2);
+  user-select: none;
 
   [part='marker'] {
     background-color: var(--marker-color, @slider-thumb-color);

--- a/packages/elemental-theme/src/custom-elements/ef-slider.less
+++ b/packages/elemental-theme/src/custom-elements/ef-slider.less
@@ -5,7 +5,6 @@
 :host {
   @input-field-margin: 16px; // margin between input and slider
   .touch-action();
-  height: @control-height;
   margin: @control-margin;
   opacity: 0.9;
 
@@ -13,8 +12,12 @@
     opacity: 1;
   }
 
-  &:not(:empty) {
+  &:not(:empty) [part='slider-wrapper'] {
     margin-bottom: 20px;
+  }
+
+  [part='slider-wrapper'] {
+    height: @control-height;
   }
 
   [part='track-wrapper'] {
@@ -126,7 +129,7 @@
     width: var(--input-field-width, 40px);
     min-width: 40px;
     text-align: center;
-    height: 100%;
+    height: @control-height;
   }
 
   [part='input'][name='to'],

--- a/packages/elements/src/slider/__demo__/index.html
+++ b/packages/elements/src/slider/__demo__/index.html
@@ -44,6 +44,9 @@
       ef-slider[pin] {
         margin-top: 25px;
       }
+      label {
+        display: block;
+      }
     </style>
 
     <demo-block layout="normal" header="Default">
@@ -112,18 +115,22 @@
         <ef-slider-marker value="26"></ef-slider-marker>
         <ef-slider-marker value="67"></ef-slider-marker>
       </ef-slider>
-      <ef-slider>
+      <label for="rating">Rating</label>
+      <ef-slider id="rating">
         <ef-slider-marker value="0"><ef-icon icon="rating-1"></ef-icon></ef-slider-marker>
         <ef-slider-marker value="50"><ef-icon icon="rating-2"></ef-icon></ef-slider-marker>
         <ef-slider-marker value="100"><ef-icon icon="rating-3"></ef-icon></ef-slider-marker>
       </ef-slider>
-      <ef-slider step="5" show-steps>
+      <label for="temperature">Temperature</label>
+      <ef-slider id="temperature" step="5" show-steps>
+        <ef-slider-marker value="0">0°C</ef-slider-marker>
         <ef-slider-marker value="5">5°C</ef-slider-marker>
         <ef-slider-marker value="20">20°C</ef-slider-marker>
         <ef-slider-marker value="50">50°C</ef-slider-marker>
         <ef-slider-marker value="100">100°C</ef-slider-marker>
       </ef-slider>
-      <ef-slider step="5" min="-17" max="200" value="-15" show-input-field>
+      <label for="minus-temperature">Minus Temperature</label>
+      <ef-slider id="minus-temperature" step="5" min="-17" max="200" value="-15" show-input-field>
         <ef-slider-marker value="-10">-10°C</ef-slider-marker>
         <ef-slider-marker value="5">5°C</ef-slider-marker>
         <ef-slider-marker value="20">20°C</ef-slider-marker>
@@ -141,7 +148,8 @@
         <ef-slider-marker value="90">90°C</ef-slider-marker>
         <ef-slider-marker value="100">100°C</ef-slider-marker>
       </ef-slider>
-      <ef-slider step="5" range show-input-field min-range="10">
+      <label for="range-step-temparature">Range step Temperature</label>
+      <ef-slider id="range-step-temparature" step="5" range show-input-field min-range="10">
         <ef-slider-marker value="0">0°C</ef-slider-marker>
         <ef-slider-marker value="5">5°C</ef-slider-marker>
         <ef-slider-marker value="8">8°C</ef-slider-marker>

--- a/packages/elements/src/slider/__demo__/index.html
+++ b/packages/elements/src/slider/__demo__/index.html
@@ -178,6 +178,16 @@
       </ef-slider>
     </demo-block>
 
+    <demo-block layout="normal" header="Override aria-hidden">
+      <ef-slider step="20" custom-align>
+        <ef-slider-marker aria-hidden="false" value="0">Zero</ef-slider-marker>
+        <ef-slider-marker aria-hidden="false" value="25">Twenty-five</ef-slider-marker>
+        <ef-slider-marker aria-hidden="false" value="50">Fifty</ef-slider-marker>
+        <ef-slider-marker aria-hidden="false" value="75">Seventy-five</ef-slider-marker>
+        <ef-slider-marker aria-hidden="false" value="100">One hundred</ef-slider-marker>
+      </ef-slider>
+    </demo-block>
+
     <script>
       const demoBlock = document.querySelectorAll('demo-block');
       demoBlock.forEach(function (block) {

--- a/packages/elements/src/slider/__test__/__snapshots__/slider.test.snap.js
+++ b/packages/elements/src/slider/__test__/__snapshots__/slider.test.snap.js
@@ -100,6 +100,7 @@ snapshots["slider/Slider Snapshots DOM structure with markers is correct"] =
 
 snapshots["slider/Slider Snapshots LightDOM structure with markers is correct"] = 
 `<ef-slider-marker
+  aria-hidden="true"
   label-align="left"
   style="left: 0%;"
   value="0"
@@ -107,17 +108,20 @@ snapshots["slider/Slider Snapshots LightDOM structure with markers is correct"] 
   0
 </ef-slider-marker>
 <ef-slider-marker
+  aria-hidden="true"
   style="left: 10%;"
   value="10"
 >
   10
 </ef-slider-marker>
 <ef-slider-marker
+  aria-hidden="true"
   style="left: 50%;"
   value="50"
 >
 </ef-slider-marker>
 <ef-slider-marker
+  aria-hidden="true"
   label-align="right"
   style="left: 100%; transform: translateX(-100%);"
   value="100"

--- a/packages/elements/src/slider/__test__/__snapshots__/slider.test.snap.js
+++ b/packages/elements/src/slider/__test__/__snapshots__/slider.test.snap.js
@@ -51,6 +51,56 @@ snapshots["slider/Slider Snapshots DOM structure is correct"] =
 /* end snapshot slider/Slider Snapshots DOM structure is correct */
 
 snapshots["slider/Slider Snapshots DOM structure with markers is correct"] = 
+`<div part="slider-wrapper">
+  <div part="slider">
+    <div part="track-wrapper">
+      <div
+        part="step-container"
+        style="transform:translateX(-0.5%);"
+      >
+        <div
+          part="step"
+          style="transform:translateX(0.5%);background-size:1% 100%;"
+        >
+        </div>
+      </div>
+      <div
+        part="track-fill"
+        style="width:100%;"
+      >
+      </div>
+    </div>
+    <slot>
+    </slot>
+    <div
+      aria-label="Value"
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="100"
+      aria-valuetext="100 100"
+      name="value"
+      part="thumb-container"
+      role="slider"
+      style="left:100%;"
+      tabindex="1"
+    >
+      <div part="pin">
+        <span part="pin-value-marker">
+          100
+        </span>
+      </div>
+      <div
+        draggable="true"
+        part="thumb"
+      >
+      </div>
+    </div>
+  </div>
+</div>
+`;
+/* end snapshot slider/Slider Snapshots DOM structure with markers is correct */
+
+snapshots["slider/Slider Snapshots LightDOM structure with markers is correct"] = 
 `<ef-slider-marker
   label-align="left"
   style="left: 0%;"
@@ -77,5 +127,5 @@ snapshots["slider/Slider Snapshots DOM structure with markers is correct"] =
   100
 </ef-slider-marker>
 `;
-/* end snapshot slider/Slider Snapshots DOM structure with markers is correct */
+/* end snapshot slider/Slider Snapshots LightDOM structure with markers is correct */
 

--- a/packages/elements/src/slider/__test__/__snapshots__/slider.test.snap.js
+++ b/packages/elements/src/slider/__test__/__snapshots__/slider.test.snap.js
@@ -24,7 +24,6 @@ snapshots["slider/Slider Snapshots DOM structure is correct"] =
     <slot>
     </slot>
     <div
-      aria-label="Value"
       aria-valuemax="100"
       aria-valuemin="0"
       aria-valuenow="0"
@@ -73,7 +72,6 @@ snapshots["slider/Slider Snapshots DOM structure with markers is correct"] =
     <slot>
     </slot>
     <div
-      aria-label="Value"
       aria-valuemax="100"
       aria-valuemin="0"
       aria-valuenow="100"

--- a/packages/elements/src/slider/__test__/slider.test.js
+++ b/packages/elements/src/slider/__test__/slider.test.js
@@ -18,7 +18,17 @@ describe('slider/Slider', function () {
     });
     it('DOM structure with markers is correct', async function () {
       const el = await fixture(`
-      <ef-slider>
+      <ef-slider value="100">
+        <ef-slider-marker value="0">0</ef-slider-marker>
+        <ef-slider-marker value="10">10</ef-slider-marker>
+        <ef-slider-marker value="50"></ef-slider-marker>
+        <ef-slider-marker value="100">100</ef-slider-marker>
+      </ef-slider>`);
+      await expect(el).shadowDom.to.equalSnapshot();
+    });
+    it('LightDOM structure with markers is correct', async function () {
+      const el = await fixture(`
+      <ef-slider value="10">
         <ef-slider-marker value="0">0</ef-slider-marker>
         <ef-slider-marker value="10">10</ef-slider-marker>
         <ef-slider-marker value="50"></ef-slider-marker>

--- a/packages/elements/src/slider/__test__/slider.test.js
+++ b/packages/elements/src/slider/__test__/slider.test.js
@@ -28,7 +28,7 @@ describe('slider/Slider', function () {
     });
     it('LightDOM structure with markers is correct', async function () {
       const el = await fixture(`
-      <ef-slider value="10">
+      <ef-slider value="100">
         <ef-slider-marker value="0">0</ef-slider-marker>
         <ef-slider-marker value="10">10</ef-slider-marker>
         <ef-slider-marker value="50"></ef-slider-marker>
@@ -547,10 +547,10 @@ describe('slider/Slider', function () {
       expect(fromThumb.getAttribute('aria-valuetext')).to.equal('0 item 0');
       expect(toThumb.getAttribute('aria-valuetext')).to.equal(null);
       el.from = 50;
-      el.to = 100;
+      el.to = 60;
       await elementUpdated(el);
       expect(fromThumb.getAttribute('aria-valuetext')).to.equal(null);
-      expect(toThumb.getAttribute('aria-valuetext')).to.equal(null);
+      expect(toThumb.getAttribute('aria-valuetext')).to.equal('60 items 60');
     });
     // todo: can't mock mousemove event by user
     // it('should update the slider value when clicking on a marker label', async function () { });

--- a/packages/elements/src/slider/__test__/slider.test.js
+++ b/packages/elements/src/slider/__test__/slider.test.js
@@ -525,6 +525,7 @@ describe('slider/Slider', function () {
         <ef-slider-marker value="30">30 items</ef-slider-marker>
         <ef-slider-marker value="60">60 items</ef-slider-marker>
       </ef-slider>`);
+      await elementUpdated(el);
       const thumb = el.valueThumbRef.value;
       expect(thumb.getAttribute('aria-valuetext')).to.equal('0 item 0');
       el.value = 15;
@@ -540,6 +541,7 @@ describe('slider/Slider', function () {
         <ef-slider-marker value="60">60 items</ef-slider-marker>
         <ef-slider-marker value="100"></ef-slider-marker>
       </ef-slider>`);
+      await elementUpdated(el);
       const fromThumb = el.fromThumbRef.value;
       const toThumb = el.toThumbRef.value;
       expect(fromThumb.getAttribute('aria-valuetext')).to.equal('0 item 0');

--- a/packages/elements/src/slider/__test__/slider.test.js
+++ b/packages/elements/src/slider/__test__/slider.test.js
@@ -517,6 +517,39 @@ describe('slider/Slider', function () {
       expect(marker[1].labelAlign).to.equal(null);
       expect(marker[2].labelAlign).to.equal('right');
     });
+    it('Should update aria-valuetext of thumb correctly', async function () {
+      const el = await fixture(`
+      <ef-slider min="0" max="60">
+        <ef-slider-marker value="0">0 item</ef-slider-marker>
+        <ef-slider-marker value="15"></ef-slider-marker>
+        <ef-slider-marker value="30">30 items</ef-slider-marker>
+        <ef-slider-marker value="60">60 items</ef-slider-marker>
+      </ef-slider>`);
+      const thumb = el.valueThumbRef.value;
+      expect(thumb.getAttribute('aria-valuetext')).to.equal('0 item 0');
+      el.value = 15;
+      await elementUpdated(el);
+      expect(thumb.getAttribute('aria-valuetext')).to.equal(null);
+    });
+    it('Should update aria-valuetext of toThumb and fromThumb correctly', async function () {
+      const el = await fixture(`
+      <ef-slider min="0" max="100" range from="0" to="15">
+        <ef-slider-marker value="0">0 item</ef-slider-marker>
+        <ef-slider-marker value="15"></ef-slider-marker>
+        <ef-slider-marker value="30">30 items</ef-slider-marker>
+        <ef-slider-marker value="60">60 items</ef-slider-marker>
+        <ef-slider-marker value="100"></ef-slider-marker>
+      </ef-slider>`);
+      const fromThumb = el.fromThumbRef.value;
+      const toThumb = el.toThumbRef.value;
+      expect(fromThumb.getAttribute('aria-valuetext')).to.equal('0 item 0');
+      expect(toThumb.getAttribute('aria-valuetext')).to.equal(null);
+      el.from = 50;
+      el.to = 100;
+      await elementUpdated(el);
+      expect(fromThumb.getAttribute('aria-valuetext')).to.equal(null);
+      expect(toThumb.getAttribute('aria-valuetext')).to.equal(null);
+    });
     // todo: can't mock mousemove event by user
     // it('should update the slider value when clicking on a marker label', async function () { });
     // it('should set slider's value to the nearest possible valid value if marker's value is not valid', async function () { });

--- a/packages/elements/src/slider/elements/slider-marker.ts
+++ b/packages/elements/src/slider/elements/slider-marker.ts
@@ -31,6 +31,13 @@ export class SliderMarker extends BasicElement {
   }
 
   /**
+   * Hide the element from accessability API,
+   * as it could be detrimental to assistive technology
+   */
+  @property({ type: String, reflect: true, attribute: 'aria-hidden' })
+  public override ariaHidden = 'true';
+
+  /**
    * Used to determine the position of the marker on the scale.
    */
   @property({ type: String })

--- a/packages/elements/src/slider/elements/slider.ts
+++ b/packages/elements/src/slider/elements/slider.ts
@@ -595,9 +595,12 @@ export class Slider extends ControlElement {
     }
 
     const markerLabel = activeMarker.textContent;
+    const ariaValueText = markerLabel ? `${markerLabel} ${markerValue}` : null;
 
-    if (markerLabel) {
-      thumbRef.setAttribute('aria-valuetext', markerLabel + ` ${markerValue}`);
+    if (ariaValueText) {
+      thumbRef.setAttribute('aria-valuetext', ariaValueText);
+    } else {
+      thumbRef.removeAttribute('aria-valuetext');
     }
   }
 

--- a/packages/elements/src/slider/elements/slider.ts
+++ b/packages/elements/src/slider/elements/slider.ts
@@ -593,19 +593,19 @@ export class Slider extends FormFieldElement {
   /**
    * Update the ARIA value text for a given thumb.
    *
-   * @param thumbRef - The reference to the thumb element.
+   * @param thumbElement - The thumb element.
    * @param markerValue - The value associated with the marker.
    * @returns {void}
    */
-  private updateAriaValueText(thumbRef: HTMLDivElement | undefined, markerValue: string): void {
-    if (!thumbRef) {
+  private updateAriaValueText(thumbElement: HTMLDivElement | undefined, markerValue: string): void {
+    if (!thumbElement) {
       return;
     }
 
     const activeMarker = this.getActiveMarker(markerValue);
 
     if (!activeMarker) {
-      thumbRef.removeAttribute('aria-valuetext');
+      thumbElement.removeAttribute('aria-valuetext');
       return;
     }
 
@@ -613,9 +613,9 @@ export class Slider extends FormFieldElement {
     const ariaValueText = markerLabel ? `${markerLabel} ${markerValue}` : null;
 
     if (ariaValueText) {
-      thumbRef.setAttribute('aria-valuetext', ariaValueText);
+      thumbElement.setAttribute('aria-valuetext', ariaValueText);
     } else {
-      thumbRef.removeAttribute('aria-valuetext');
+      thumbElement.removeAttribute('aria-valuetext');
     }
   }
 

--- a/packages/elements/src/slider/elements/slider.ts
+++ b/packages/elements/src/slider/elements/slider.ts
@@ -439,6 +439,20 @@ export class Slider extends ControlElement {
   }
 
   /**
+   * Gets the active marker based on the provided marker value.
+   * @param value - The marker value.
+   * @returns The active marker element.
+   */
+  private getActiveMarker(value: string): SliderMarker | null {
+    for (const child of this.children) {
+      if (child instanceof SliderMarker && child.value === value) {
+        return child;
+      }
+    }
+    return null;
+  }
+
+  /**
    * Finds the closest ancestor ef-slider-marker in the DOM tree.
    * @param startingElement The HTML element to start searching from.
    * @returns The found marker, or null if not found.
@@ -558,6 +572,32 @@ export class Slider extends ControlElement {
     if (changedProperties.has('range')) {
       this.prepareValues();
       this.prepareThumbs();
+    }
+  }
+
+  /**
+   * Update the ARIA value text for a given thumb.
+   *
+   * @param thumbRef - The reference to the thumb element.
+   * @param markerValue - The value associated with the marker.
+   * @returns {void}
+   */
+  private updateAriaValueText(thumbRef: HTMLDivElement | undefined, markerValue: string): void {
+    if (!thumbRef) {
+      return;
+    }
+
+    const activeMarker = this.getActiveMarker(markerValue);
+
+    if (!activeMarker) {
+      thumbRef.removeAttribute('aria-valuetext');
+      return;
+    }
+
+    const markerLabel = activeMarker.textContent;
+
+    if (markerLabel) {
+      thumbRef.setAttribute('aria-valuetext', markerLabel + ` ${markerValue}`);
     }
   }
 
@@ -1192,9 +1232,11 @@ export class Slider extends ControlElement {
     }
 
     if (!this.dragging) {
-      // Update internal `valuePrevious` when `value` was programatically set by user.
+      // Update internal `valuePrevious` when `value` was programmatically set by user.
       this.valuePrevious = this.value;
     }
+
+    this.updateAriaValueText(this.valueThumbRef.value, this.value);
   }
 
   /**
@@ -1223,6 +1265,8 @@ export class Slider extends ControlElement {
     if (!this.dragging) {
       this.fromPrevious = this.from;
     }
+
+    this.updateAriaValueText(this.fromThumbRef.value, this.from);
   }
 
   /**
@@ -1274,6 +1318,8 @@ export class Slider extends ControlElement {
     if (!this.dragging) {
       this.toPrevious = this.to;
     }
+
+    this.updateAriaValueText(this.toThumbRef.value, this.to);
   }
 
   /**

--- a/packages/elements/src/slider/elements/slider.ts
+++ b/packages/elements/src/slider/elements/slider.ts
@@ -141,7 +141,7 @@ export class Slider extends FormFieldElement {
   private fromPreviousInput = ''; // dynamically accessed
   private toPreviousInput = ''; // dynamically accessed
 
-  /** Aria label for the 'to' and 'from' slider, resolved based on locale. */
+  /** Aria label for 'to' and 'from' value thumb, resolved based on locale. */
   private toAriaLabel = 'to';
   private fromAriaLabel = 'from';
 
@@ -433,8 +433,10 @@ export class Slider extends FormFieldElement {
    * @returns promise
    */
   protected override async performUpdate(): Promise<void> {
-    this.toAriaLabel = await this.labelTPromise(SliderDataName.to.toUpperCase());
-    this.fromAriaLabel = await this.labelTPromise(SliderDataName.from.toUpperCase());
+    [this.toAriaLabel, this.fromAriaLabel] = await Promise.all([
+      this.labelTPromise(SliderDataName.to.toUpperCase()),
+      this.labelTPromise(SliderDataName.from.toUpperCase())
+    ]);
     void super.performUpdate();
   }
 

--- a/packages/elements/src/slider/elements/slider.ts
+++ b/packages/elements/src/slider/elements/slider.ts
@@ -525,6 +525,7 @@ export class Slider extends FormFieldElement {
   }
 
   /**
+   * @ignore
    * On willUpdate lifecycle
    * @param changedProperties changed properties
    * @returns {void}

--- a/packages/elements/src/slider/elements/slider.ts
+++ b/packages/elements/src/slider/elements/slider.ts
@@ -142,8 +142,8 @@ export class Slider extends FormFieldElement {
   private toPreviousInput = ''; // dynamically accessed
 
   /** Aria label for the 'to' and 'from' slider, resolved based on locale. */
-  private toAriaLabel = 'to';
-  private fromAriaLabel = 'from';
+  private toAriaLabel: string = SliderDataName.to;
+  private fromAriaLabel: string = SliderDataName.from;
 
   /**
    * Specified size of increment or decrement jump between value.
@@ -593,23 +593,18 @@ export class Slider extends FormFieldElement {
   /**
    * Update the ARIA value text for a given thumb.
    *
-   * @param thumbElement - The thumb element.
+   * @param thumbRef - The reference to the thumb element.
    * @param markerValue - The value associated with the marker.
    * @returns {void}
    */
-  private updateAriaValueText(thumbElement: HTMLDivElement | undefined, markerValue: string): void {
+  private updateAriaValueText(thumbRef: Ref<HTMLDivElement>, markerValue: string): void {
+    const thumbElement = thumbRef.value;
     if (!thumbElement) {
       return;
     }
 
     const activeMarker = this.getActiveMarker(markerValue);
-
-    if (!activeMarker) {
-      thumbElement.removeAttribute('aria-valuetext');
-      return;
-    }
-
-    const markerLabel = activeMarker.textContent;
+    const markerLabel = activeMarker?.textContent;
     const ariaValueText = markerLabel ? `${markerLabel} ${markerValue}` : null;
 
     if (ariaValueText) {
@@ -1254,7 +1249,7 @@ export class Slider extends FormFieldElement {
       this.valuePrevious = this.value;
     }
 
-    this.updateAriaValueText(this.valueThumbRef.value, this.value);
+    this.updateAriaValueText(this.valueThumbRef, this.value);
   }
 
   /**
@@ -1284,7 +1279,7 @@ export class Slider extends FormFieldElement {
       this.fromPrevious = this.from;
     }
 
-    this.updateAriaValueText(this.fromThumbRef.value, this.from);
+    this.updateAriaValueText(this.fromThumbRef, this.from);
   }
 
   /**
@@ -1337,7 +1332,7 @@ export class Slider extends FormFieldElement {
       this.toPrevious = this.to;
     }
 
-    this.updateAriaValueText(this.toThumbRef.value, this.to);
+    this.updateAriaValueText(this.toThumbRef, this.to);
   }
 
   /**


### PR DESCRIPTION
## Description
To use `aria-valuetext` instead of `aria-valuenow` to provide more user-friendly to users.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
