### PR TITLE
fix: missing scrollbar custom style on Chrome 121

### DIFF
--- a/packages/elemental-theme/src/custom-elements/ef-autosuggest.less
+++ b/packages/elemental-theme/src/custom-elements/ef-autosuggest.less
@@ -22,7 +22,7 @@
     overflow: auto;
     .touch-action();
     .ie-scrollbars();
-    .mozilla-scrollbars();
+    .standard-scrollbars();
   }
 
   [part='more-results'] {

--- a/packages/elemental-theme/src/custom-elements/ef-card.less
+++ b/packages/elemental-theme/src/custom-elements/ef-card.less
@@ -57,6 +57,6 @@
   }
 
   .ie-scrollbars();
-  .mozilla-scrollbars();
+  .standard-scrollbars();
 }
 .webkit-scrollbars();

--- a/packages/elemental-theme/src/custom-elements/ef-combo-box.less
+++ b/packages/elemental-theme/src/custom-elements/ef-combo-box.less
@@ -56,7 +56,7 @@
   }
 
   .ie-scrollbars();
-  .mozilla-scrollbars();
+  .standard-scrollbars();
 }
 
 .webkit-scrollbars();

--- a/packages/elemental-theme/src/custom-elements/ef-dialog.less
+++ b/packages/elemental-theme/src/custom-elements/ef-dialog.less
@@ -29,6 +29,7 @@
       opacity: 0.6;
     }
   }
+
   [part='default-button'] {
     .touch-action();
     margin: @panel-padding;
@@ -37,12 +38,14 @@
       margin-right: 0;
     }
   }
+
   [part='footer'] {
     border-top: @separator-width solid @separator-color;
     background: @scrollbar-track-background-color;
   }
+
   .ie-scrollbars();
-  .mozilla-scrollbars();
+  .standard-scrollbars();
 }
 
 .webkit-scrollbars();

--- a/packages/elemental-theme/src/custom-elements/ef-multi-input.less
+++ b/packages/elemental-theme/src/custom-elements/ef-multi-input.less
@@ -8,6 +8,7 @@
 
   .input-defaults;
   .input-standard(true);
+
   &[focused] {
     .input-focus;
   }
@@ -27,8 +28,9 @@
   [part='search-holder'] {
     align-items: center;
   }
+
   .ie-scrollbars();
-  .mozilla-scrollbars();
+  .standard-scrollbars();
 }
 
 .webkit-scrollbars();

--- a/packages/elemental-theme/src/custom-elements/ef-overlay-menu.less
+++ b/packages/elemental-theme/src/custom-elements/ef-overlay-menu.less
@@ -20,7 +20,7 @@
   }
 
   .ie-scrollbars();
-  .mozilla-scrollbars();
+  .standard-scrollbars();
 }
 
 .webkit-scrollbars();

--- a/packages/elemental-theme/src/custom-elements/ef-overlay.less
+++ b/packages/elemental-theme/src/custom-elements/ef-overlay.less
@@ -12,7 +12,7 @@
   }
 
   .ie-scrollbars();
-  .mozilla-scrollbars();
+  .standard-scrollbars();
 }
 
 .webkit-scrollbars();

--- a/packages/elemental-theme/src/custom-elements/ef-select.less
+++ b/packages/elemental-theme/src/custom-elements/ef-select.less
@@ -10,21 +10,27 @@
 :host {
   // #region - Extend from ef-text-field
   &:extend(:host);
+
   &:not([readonly]):hover {
     &:extend(:host:hover);
   }
+
   &:not([readonly]):active {
     &:extend(:host:active);
   }
+
   &:not([readonly])[focused] {
     &:extend(:host[focused]);
   }
+
   &[warning] {
     &:extend(:host[warning] all);
   }
+
   &[error] {
     &:extend(:host[error] all);
   }
+
   &[disabled] {
     &:extend(:host[disabled]);
   }
@@ -33,24 +39,30 @@
   &[readonly] {
     cursor: default;
   }
+
   [part='placeholder'] {
     opacity: 0.5;
   }
+
   [part='label'],
   [part='placeholder'] {
     margin-right: 3px;
   }
+
   [part~='icon'] {
     color: @input-text-color;
     opacity: 0.7;
   }
+
   &:not([readonly]):hover [part~='icon'],
   &:not([readonly])[focused] [part~='icon'] {
     opacity: 1;
   }
+
   &:not([readonly])[focused] [part~='icon'] {
     color: @scheme-color-primary;
   }
+
   &[disabled] [part~='icon'] {
     color: @input-disabled-border-color;
   }
@@ -61,7 +73,7 @@
   }
 
   .ie-scrollbars();
-  .mozilla-scrollbars();
+  .standard-scrollbars();
 }
 
 .webkit-scrollbars();

--- a/packages/elemental-theme/src/custom-elements/ef-sidebar-layout.less
+++ b/packages/elemental-theme/src/custom-elements/ef-sidebar-layout.less
@@ -4,13 +4,14 @@
 :host {
   --sidebar-width: 250px;
   .ie-scrollbars();
-  .mozilla-scrollbars();
+  .standard-scrollbars();
 
   &:not([sidebar-position]) [part='sidebar'],
   &[sidebar-position='left'] [part='sidebar'] {
     border-right: @separator-width solid @separator-color;
     transition: margin-left @global-transition-duration ease;
   }
+
   &[sidebar-position='right'] [part='sidebar'] {
     order: 1;
     border-left: @separator-width solid @separator-color;

--- a/packages/elemental-theme/src/native-elements/html.less
+++ b/packages/elemental-theme/src/native-elements/html.less
@@ -5,7 +5,7 @@ html {
   touch-action: manipulation; // Improve tap speed on mobile browsers
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   .ie-scrollbars();
-  .mozilla-scrollbars();
+  .standard-scrollbars();
   @css-properties();
 }
 

--- a/packages/elemental-theme/src/shared-styles/list.less
+++ b/packages/elemental-theme/src/shared-styles/list.less
@@ -9,7 +9,7 @@
 
   .touch-action();
   .ie-scrollbars();
-  .mozilla-scrollbars();
+  .standard-scrollbars();
 
   &:focus {
     outline: none;

--- a/packages/elemental-theme/src/shared-styles/scrollbar.less
+++ b/packages/elemental-theme/src/shared-styles/scrollbar.less
@@ -1,10 +1,14 @@
-// TODO: `scrollbar-width` and `scrollbar-color` are now standardized in Chrome 121, not limited to Firefox. This mixin should be refactored in the next major release.
-.mozilla-scrollbars() {
+.standard-scrollbars() {
   @supports not selector(::-webkit-scrollbar) {
     & {
       scrollbar-color: @scrollbar-thumb-background-color @scrollbar-track-background-color;
     }
   }
+}
+
+// `.mozilla-scrollbars()` is deprecated. Use `standard-scrollbars` instead.
+.mozilla-scrollbars() {
+  .standard-scrollbars();
 }
 
 // Helper Mixins. Shared between IE & Webkit.
@@ -210,6 +214,19 @@
   }
 }
 
+/*
+`.scrollbars()` is deprecated. Use `.standard-scrollbars()` and `.webkit-scrollbars()` instead.
+While `.standard-scrollbars()` utilizes standard CSS properties,
+it still requires a selector to apply those styles.
+However, `.webkit-scrollbars()` is a CSS pseudo-element that acts as a selector itself,
+eliminating the need to push the mixin into host.
+
+::host {
+  .standard-scrollbars();
+}
+.webkit-scrollbars();
+
+ */
 .scrollbars() {
   .webkit-scrollbars();
   .ie-scrollbars();

--- a/packages/elemental-theme/src/shared-styles/scrollbar.less
+++ b/packages/elemental-theme/src/shared-styles/scrollbar.less
@@ -1,3 +1,12 @@
+// TODO: `scrollbar-width` and `scrollbar-color` are now standardized in Chrome 121, not limited to Firefox. This mixin should be refactored in the next major release.
+.mozilla-scrollbars() {
+  @supports not selector(::-webkit-scrollbar) {
+    & {
+      scrollbar-color: @scrollbar-thumb-background-color @scrollbar-track-background-color;
+    }
+  }
+}
+
 // Helper Mixins. Shared between IE & Webkit.
 .scrollbar-corner-background(@property: background) {
   @{property}: @scrollbar-corner-background-color;
@@ -198,12 +207,6 @@
     .scrollbar-track-background(scrollbar-track-color);
     .scrollbar-corner-background(scrollbar-3dlight-color);
     .scrollbar-corner-background(scrollbar-darkshadow-color);
-  }
-}
-
-.mozilla-scrollbars () {
-  & {
-    scrollbar-color: @scrollbar-thumb-background-color @scrollbar-track-background-color;
   }
 }
 

--- a/packages/elemental-theme/src/shared-styles/scrollbar.less
+++ b/packages/elemental-theme/src/shared-styles/scrollbar.less
@@ -208,14 +208,15 @@
 }
 
 /*
-  While `.standard-scrollbars()` requires a selector to apply CSS properties, `.webkit-scrollbars()` could be used directly as it utilizes CSS pseudo-elements.
+  While `.standard-scrollbars()` requires a selector to apply CSS properties,
+  `.webkit-scrollbars()` could be used directly as it utilizes CSS pseudo-elements.
   Here's a usage example with web component:
-
-:host {
+```less
+::host {
   .standard-scrollbars();
 }
 .webkit-scrollbars();
-
+```
 */
 .standard-scrollbars() {
   @supports not selector(::-webkit-scrollbar) {

--- a/packages/elemental-theme/src/shared-styles/scrollbar.less
+++ b/packages/elemental-theme/src/shared-styles/scrollbar.less
@@ -1,16 +1,3 @@
-.standard-scrollbars() {
-  @supports not selector(::-webkit-scrollbar) {
-    & {
-      scrollbar-color: @scrollbar-thumb-background-color @scrollbar-track-background-color;
-    }
-  }
-}
-
-// `.mozilla-scrollbars()` is deprecated. Use `standard-scrollbars` instead.
-.mozilla-scrollbars() {
-  .standard-scrollbars();
-}
-
 // Helper Mixins. Shared between IE & Webkit.
 .scrollbar-corner-background(@property: background) {
   @{property}: @scrollbar-corner-background-color;
@@ -214,20 +201,31 @@
   }
 }
 
-/*
-`.scrollbars()` is deprecated. Use `.standard-scrollbars()` and `.webkit-scrollbars()` instead.
-While `.standard-scrollbars()` utilizes standard CSS properties,
-it still requires a selector to apply those styles.
-However, `.webkit-scrollbars()` is a CSS pseudo-element that acts as a selector itself,
-eliminating the need to push the mixin into host.
+// `.scrollbars()` is deprecated. Use `.standard-scrollbars()` and `.webkit-scrollbars()` instead.
+.scrollbars() {
+  .webkit-scrollbars();
+  .ie-scrollbars();
+}
 
-::host {
+/*
+  While `.standard-scrollbars()` requires a selector to apply CSS properties, `.webkit-scrollbars()` could be used directly as it utilizes CSS pseudo-elements.
+  Here's a usage example with web component:
+
+:host {
   .standard-scrollbars();
 }
 .webkit-scrollbars();
 
- */
-.scrollbars() {
-  .webkit-scrollbars();
-  .ie-scrollbars();
+*/
+.standard-scrollbars() {
+  @supports not selector(::-webkit-scrollbar) {
+    & {
+      scrollbar-color: @scrollbar-thumb-background-color @scrollbar-track-background-color;
+    }
+  }
+}
+
+// `.mozilla-scrollbars()` is deprecated. Use `.standard-scrollbars()` instead.
+.mozilla-scrollbars() {
+  .standard-scrollbars();
 }

--- a/packages/elemental-theme/src/shared-styles/scrollbar.less
+++ b/packages/elemental-theme/src/shared-styles/scrollbar.less
@@ -201,19 +201,20 @@
   }
 }
 
-// `.scrollbars()` is deprecated. Use `.standard-scrollbars()` and `.webkit-scrollbars()` instead.
+// `.scrollbars()` is deprecated. Use `.standard-scrollbars()`, `.ie-scrollbars()` and `.webkit-scrollbars()` instead.
 .scrollbars() {
   .webkit-scrollbars();
   .ie-scrollbars();
 }
 
 /*
-  While `.standard-scrollbars()` requires a selector to apply CSS properties,
+  While `.standard-scrollbars()` and `.ie-scrollbars()` require a selector to apply CSS properties,
   `.webkit-scrollbars()` could be used directly as it utilizes CSS pseudo-elements.
   Here's a usage example with web component:
 ```less
 ::host {
   .standard-scrollbars();
+  .ie-scrollbars();
 }
 .webkit-scrollbars();
 ```

--- a/packages/halo-theme/src/custom-elements/ef-select.less
+++ b/packages/halo-theme/src/custom-elements/ef-select.less
@@ -57,8 +57,9 @@
       display: none;
     }
   }
+
   .ie-scrollbars();
-  .mozilla-scrollbars();
+  .standard-scrollbars();
 }
 
 .webkit-scrollbars();

--- a/packages/halo-theme/src/native-elements/html.less
+++ b/packages/halo-theme/src/native-elements/html.less
@@ -1,6 +1,8 @@
 @import '@refinitiv-ui/elemental-theme/src/native-elements/html';
 @import '../shared-styles/scrollbar';
 
-html {
-  scrollbar-width: auto;
+@supports not selector(::-webkit-scrollbar) {
+  html {
+    scrollbar-width: auto;
+  }
 }

--- a/packages/halo-theme/src/shared-styles/scrollbar.less
+++ b/packages/halo-theme/src/shared-styles/scrollbar.less
@@ -1,5 +1,14 @@
 @import '@refinitiv-ui/elemental-theme/src/shared-styles/scrollbar';
 
+// TODO: `scrollbar-width` and `scrollbar-color` are now standardized in Chrome 121, not limited to Firefox. This mixin should be refactored in the next major release.
+.mozilla-scrollbars() {
+  @supports not selector(::-webkit-scrollbar) {
+    & {
+      scrollbar-width: thin;
+    }
+  }
+}
+
 .scrollbar-thumb(@width) {
   .thumb-background-border(@direction, @background-color) {
     background-image: linear-gradient(@direction, @background-color, @background-color);
@@ -251,11 +260,5 @@
       .draw-arrow(@arrow-size, @pixel-active, right);
       border-left-color: @scrollbar-button-pressed-border-opposite-color;
     }
-  }
-}
-
-.mozilla-scrollbars () {
-  & {
-    scrollbar-width: thin;
   }
 }

--- a/packages/halo-theme/src/shared-styles/scrollbar.less
+++ b/packages/halo-theme/src/shared-styles/scrollbar.less
@@ -255,12 +255,13 @@
 }
 
 /*
-  While `.standard-scrollbars()` requires a selector to apply CSS properties,
+  While `.standard-scrollbars()` and `.ie-scrollbars()` require a selector to apply CSS properties,
   `.webkit-scrollbars()` could be used directly as it utilizes CSS pseudo-elements.
   Here's a usage example with web component:
 ```less
 ::host {
   .standard-scrollbars();
+  .ie-scrollbars();
 }
 .webkit-scrollbars();
 ```

--- a/packages/halo-theme/src/shared-styles/scrollbar.less
+++ b/packages/halo-theme/src/shared-styles/scrollbar.less
@@ -1,18 +1,5 @@
 @import '@refinitiv-ui/elemental-theme/src/shared-styles/scrollbar';
 
-.standard-scrollbars() {
-  @supports not selector(::-webkit-scrollbar) {
-    & {
-      scrollbar-width: thin;
-    }
-  }
-}
-
-// `.mozilla-scrollbars()` is deprecated. Use `standard-scrollbars` instead.
-.mozilla-scrollbars() {
-  .standard-scrollbars();
-}
-
 .scrollbar-thumb(@width) {
   .thumb-background-border(@direction, @background-color) {
     background-image: linear-gradient(@direction, @background-color, @background-color);
@@ -265,4 +252,27 @@
       border-left-color: @scrollbar-button-pressed-border-opposite-color;
     }
   }
+}
+
+/*
+  While `.standard-scrollbars()` requires a selector to apply CSS properties, `.webkit-scrollbars()` could be used directly as it utilizes CSS pseudo-elements.
+  Here's a usage example with web component:
+
+:host {
+  .standard-scrollbars();
+}
+.webkit-scrollbars();
+
+*/
+.standard-scrollbars() {
+  @supports not selector(::-webkit-scrollbar) {
+    & {
+      scrollbar-width: thin;
+    }
+  }
+}
+
+// `.mozilla-scrollbars()` is deprecated. Use `.standard-scrollbars()` instead.
+.mozilla-scrollbars() {
+  .standard-scrollbars();
 }

--- a/packages/halo-theme/src/shared-styles/scrollbar.less
+++ b/packages/halo-theme/src/shared-styles/scrollbar.less
@@ -255,14 +255,15 @@
 }
 
 /*
-  While `.standard-scrollbars()` requires a selector to apply CSS properties, `.webkit-scrollbars()` could be used directly as it utilizes CSS pseudo-elements.
+  While `.standard-scrollbars()` requires a selector to apply CSS properties,
+  `.webkit-scrollbars()` could be used directly as it utilizes CSS pseudo-elements.
   Here's a usage example with web component:
-
-:host {
+```less
+::host {
   .standard-scrollbars();
 }
 .webkit-scrollbars();
-
+```
 */
 .standard-scrollbars() {
   @supports not selector(::-webkit-scrollbar) {

--- a/packages/halo-theme/src/shared-styles/scrollbar.less
+++ b/packages/halo-theme/src/shared-styles/scrollbar.less
@@ -1,12 +1,16 @@
 @import '@refinitiv-ui/elemental-theme/src/shared-styles/scrollbar';
 
-// TODO: `scrollbar-width` and `scrollbar-color` are now standardized in Chrome 121, not limited to Firefox. This mixin should be refactored in the next major release.
-.mozilla-scrollbars() {
+.standard-scrollbars() {
   @supports not selector(::-webkit-scrollbar) {
     & {
       scrollbar-width: thin;
     }
   }
+}
+
+// `.mozilla-scrollbars()` is deprecated. Use `standard-scrollbars` instead.
+.mozilla-scrollbars() {
+  .standard-scrollbars();
 }
 
 .scrollbar-thumb(@width) {

--- a/packages/solar-theme/src/custom-elements/ef-select.less
+++ b/packages/solar-theme/src/custom-elements/ef-select.less
@@ -10,13 +10,16 @@
   &:extend(:host);
   // pointer cursor style would be applied internally to trigger element instead
   cursor: unset;
+
   &:not([readonly]):hover {
     &:extend(:host:hover);
   }
+
   &:not([readonly]):active,
   &:not([readonly])[focused] {
     &:extend(:host:active);
   }
+
   &:not([disabled])[focused] {
     &:extend(:host:focus);
     border: 1px dotted @select-focused-border-color !important;
@@ -26,6 +29,7 @@
       box-shadow: inset 0 0 0 1px @select-box-shadow-color;
     }
   }
+
   &[disabled] {
     &:extend(:host[disabled]);
   }
@@ -49,8 +53,9 @@
     border: 1px solid @popup-border-color;
     background-color: @button-background-color;
   }
+
   .ie-scrollbars();
-  .mozilla-scrollbars();
+  .standard-scrollbars();
 }
 
 .webkit-scrollbars();


### PR DESCRIPTION
## Description
Chrome 121 introduces support for [scrollbar-color](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color) and [scrollbar-width](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width). Using any of these property would disable ::-webkit-scrollbar styling. Although EF uses these properties to style scrollbar just for Firefox, it also applies to Chrome 121+ disabling ::-webkit-scrollbar styling.


Fixes # (issue)
[DME-6491](https://jira.refinitiv.com/browse/DME-6491)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
