### PR TITLE
docs(tree-select): fix typo on CSS Variables section

### DIFF
--- a/documents/src/pages/elements/tree-select.md
+++ b/documents/src/pages/elements/tree-select.md
@@ -482,7 +482,7 @@ This control will abort any current selection changes and go back to the tree st
 The theme manages the size of popup panel, but can be overridden by using CSS variables.
 
 ```css
-ef-select {
+ef-tree-select {
   --list-max-width: 70px;
   --list-max-height: 120px;
 }


### PR DESCRIPTION
## Description

Found typo on tree-select page. It used ef-select instead of ef-tree-select at https://ui.refinitiv.com/elements/tree-select#css-variables.