### PR TITLE
refactor(combo-box): move placeholder property to document comment

### DIFF
--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -66,6 +66,9 @@ const freeTextMultipleWarning = new WarningNotice('"free-text" mode is not compa
  * @attr {boolean} disabled - Set disabled state
  * @prop {boolean} [disabled=false] - Set disabled state
  *
+ * @attr {string} placeholder - Set placeholder text
+ * @prop {string} [placeholder=""] - Set placeholder text
+ *
  * @fires value-changed - Fired when the user commits a value change. The event is not triggered if `value` property is changed programmatically.
  * @fires query-changed - Fired when the user changes value in the input to change a query word. If `query-debounce-rate` is set, this event will be triggered after debounce completion. The event is not triggered if `query` property is changed programmatically.
  * @fires opened-changed - Fired when the user opens or closes control's popup. The event is not triggered if `opened` property is changed programmatically.

--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -151,12 +151,6 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
   public opened = false;
 
   /**
-   * Placeholder for input field
-   */
-  @property({ type: String })
-  public override placeholder = '';
-
-  /**
    * Show clears button
    */
   @property({ type: Boolean })


### PR DESCRIPTION
## Description

Found that ComboBox placeholder property didn't align with other FormFieldElement. The property declared inside the class but other components, ex select, described at JSDoc document comment.

### AC
- placeholder should display on document at property API reference section.
- placeholder should work by the same.