### PR TITLE
fix(combo-box): cannot set value in free text when data is empty 

### DIFF
--- a/packages/elements/src/combo-box/__test__/combo-box.value.test.js
+++ b/packages/elements/src/combo-box/__test__/combo-box.value.test.js
@@ -137,5 +137,19 @@ describe('combo-box/Value', function () {
       el.value = '';
       expect(el.value).to.equal('', 'Value must be empty string when reset value on free text mode');
     });
+    it('Cannot set any value without free text mode when data is empty', async function () {
+      const el = await fixture('<ef-combo-box lang="en"></ef-combo-box>');
+      el.value = 'AL';
+
+      await elementUpdated(el);
+      expect(el.value).to.equal('');
+    });
+    it('Set any value with free text mode when data is empty', async function () {
+      const el = await fixture('<ef-combo-box free-text lang="en"></ef-combo-box>');
+      el.value = 'AL';
+
+      await elementUpdated(el);
+      expect(el.value).to.equal('AL');
+    });
   });
 });

--- a/packages/elements/src/combo-box/__test__/combo-box.value.test.js
+++ b/packages/elements/src/combo-box/__test__/combo-box.value.test.js
@@ -137,7 +137,7 @@ describe('combo-box/Value', function () {
       el.value = '';
       expect(el.value).to.equal('', 'Value must be empty string when reset value on free text mode');
     });
-    it('Cannot set any value without free text mode when data is empty', async function () {
+    it('Should not update value when data is empty', async function () {
       const el = await fixture('<ef-combo-box lang="en"></ef-combo-box>');
       el.value = 'AL';
 

--- a/packages/elements/src/combo-box/__test__/combo-box.value.test.js
+++ b/packages/elements/src/combo-box/__test__/combo-box.value.test.js
@@ -144,7 +144,7 @@ describe('combo-box/Value', function () {
       await elementUpdated(el);
       expect(el.value).to.equal('');
     });
-    it('Set any value with free text mode when data is empty', async function () {
+    it('Should update value in free text mode when data is empty', async function () {
       const el = await fixture('<ef-combo-box free-text lang="en"></ef-combo-box>');
       el.value = 'AL';
 

--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -254,6 +254,10 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
     if (this.composer.size) {
       this.values = [value];
     } else {
+      if (this.freeText && this.freeTextValue !== value) {
+        this.freeTextValue = value;
+        this.requestUpdate();
+      }
       this.cachedValue = value;
     }
   }


### PR DESCRIPTION
## Description
As datetime-picker attaches calendar inside, we also need to cascade the custom cell slot on from datetime-picker to calendar.


Fixes # (issue)
ELF-2267

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
