### PR TITLE
fix(combo-box): cannot set value in free text when data is empty

### DIFF
--- a/packages/elements/src/combo-box/__test__/combo-box.value.test.js
+++ b/packages/elements/src/combo-box/__test__/combo-box.value.test.js
@@ -132,7 +132,7 @@ describe('combo-box/Value', function () {
       el.value = '';
       expect(el.value).to.equal('', 'Value must be empty string when reset value on free text mode');
     });
-    it('Cannot set any value without free text mode when data is empty', async function () {
+    it('Should not update value when data is empty', async function () {
       const el = await fixture('<ef-combo-box lang="en"></ef-combo-box>');
       el.value = 'AL';
 

--- a/packages/elements/src/combo-box/__test__/combo-box.value.test.js
+++ b/packages/elements/src/combo-box/__test__/combo-box.value.test.js
@@ -139,7 +139,7 @@ describe('combo-box/Value', function () {
       await elementUpdated(el);
       expect(el.value).to.equal('');
     });
-    it('Set any value with free text mode when data is empty', async function () {
+    it('Should update value in free text mode when data is empty', async function () {
       const el = await fixture('<ef-combo-box free-text lang="en"></ef-combo-box>');
       el.value = 'AL';
 

--- a/packages/elements/src/combo-box/__test__/combo-box.value.test.js
+++ b/packages/elements/src/combo-box/__test__/combo-box.value.test.js
@@ -132,5 +132,19 @@ describe('combo-box/Value', function () {
       el.value = '';
       expect(el.value).to.equal('', 'Value must be empty string when reset value on free text mode');
     });
+    it('Cannot set any value without free text mode when data is empty', async function () {
+      const el = await fixture('<ef-combo-box lang="en"></ef-combo-box>');
+      el.value = 'AL';
+
+      await elementUpdated(el);
+      expect(el.value).to.equal('');
+    });
+    it('Set any value with free text mode when data is empty', async function () {
+      const el = await fixture('<ef-combo-box free-text lang="en"></ef-combo-box>');
+      el.value = 'AL';
+
+      await elementUpdated(el);
+      expect(el.value).to.equal('AL');
+    });
   });
 });

--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -254,6 +254,10 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
     if (this.composer.size) {
       this.values = [value];
     } else {
+      if (this.freeText && this.freeTextValue !== value) {
+        this.freeTextValue = value;
+        this.requestUpdate();
+      }
       this.cachedValue = value;
     }
   }


### PR DESCRIPTION
## Description

In free text mode, a developer cannot set any value to the combo-box when data is empty. Therefore, I propose the solution that when a developer sets a value, it will save the value as the free text value.

Fixes # (issue)
ELF-2349

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
