### PR TITLE
fix(autosuggest): incorrect mark style

### DIFF
--- a/packages/elemental-theme/src/custom-elements/ef-autosuggest.less
+++ b/packages/elemental-theme/src/custom-elements/ef-autosuggest.less
@@ -4,7 +4,6 @@
 @import '../shared-styles/scrollbar';
 @import '../responsive';
 @import '../native-elements/kbd';
-@import '../native-elements/mark';
 
 :host {
   min-height: 0;

--- a/packages/elemental-theme/src/custom-elements/ef-item.less
+++ b/packages/elemental-theme/src/custom-elements/ef-item.less
@@ -1,6 +1,7 @@
 @import 'element:ef-icon';
 @import 'element:ef-checkbox';
 @import '../responsive';
+@import (reference) '../native-elements/mark';
 
 :host {
   line-height: normal;
@@ -94,5 +95,9 @@
 
   [part='sub-label'] {
     font-size: 80%;
+  }
+
+  ::slotted(mark) {
+    .default-mark();
   }
 }

--- a/packages/elemental-theme/src/native-elements/mark.less
+++ b/packages/elemental-theme/src/native-elements/mark.less
@@ -1,4 +1,8 @@
-mark {
+.default-mark() {
   color: @global-text-mark-color;
   background-color: @global-text-mark-background;
+}
+
+mark {
+  .default-mark();
 }

--- a/packages/elements/src/autosuggest/__demo__/index.html
+++ b/packages/elements/src/autosuggest/__demo__/index.html
@@ -656,7 +656,7 @@
       </p>
       <div id="search-suggestion"></div>
       <script>
-        const wrapper = document.getElementById('search-suggestion');
+        const hostElement = document.getElementById('search-suggestion').attachShadow({ mode: 'open' });
         const searchField = document.createElement('ef-search-field');
         const autoSuggest = document.createElement('ef-autosuggest');
         autoSuggest.attach = searchField;
@@ -666,8 +666,8 @@
             autoSuggest.suggestions = data;
           });
         });
-        wrapper.appendChild(searchField);
-        wrapper.appendChild(autoSuggest);
+        hostElement.appendChild(searchField);
+        hostElement.appendChild(autoSuggest);
       </script>
     </demo-block>
   </body>

--- a/packages/elements/src/autosuggest/__demo__/index.html
+++ b/packages/elements/src/autosuggest/__demo__/index.html
@@ -37,7 +37,7 @@
     </script>
 
     <script type="module">
-      import { escapeRegExp } from './../../../lib/autosuggest/helpers/utils';
+      import { escapeRegExp } from '@refinitiv-ui/elements/autosuggest';
 
       (function () {
         const data = JSON.parse(
@@ -317,7 +317,7 @@
           }
         </style>
         <script type="module">
-          import { queryWordSelect } from './../../../lib/autosuggest/helpers/utils';
+          import { queryWordSelect } from '@refinitiv-ui/elements/autosuggest';
 
           (function () {
             const autoSuggest = document.getElementById('custom-render-a');
@@ -484,7 +484,7 @@
       </div>
       <ef-autosuggest id="compound-input-a" attach="#compound-input"></ef-autosuggest>
       <script type="module">
-        import { renderer } from './../../../lib/autosuggest';
+        import { renderer } from '@refinitiv-ui/elements/autosuggest';
 
         (function () {
           const group = document.getElementById('compound-input-group');
@@ -616,7 +616,7 @@
       <ef-autosuggest id="html-renderer-a" attach="#html-renderer" html-renderer></ef-autosuggest>
 
       <script type="module">
-        import { queryWordSelect } from './../../../lib/autosuggest/helpers/utils';
+        import { queryWordSelect } from '@refinitiv-ui/elements/autosuggest';
 
         (function () {
           const autoSuggest = document.getElementById('html-renderer-a');
@@ -650,14 +650,18 @@
     </demo-block>
 
     <demo-block layout="normal" header="Inside Shadow DOM" tags="Shadow DOM">
+      <p>
+        The example below simulates a scenario when a user creates a new component by integrating auto suggest
+        with a search field and wrap it in the shadow DOM.
+      </p>
       <div id="search-suggestion"></div>
       <script>
         const wrapper = document.getElementById('search-suggestion');
-        let searchField = document.createElement('ef-search-field');
-        let autoSuggest = document.createElement('ef-autosuggest');
+        const searchField = document.createElement('ef-search-field');
+        const autoSuggest = document.createElement('ef-autosuggest');
         autoSuggest.attach = searchField;
         autoSuggest.addEventListener('suggestions-fetch-requested', (event) => {
-          let query = event.detail.query;
+          const query = event.detail.query;
           window.filterData(query).then(({ data }) => {
             autoSuggest.suggestions = data;
           });

--- a/packages/elements/src/autosuggest/__demo__/index.html
+++ b/packages/elements/src/autosuggest/__demo__/index.html
@@ -28,7 +28,7 @@
       import '@refinitiv-ui/elements/header';
       import '@refinitiv-ui/elements/item';
       import '@refinitiv-ui/elements/multi-input';
-      // import '@refinitiv-ui/elements/emerald-grid';
+      import '@refinitiv-ui/elements/search-field';
       import '@refinitiv-ui/elements/select';
       import '@refinitiv-ui/elements/text-field';
       import '@refinitiv-ui/elements/tooltip';
@@ -649,66 +649,21 @@
       </script>
     </demo-block>
 
-    <demo-block layout="normal" header="Inside Shadow DOM" tags="Shadow DOM,Grid">
-      <emerald-grid id="grid" style="height: 200px"></emerald-grid>
+    <demo-block layout="normal" header="Inside Shadow DOM" tags="Shadow DOM">
+      <div id="search-suggestion"></div>
       <script>
-        (function () {
-          const grid = document.getElementById('grid');
-          grid.config = {
-            rowHighlight: true,
-            rowSelection: true,
-            columns: [
-              {
-                id: 'suggest',
-                title: 'Suggest',
-                field: 'suggest',
-                formatter: {
-                  render: function () {},
-                  bind: function (rowIndex, columnIndex, value, cell, columnDef, dataRow, dataTable) {
-                    let wrapper = cell.getContent();
-                    if (!wrapper) {
-                      wrapper = document.createElement('div');
-                      const input = document.createElement('ef-text-field');
-                      input.style.height = '32px';
-                      input.style.margin = '0';
-                      input.placeholder = 'Start typing...';
-                      wrapper.appendChild(input);
-
-                      const autoSuggest = document.createElement('ef-autosuggest');
-                      autoSuggest.attach = input;
-                      autoSuggest.addEventListener(
-                        'suggestions-fetch-requested',
-                        ({ target, detail: { query } }) => {
-                          window.filterData(query, { minLength: 0 }).then(({ data }) => {
-                            target.suggestions = data;
-                          });
-                        }
-                      );
-                      wrapper.appendChild(autoSuggest);
-
-                      wrapper.input = input;
-                      wrapper.autoSuggest = autoSuggest;
-                    }
-                    cell.setContent(wrapper);
-                    wrapper.input.value = value;
-                  }
-                }
-              }
-            ],
-            dataModel: {
-              fields: ['suggest'],
-              format: 'rows',
-              data: [
-                {
-                  suggest: ''
-                },
-                {
-                  suggest: 'Cornelius Martin'
-                }
-              ]
-            }
-          };
-        })();
+        const wrapper = document.getElementById('search-suggestion');
+        let searchField = document.createElement('ef-search-field');
+        let autoSuggest = document.createElement('ef-autosuggest');
+        autoSuggest.attach = searchField;
+        autoSuggest.addEventListener('suggestions-fetch-requested', (event) => {
+          let query = event.detail.query;
+          window.filterData(query).then(({ data }) => {
+            autoSuggest.suggestions = data;
+          });
+        });
+        wrapper.appendChild(searchField);
+        wrapper.appendChild(autoSuggest);
       </script>
     </demo-block>
   </body>

--- a/packages/halo-theme/src/custom-elements/ef-autosuggest.less
+++ b/packages/halo-theme/src/custom-elements/ef-autosuggest.less
@@ -1,6 +1,5 @@
 @import '@refinitiv-ui/elemental-theme/src/custom-elements/ef-autosuggest';
 @import '../native-elements/kbd';
-@import '../native-elements/mark';
 @import '../shared-styles/scrollbar';
 
 :host {


### PR DESCRIPTION
## Description

`mark` color on suggestion list is not correct when attach the `ef-autosuggest` inside the shadow DOM. The root cause of this issue is that the `mark` element is not within the scope of the `ef-autosuggest` theme. It is slotted inside the `ef-item`. Therefore, moving the `mark` style to the scope of `ef-item` will fix the issue.

Fixes # (issue)
ELF-2366

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
