### PR TITLE
chore(chart): update chart.js min version to 4.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6231,14 +6231,14 @@
       "dev": true
     },
     "node_modules/chart.js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.1.tgz",
-      "integrity": "sha512-C74QN1bxwV1v2PEujhmKjOZ7iUM4w6BWs23Md/6aOZZSlwMzeCIDGuZay++rBgChYru7/+QFeoQW0fQoP534Dg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.2.tgz",
+      "integrity": "sha512-6GD7iKwFpP5kbSD4MeRRRlTnQvxfQREy36uEtm1hzHzcOqwWx0YEHuspuoNlslu+nciLIB7fjjsHkUv/FzFcOg==",
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
       "engines": {
-        "pnpm": ">=7"
+        "pnpm": ">=8"
       }
     },
     "node_modules/chartjs-adapter-date-fns": {
@@ -22143,7 +22143,7 @@
         "@lit-labs/context": "^0.3.1",
         "@refinitiv-ui/halo-theme": "^7.3.5",
         "@refinitiv-ui/solar-theme": "^7.2.6",
-        "chart.js": "^4.3.0",
+        "chart.js": "^4.4.2",
         "chartjs-adapter-date-fns": "^3.0.0",
         "d3-interpolate": "^3.0.1",
         "date-fns": "^2.29.3",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -344,7 +344,7 @@
     "@lit-labs/context": "^0.3.1",
     "@refinitiv-ui/halo-theme": "^7.3.5",
     "@refinitiv-ui/solar-theme": "^7.2.6",
-    "chart.js": "^4.3.0",
+    "chart.js": "^4.4.2",
     "chartjs-adapter-date-fns": "^3.0.0",
     "d3-interpolate": "^3.0.1",
     "date-fns": "^2.29.3",


### PR DESCRIPTION
Test passed. Should have no impact as currently we already do chart.js ^4.3.0.