### PR TITLE
refactor: add event listeners to all shadow roots

### DIFF
--- a/packages/core/src/registries/FocusRegistry.ts
+++ b/packages/core/src/registries/FocusRegistry.ts
@@ -228,6 +228,21 @@ const onShadowRootBlur = function (this: ShadowRoot): void {
   }
 };
 
+/**
+ * add focus & blur event listeners to shadow roots
+ * @param element an element which event listeners should be added to its shadow roots
+ * @return {void}
+ */
+const addShadowRootEventListeners = (element: Element): void => {
+  const RootNode = element.getRootNode();
+  if (RootNode instanceof ShadowRoot) {
+    // No need to worry about duplicate listeners as same callback with the same scope is skipped
+    RootNode.addEventListener('focus', onShadowRootFocus, true);
+    RootNode.addEventListener('blur', onShadowRootBlur, true);
+    addShadowRootEventListeners(RootNode.host);
+  }
+};
+
 abstract class FocusRegistry {
   /**
    * Connect an element to focus global listener
@@ -243,11 +258,7 @@ abstract class FocusRegistry {
       window.addEventListener('blur', onWindowBlur);
     }
 
-    if (element.renderRoot instanceof ShadowRoot) {
-      /* No need to remove listeners as same callback with the same scope is skipped */
-      element.renderRoot.addEventListener('focus', onShadowRootFocus, true);
-      element.renderRoot.addEventListener('blur', onShadowRootBlur, true);
-    }
+    addShadowRootEventListeners(element);
 
     register.add(element);
     autoFocus(element);


### PR DESCRIPTION
## Description

add event listener to all shadow roots rather than limiting to EF element's shadow roots only.

Fixes # (https://jira.refinitiv.com/browse/ELF-2324)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
