### PR TITLE
fix(create-efx): add extension to bin file for support type module

### DIFF
--- a/packages/create-efx/bin/create-efx
+++ b/packages/create-efx/bin/create-efx
@@ -1,3 +1,0 @@
-#! /usr/bin/env node
-
-require('../lib/index.js');

--- a/packages/create-efx/bin/create-efx.js
+++ b/packages/create-efx/bin/create-efx.js
@@ -1,0 +1,2 @@
+#! /usr/bin/env node
+import '../lib/index.js';

--- a/packages/create-efx/package.json
+++ b/packages/create-efx/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "type": "module",
   "bin": {
-    "create-efx": "./bin/create-efx"
+    "create-efx": "./bin/create-efx.js"
   },
   "files": [
     "bin",
@@ -26,6 +26,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
+    "test-init": "node ./bin/create-efx.js efx-test && rm -rf efx-test",
     "clean": "nx exec -- rm -rf lib tsconfig.tsbuildinfo",
     "prepublishOnly": "npm run build"
   },

--- a/packages/create-efx/template/package.json.template
+++ b/packages/create-efx/template/package.json.template
@@ -40,7 +40,7 @@
     "@web/test-runner-playwright": "^0.10.1",
     "fast-glob": "^3.2.12",
     "typescript": "^4.8.3",
-    "vite": "^5.0.8",
+    "vite": "^5.0.8"
   },
   "peerDependencies": {
     "@refinitiv-ui/core": "^7.0.0",

--- a/packages/create-efx/template/package.json.template
+++ b/packages/create-efx/template/package.json.template
@@ -10,7 +10,7 @@
   "author": "LSEG",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.0.0",
     "npm": ">=8.0.0"
   },
   "scripts": {


### PR DESCRIPTION
## Description
`npx create-efx@latest efx-element` failed in node v16-v20. 

In node v16 and v18, it throws ERR_UNKNOWN_FILE_EXTENSION.

In node 20, it throws error on `require`.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
