### PR TITLE
chore: update vite to prevent server.fs.deny bypass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "nx": "^16.9.1",
         "sinon": "^15.1.0",
         "typescript": "^4.8.3",
-        "vite": "^5.0.11",
+        "vite": "^5.0.12",
         "web-component-analyzer": "2.0.0",
         "yargs": "^17.7.2"
       },
@@ -20994,9 +20994,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-      "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "nx": "^16.9.1",
     "sinon": "^15.1.0",
     "typescript": "^4.8.3",
-    "vite": "^5.0.11",
+    "vite": "^5.0.12",
     "web-component-analyzer": "2.0.0",
     "yargs": "^17.7.2"
   }


### PR DESCRIPTION
## Description

[Vite dev server option `server.fs.deny` can be bypassed when hosted on case-insensitive filesystem](https://github.com/Refinitiv/refinitiv-ui/security/dependabot/116)
