### PR TITLE
fix(list, combobox, tree): fix EvalError with CSP on renderer

### DIFF
--- a/documents/src/pages/elements/combo-box.md
+++ b/documents/src/pages/elements/combo-box.md
@@ -451,7 +451,7 @@ comboBox.addEventListener('query-changed', (event) => {
 
 Combo Box supports custom rendering by providing a renderer function to the `renderer` property. The renderer receives a data item, Collection Composer and previously mapped item elements (if any), and must return an `HTMLElement`.
 
-The preferred approach is to create new renderer reference to the `createComboBoxRenderer` that comes with Combo Box. The default renderer uses [Item](./elements/item) elements, and supports highlighted, selected, disabled, hidden and readonly states.
+The preferred approach is to create new renderer reference with `createComboBoxRenderer` that comes with Combo Box. The default renderer uses [Item](./elements/item) elements, and supports highlighted, selected, disabled, hidden and readonly states.
 
 ```javascript
 import { createComboBoxRenderer } from '@refinitiv-ui/elements/combo-box';

--- a/documents/src/pages/elements/combo-box.md
+++ b/documents/src/pages/elements/combo-box.md
@@ -451,17 +451,17 @@ comboBox.addEventListener('query-changed', (event) => {
 
 Combo Box supports custom rendering by providing a renderer function to the `renderer` property. The renderer receives a data item, Collection Composer and previously mapped item elements (if any), and must return an `HTMLElement`.
 
-The preferred approach is to create new renderer reference to the `ComboBoxRenderer` that comes with Combo Box. The default renderer uses [Item](./elements/item) elements, and supports highlighted, selected, disabled, hidden and readonly states.
+The preferred approach is to create new renderer reference to the `createComboBoxRenderer` that comes with Combo Box. The default renderer uses [Item](./elements/item) elements, and supports highlighted, selected, disabled, hidden and readonly states.
 
 ```javascript
-import { ComboBoxRenderer } from '@refinitiv-ui/elements/combo-box';
+import { createComboBoxRenderer } from '@refinitiv-ui/elements/combo-box';
 
 // import flag to use in custom renderer
 import '@refinitiv-ui/elements/flag';
 import '@refinitiv-ui/elements/flag/themes/halo/dark';
 
 // Keep the reference to the default renderer
-const itemRenderer = new ComboBoxRenderer(comboBox);
+const itemRenderer = createComboBoxRenderer(comboBox);
 // Keep track flag elements after creating to avoid memory leak and re-render the same flag
 const flagMap = new WeakMap();
 
@@ -496,7 +496,7 @@ comboBox.renderer = (item, composer, element) => {
 ```typescript
 import { ItemData } from '@refinitiv-ui/elements/item';
 import { ListItem } from '@refinitiv-ui/elements/list';
-import { ComboBoxRenderer } from '@refinitiv-ui/elements/combo-box';
+import { createComboBoxRenderer } from '@refinitiv-ui/elements/combo-box';
 
 import { CollectionComposer } from '@refinitiv-ui/utils';
 
@@ -505,7 +505,7 @@ import '@refinitiv-ui/elements/flag';
 import '@refinitiv-ui/elements/flag/themes/halo/dark';
 
 // Keep the reference to the default renderer
-const itemRenderer = new ComboBoxRenderer(comboBox);
+const itemRenderer = createComboBoxRenderer(comboBox);
 // Keep track flag elements after creating to avoid memory leak and re-render the same flag
 const flagMap = new WeakMap();
 
@@ -540,7 +540,7 @@ comboBox.renderer = (item: ItemData, composer: CollectionComposer, element: List
 ::
 ```javascript
 ::import-elements::
-import { ComboBoxRenderer } from '/resources/elements/index.js';
+import { createComboBoxRenderer } from '/resources/elements/index.js';
 
 const comboBox = document.querySelector('ef-combo-box');
 comboBox.data = [
@@ -561,7 +561,7 @@ comboBox.data = [
   { label: 'Argentina', value: 'ar' }
 ];
 
-const itemRenderer = new ComboBoxRenderer(comboBox);
+const itemRenderer = createComboBoxRenderer(comboBox);
 const flagMap = new WeakMap();
 
 comboBox.renderer = (item, composer, element) => {

--- a/documents/src/pages/elements/list.md
+++ b/documents/src/pages/elements/list.md
@@ -172,10 +172,10 @@ Extending the default renderer is the easiest way to display custom content, whi
 !> Renders are currently being upgraded and should only be used for testing purposes.
 
 ```javascript
-import { ListRenderer } from '@refinitiv-ui/elements/list';
+import { createListRenderer } from '@refinitiv-ui/elements/list';
 
 const list = document.querySelector('ef-list');
-const itemRenderer = new ListRenderer(list);
+const itemRenderer = createListRenderer(list);
 
 list.renderer = (item, composer, element) => {
   const itemElement = itemRenderer(item, composer, element);
@@ -186,12 +186,12 @@ list.renderer = (item, composer, element) => {
 
 ```typescript
 import { CollectionComposer } from '@refinitiv-ui/utils';
-import { List, ListItem, ListRenderer } from '@refinitiv-ui/elements/list';
+import { List, ListItem, createListRenderer } from '@refinitiv-ui/elements/list';
 
 const list: List | null = document.querySelector('ef-list');
 
 if (list) {
-  const itemRenderer = new ListRenderer(list);
+  const itemRenderer = createListRenderer(list);
   list.renderer = (item: ListItem, composer: CollectionComposer, element: HTMLElement) => {
     const itemElement = itemRenderer(item, composer, element);
     // do something extra

--- a/packages/elements/src/combo-box/__demo__/index.html
+++ b/packages/elements/src/combo-box/__demo__/index.html
@@ -206,7 +206,6 @@
       <ef-combo-box id="custom-renderer"></ef-combo-box>
       <script type="module">
         import { createComboBoxRenderer } from '@refinitiv-ui/elements/combo-box';
-        import '@refinitiv-ui/elements/flag';
 
         const createFlagRender = (context) => {
           // Keep the reference to the default renderer

--- a/packages/elements/src/combo-box/__demo__/index.html
+++ b/packages/elements/src/combo-box/__demo__/index.html
@@ -8,6 +8,7 @@
   <body>
     <script type="module">
       import '@refinitiv-ui/elements/combo-box';
+      import '@refinitiv-ui/elements/flag';
 
       import '@refinitiv-ui/demo-block';
       import '@refinitiv-ui/demo-block/demo.css';
@@ -26,6 +27,7 @@
 
       import(`../../../../../node_modules/@refinitiv-ui/${theme}-theme/${variant}/css/native-elements.css`);
       import(`../../../lib/combo-box/themes/${theme}/${variant}/index.js`);
+      import(`../../../lib/flag/themes/${theme}/${variant}/index.js`);
     </script>
     <script type="module">
       // Translations

--- a/packages/elements/src/combo-box/__demo__/index.html
+++ b/packages/elements/src/combo-box/__demo__/index.html
@@ -243,7 +243,7 @@
         };
 
         const customRenderer = document.getElementById('custom-renderer');
-        customRenderer.renderer = flagRender(customRenderer);
+        customRenderer.renderer = createFlagRender(customRenderer);
       </script>
     </demo-block>
 

--- a/packages/elements/src/combo-box/__demo__/index.html
+++ b/packages/elements/src/combo-box/__demo__/index.html
@@ -206,7 +206,7 @@
         import { createComboBoxRenderer } from '@refinitiv-ui/elements/combo-box';
         import '@refinitiv-ui/elements/flag';
 
-        const flagRender = (context) => {
+        const createFlagRender = (context) => {
           // Keep the reference to the default renderer
           const renderer = createComboBoxRenderer(context);
           // store reference to flag for easy access.

--- a/packages/elements/src/combo-box/__demo__/index.html
+++ b/packages/elements/src/combo-box/__demo__/index.html
@@ -203,49 +203,47 @@
     <demo-block header="Custom renderer" layout="normal" tags="renderer">
       <ef-combo-box id="custom-renderer"></ef-combo-box>
       <script type="module">
-        import { ComboBoxRenderer } from '@refinitiv-ui/elements/combo-box';
+        import { createComboBoxRenderer } from '@refinitiv-ui/elements/combo-box';
         import '@refinitiv-ui/elements/flag';
 
-        class FlagRender extends ComboBoxRenderer {
-          constructor(context) {
-            // Keep the reference to the default renderer
-            const renderer = super(context);
-            // store reference to flag for easy access.
-            // Use WeakMap to not care about memory leaks
-            const flagMap = new WeakMap();
+        const flagRender = (context) => {
+          // Keep the reference to the default renderer
+          const renderer = createComboBoxRenderer(context);
+          // store reference to flag for easy access.
+          // Use WeakMap to not care about memory leaks
+          const flagMap = new WeakMap();
 
-            // Return the closure
-            return (item, composer, element) => {
-              element = renderer(item, composer, element);
-              const type = composer.getItemPropertyValue(item, 'type');
-              // reuse existing flag element if available
-              let flagElement = flagMap.get(element);
-              if (!flagElement && (!type || type === 'text')) {
-                // Text items
-                flagElement = document.createElement('ef-flag');
-                flagElement.slot = 'left';
-                element.appendChild(flagElement);
-                flagMap.set(element, flagElement);
-              } else if (flagElement && type && type !== 'text') {
-                // Header items, which should not have a flag
-                // Make sure that flag element is removed
-                flagElement.parentNode.removeChild(flagElement);
-                flagMap.remove(element, flagElement);
-                flagElement = null;
-              }
+          // Return the closure
+          return (item, composer, element) => {
+            element = renderer(item, composer, element);
+            const type = composer.getItemPropertyValue(item, 'type');
+            // reuse existing flag element if available
+            let flagElement = flagMap.get(element);
+            if (!flagElement && (!type || type === 'text')) {
+              // Text items
+              flagElement = document.createElement('ef-flag');
+              flagElement.slot = 'left';
+              element.appendChild(flagElement);
+              flagMap.set(element, flagElement);
+            } else if (flagElement && type && type !== 'text') {
+              // Header items, which should not have a flag
+              // Make sure that flag element is removed
+              flagElement.parentNode.removeChild(flagElement);
+              flagMap.remove(element, flagElement);
+              flagElement = null;
+            }
 
-              // Make sure that you can re-use the same element with new data item
-              if (flagElement) {
-                flagElement.flag = composer.getItemPropertyValue(item, 'value');
-              }
+            // Make sure that you can re-use the same element with new data item
+            if (flagElement) {
+              flagElement.flag = composer.getItemPropertyValue(item, 'value');
+            }
 
-              return element;
-            };
-          }
-        }
+            return element;
+          };
+        };
 
         const customRenderer = document.getElementById('custom-renderer');
-        customRenderer.renderer = new FlagRender(customRenderer);
+        customRenderer.renderer = flagRender(customRenderer);
       </script>
     </demo-block>
 

--- a/packages/elements/src/combo-box/helpers/renderer.ts
+++ b/packages/elements/src/combo-box/helpers/renderer.ts
@@ -32,7 +32,7 @@ const deprecationNotice = new DeprecationNotice(
 /**
  * Renders list items as `ef-item` elements.
  * Extends its behaviour from ListRenderer.
- * @deprecate ComboRenderer is deprecated. Use createComboBoxRenderer instead.
+ * @deprecate ComboBoxRenderer is deprecated. Use createComboBoxRenderer instead.
  */
 export class ComboBoxRenderer extends Renderer {
   constructor(context?: unknown) {

--- a/packages/elements/src/combo-box/helpers/renderer.ts
+++ b/packages/elements/src/combo-box/helpers/renderer.ts
@@ -8,7 +8,7 @@ import { Renderer } from '../../list/renderer.js';
 
 export const createComboBoxRenderer = <T extends DataItem = ItemData>(
   context?: unknown
-): ((item: T, composer: CollectionComposer<T>, element?: HTMLElement) => HTMLElement) => {
+) => {
   const listRenderer = createListRenderer<T>(context);
 
   return (item: T, composer: CollectionComposer<T>, element?: HTMLElement) => {

--- a/packages/elements/src/combo-box/helpers/renderer.ts
+++ b/packages/elements/src/combo-box/helpers/renderer.ts
@@ -32,7 +32,7 @@ const deprecationNotice = new DeprecationNotice(
 /**
  * Renders list items as `ef-item` elements.
  * Extends its behaviour from ListRenderer.
- * @deprecate Don't use this! It causes uncaught EvalError when using script-src 'self' CSP.
+ * @deprecate ComboRenderer is deprecated. Use createComboBoxRenderer instead.
  */
 export class ComboBoxRenderer extends Renderer {
   constructor(context?: unknown) {

--- a/packages/elements/src/combo-box/helpers/renderer.ts
+++ b/packages/elements/src/combo-box/helpers/renderer.ts
@@ -1,8 +1,35 @@
-import type { CollectionComposer } from '@refinitiv-ui/utils/collection.js';
+import { DeprecationNotice } from '@refinitiv-ui/core';
+
+import type { CollectionComposer, DataItem } from '@refinitiv-ui/utils/collection.js';
 
 import type { Item, ItemData } from '../../item';
-import { ListRenderer } from '../../list/index.js';
+import { createListRenderer } from '../../list/index.js';
 import { Renderer } from '../../list/renderer.js';
+
+export const createComboBoxRenderer = <T extends DataItem = ItemData>(
+  context?: unknown
+): ((item: T, composer: CollectionComposer<T>, element?: HTMLElement) => HTMLElement) => {
+  const listRenderer = createListRenderer<T>(context);
+
+  return (item: T, composer: CollectionComposer<T>, element?: HTMLElement) => {
+    // Extending renderer from listRenderer
+    element = listRenderer(item, composer, element);
+    const value = composer.getItemPropertyValue(item, 'value') as string;
+
+    // Using value as id for `aria-activedescendant` in combobox
+    if (value && element.id !== value) {
+      element.id = value;
+    } else if (!value && element.id) {
+      element.removeAttribute('id');
+    }
+
+    return element;
+  };
+};
+
+const deprecationNotice = new DeprecationNotice(
+  'ComboRenderer is deprecated. Use createComboBoxRenderer instead.'
+);
 
 /**
  * Renders list items as `ef-item` elements.
@@ -10,21 +37,7 @@ import { Renderer } from '../../list/renderer.js';
  */
 export class ComboBoxRenderer extends Renderer {
   constructor(context?: unknown) {
-    const listRenderer = new ListRenderer(context);
-
-    super((item: ItemData, composer: CollectionComposer<ItemData>, element?: HTMLElement) => {
-      // Extending renderer from listRenderer
-      element = listRenderer(item, composer, element) as Item;
-      const value = composer.getItemPropertyValue(item, 'value') as string;
-
-      // Using value as id for `aria-activedescendant` in combobox
-      if (value && element.id !== value) {
-        element.id = value;
-      } else if (!value && element.id) {
-        element.removeAttribute('id');
-      }
-
-      return element;
-    });
+    super(createComboBoxRenderer(context));
+    deprecationNotice.show();
   }
 }

--- a/packages/elements/src/combo-box/helpers/renderer.ts
+++ b/packages/elements/src/combo-box/helpers/renderer.ts
@@ -6,9 +6,7 @@ import type { ItemData } from '../../item';
 import { createListRenderer } from '../../list/index.js';
 import { Renderer } from '../../list/renderer.js';
 
-export const createComboBoxRenderer = <T extends DataItem = ItemData>(
-  context?: unknown
-) => {
+export const createComboBoxRenderer = <T extends DataItem = ItemData>(context?: unknown) => {
   const listRenderer = createListRenderer<T>(context);
 
   return (item: T, composer: CollectionComposer<T>, element?: HTMLElement): HTMLElement => {

--- a/packages/elements/src/combo-box/helpers/renderer.ts
+++ b/packages/elements/src/combo-box/helpers/renderer.ts
@@ -2,7 +2,7 @@ import { DeprecationNotice } from '@refinitiv-ui/core';
 
 import type { CollectionComposer, DataItem } from '@refinitiv-ui/utils/collection.js';
 
-import type { Item, ItemData } from '../../item';
+import type { ItemData } from '../../item';
 import { createListRenderer } from '../../list/index.js';
 import { Renderer } from '../../list/renderer.js';
 

--- a/packages/elements/src/combo-box/helpers/renderer.ts
+++ b/packages/elements/src/combo-box/helpers/renderer.ts
@@ -32,6 +32,7 @@ const deprecationNotice = new DeprecationNotice(
 /**
  * Renders list items as `ef-item` elements.
  * Extends its behaviour from ListRenderer.
+ * @deprecate Don't use this! It causes uncaught EvalError when using script-src 'self' CSP.
  */
 export class ComboBoxRenderer extends Renderer {
   constructor(context?: unknown) {

--- a/packages/elements/src/combo-box/helpers/renderer.ts
+++ b/packages/elements/src/combo-box/helpers/renderer.ts
@@ -11,7 +11,7 @@ export const createComboBoxRenderer = <T extends DataItem = ItemData>(
 ) => {
   const listRenderer = createListRenderer<T>(context);
 
-  return (item: T, composer: CollectionComposer<T>, element?: HTMLElement) => {
+  return (item: T, composer: CollectionComposer<T>, element?: HTMLElement): HTMLElement => {
     // Extending renderer from listRenderer
     element = listRenderer(item, composer, element);
     const value = composer.getItemPropertyValue(item, 'value') as string;

--- a/packages/elements/src/combo-box/helpers/renderer.ts
+++ b/packages/elements/src/combo-box/helpers/renderer.ts
@@ -26,7 +26,7 @@ export const createComboBoxRenderer = <T extends DataItem = ItemData>(context?: 
 };
 
 const deprecationNotice = new DeprecationNotice(
-  'ComboRenderer is deprecated. Use createComboBoxRenderer instead.'
+  'ComboBoxRenderer is deprecated. Use createComboBoxRenderer instead.'
 );
 
 /**

--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -119,7 +119,6 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
 
   /**
    * Renderer used to render list item elements
-   * @type {createComboBoxRenderer}
    */
   @property({ type: Function, attribute: false })
   public renderer = createComboBoxRenderer(this);

--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -121,7 +121,7 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
    * Renderer used to render list item elements
    */
   @property({ type: Function, attribute: false })
-  public renderer = createComboBoxRenderer(this);
+  public renderer = createComboBoxRenderer<T>(this);
 
   private _multiple = false;
   /**

--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -35,11 +35,11 @@ import { registerOverflowTooltip } from '../tooltip/index.js';
 import { VERSION } from '../version.js';
 import { defaultFilter } from './helpers/filter.js';
 import { CustomKeyboardEvent } from './helpers/keyboard-event.js';
-import { ComboBoxRenderer } from './helpers/renderer.js';
+import { ComboBoxRenderer, createComboBoxRenderer } from './helpers/renderer.js';
 import type { ComboBoxData, ComboBoxFilter } from './helpers/types';
 
 export type { ComboBoxFilter, ComboBoxData };
-export { ComboBoxRenderer };
+export { ComboBoxRenderer, createComboBoxRenderer };
 
 const QUERY_DEBOUNCE_RATE = 0;
 
@@ -119,10 +119,10 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
 
   /**
    * Renderer used to render list item elements
-   * @type {ComboBoxRenderer}
+   * @type {createComboBoxRenderer}
    */
   @property({ type: Function, attribute: false })
-  public renderer = new ComboBoxRenderer(this);
+  public renderer = createComboBoxRenderer(this);
 
   private _multiple = false;
   /**

--- a/packages/elements/src/list/elements/list.ts
+++ b/packages/elements/src/list/elements/list.ts
@@ -15,7 +15,7 @@ import { CollectionComposer, DataItem } from '@refinitiv-ui/utils/collection.js'
 
 import type { ItemData } from '../../item';
 import { VERSION } from '../../version.js';
-import { ListRenderer } from '../helpers/renderer.js';
+import { createListRenderer } from '../helpers/renderer.js';
 import type { ListData } from '../helpers/types';
 import './list-item.js';
 
@@ -85,10 +85,10 @@ export class List<T extends DataItem = ItemData> extends ControlElement {
 
   /**
    * Renderer used to render list item elements
-   * @type {ListRenderer}
+   * @type {createListRenderer}
    */
   @property({ type: Function, attribute: false })
-  public renderer = new ListRenderer(this);
+  public renderer = createListRenderer<T>(this);
 
   /**
    * Disable selections
@@ -567,7 +567,7 @@ export class List<T extends DataItem = ItemData> extends ControlElement {
       this.elementMap.set(item, recycledElement);
     }
 
-    const freshElement = this.renderer(item, this.composer, this.elementFromItem(item)) as HTMLElement;
+    const freshElement = this.renderer(item, this.composer, this.elementFromItem(item));
     if (cachedElement && cachedElement !== freshElement) {
       // Renderer returned a new element, so remove the old link.
       this.itemMap.delete(cachedElement);

--- a/packages/elements/src/list/elements/list.ts
+++ b/packages/elements/src/list/elements/list.ts
@@ -85,7 +85,6 @@ export class List<T extends DataItem = ItemData> extends ControlElement {
 
   /**
    * Renderer used to render list item elements
-   * @type {createListRenderer}
    */
   @property({ type: Function, attribute: false })
   public renderer = createListRenderer<T>(this);

--- a/packages/elements/src/list/extensible-function.ts
+++ b/packages/elements/src/list/extensible-function.ts
@@ -1,6 +1,6 @@
 /**
  * Extensible function class
- * @deprecate Don't use this! It causes uncaught EvalError when using script-src 'self' CSP.
+ * @deprecate ExtensibleFunction is deprecated.
  */
 export abstract class ExtensibleFunction extends Function {
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/elements/src/list/extensible-function.ts
+++ b/packages/elements/src/list/extensible-function.ts
@@ -1,7 +1,6 @@
 /**
  * Extensible function class
- * TODO: Move this to @refinitiv-ui/utils
- * ! Do not import this module !
+ * @deprecate Don't use this! It causes uncaught EvalError when using script-src 'self' CSP.
  */
 export abstract class ExtensibleFunction extends Function {
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/elements/src/list/extensible-function.ts
+++ b/packages/elements/src/list/extensible-function.ts
@@ -1,5 +1,5 @@
 /**
- * ExtensibleFunction is not CSP compliant. Do not use.
+ *  Do not use: ExtensibleFunction is not CSP compliant.
  * @deprecate ExtensibleFunction is deprecated.
  */
 export abstract class ExtensibleFunction extends Function {

--- a/packages/elements/src/list/extensible-function.ts
+++ b/packages/elements/src/list/extensible-function.ts
@@ -1,5 +1,5 @@
 /**
- * Extensible function class
+ * ExtensibleFunction is not CSP compliant. Do not use.
  * @deprecate ExtensibleFunction is deprecated.
  */
 export abstract class ExtensibleFunction extends Function {

--- a/packages/elements/src/list/helpers/renderer.ts
+++ b/packages/elements/src/list/helpers/renderer.ts
@@ -1,4 +1,6 @@
-import type { CollectionComposer } from '@refinitiv-ui/utils/collection.js';
+import { DeprecationNotice } from '@refinitiv-ui/core';
+
+import type { CollectionComposer, DataItem } from '@refinitiv-ui/utils/collection.js';
 import { uuid } from '@refinitiv-ui/utils/uuid.js';
 
 import type { Item, ItemData, ItemType } from '../../item';
@@ -12,6 +14,47 @@ type Context = {
   multiple?: boolean;
 };
 
+export const createListRenderer = <T extends DataItem = ItemData>(
+  context?: unknown
+): ((item: T, composer: CollectionComposer<T>, element?: HTMLElement) => HTMLElement) => {
+  /**
+   * Renderer key prefix, used in combination with item value to give unique id to each item
+   */
+  const key: string = uuid();
+  return (item: T, composer: CollectionComposer<T>, element?: HTMLElement) => {
+    /**
+     * Element to render
+     */
+    const el = (element as Item) || document.createElement('ef-list-item');
+    /**
+     * Tooltip value to be used, if any.
+     */
+    const tooltip = composer.getItemPropertyValue(item, 'tooltip') as string;
+
+    el.label = composer.getItemPropertyValue(item, 'label') as string;
+    el.subLabel = composer.getItemPropertyValue(item, 'subLabel') as string;
+    el.value = composer.getItemPropertyValue(item, 'value') as string;
+    el.id = getItemId(key, el.value);
+    el.icon = composer.getItemPropertyValue(item, 'icon') as string;
+    el.highlighted = composer.getItemPropertyValue(item, 'highlighted') === true;
+    el.selected = composer.getItemPropertyValue(item, 'selected') === true;
+    el.disabled = composer.getItemPropertyValue(item, 'disabled') === true;
+    el.hidden = composer.getItemPropertyValue(item, 'hidden') === true;
+    el.type = composer.getItemPropertyValue(item, 'type') as ItemType;
+    el.multiple = !!context && (context as Context).multiple === true;
+
+    const itemRole = el.type === 'text' || !el.type ? 'option' : 'presentation';
+    el.setAttribute('role', itemRole);
+    tooltip ? el.setAttribute('title', tooltip) : el.removeAttribute('title');
+
+    return el;
+  };
+};
+
+const deprecationNotice = new DeprecationNotice(
+  'ListRenderer is deprecated. Use createListRenderer instead.'
+);
+
 /**
  * Renders list items as `ef-item` elements.
  * This is the default renderer for lists.
@@ -19,40 +62,9 @@ type Context = {
 export class ListRenderer extends Renderer {
   constructor(context?: unknown) {
     /**
-     * Renderer key prefix, used in combination with item value to give unique id to each item
-     */
-    const key: string = uuid();
-
-    /**
      * Create and return render function
      */
-    super((item: ItemData, composer: CollectionComposer<ItemData>, element?: HTMLElement) => {
-      /**
-       * Element to render
-       */
-      const el = (element as Item) || document.createElement('ef-list-item');
-      /**
-       * Tooltip value to be used, if any.
-       */
-      const tooltip = composer.getItemPropertyValue(item, 'tooltip') as string;
-
-      el.label = composer.getItemPropertyValue(item, 'label') as string;
-      el.subLabel = composer.getItemPropertyValue(item, 'subLabel') as string;
-      el.value = composer.getItemPropertyValue(item, 'value') as string;
-      el.id = getItemId(key, el.value);
-      el.icon = composer.getItemPropertyValue(item, 'icon') as string;
-      el.highlighted = composer.getItemPropertyValue(item, 'highlighted') === true;
-      el.selected = composer.getItemPropertyValue(item, 'selected') === true;
-      el.disabled = composer.getItemPropertyValue(item, 'disabled') === true;
-      el.hidden = composer.getItemPropertyValue(item, 'hidden') === true;
-      el.type = composer.getItemPropertyValue(item, 'type') as ItemType;
-      el.multiple = !!context && (context as Context).multiple === true;
-
-      const itemRole = el.type === 'text' || !el.type ? 'option' : 'presentation';
-      el.setAttribute('role', itemRole);
-      tooltip ? el.setAttribute('title', tooltip) : el.removeAttribute('title');
-
-      return el;
-    });
+    super(createListRenderer(context));
+    deprecationNotice.show();
   }
 }

--- a/packages/elements/src/list/helpers/renderer.ts
+++ b/packages/elements/src/list/helpers/renderer.ts
@@ -56,7 +56,7 @@ const deprecationNotice = new DeprecationNotice(
 /**
  * Renders list items as `ef-item` elements.
  * This is the default renderer for lists.
- * @deprecate Don't use this! It causes uncaught EvalError when using script-src 'self' CSP.
+ * @deprecate ListRenderer is deprecated. Use createListRenderer instead.
  */
 export class ListRenderer extends Renderer {
   constructor(context?: unknown) {

--- a/packages/elements/src/list/helpers/renderer.ts
+++ b/packages/elements/src/list/helpers/renderer.ts
@@ -14,14 +14,12 @@ type Context = {
   multiple?: boolean;
 };
 
-export const createListRenderer = <T extends DataItem = ItemData>(
-  context?: unknown
-) => {
+export const createListRenderer = <T extends DataItem = ItemData>(context?: unknown) => {
   /**
    * Renderer key prefix, used in combination with item value to give unique id to each item
    */
   const key: string = uuid();
-  return (item: T, composer: CollectionComposer<T>, element?: HTMLElement) => {
+  return (item: T, composer: CollectionComposer<T>, element?: HTMLElement): HTMLElement => {
     /**
      * Element to render
      */

--- a/packages/elements/src/list/helpers/renderer.ts
+++ b/packages/elements/src/list/helpers/renderer.ts
@@ -56,6 +56,7 @@ const deprecationNotice = new DeprecationNotice(
 /**
  * Renders list items as `ef-item` elements.
  * This is the default renderer for lists.
+ * @deprecate Don't use this! It causes uncaught EvalError when using script-src 'self' CSP.
  */
 export class ListRenderer extends Renderer {
   constructor(context?: unknown) {

--- a/packages/elements/src/list/helpers/renderer.ts
+++ b/packages/elements/src/list/helpers/renderer.ts
@@ -16,7 +16,7 @@ type Context = {
 
 export const createListRenderer = <T extends DataItem = ItemData>(
   context?: unknown
-): ((item: T, composer: CollectionComposer<T>, element?: HTMLElement) => HTMLElement) => {
+) => {
   /**
    * Renderer key prefix, used in combination with item value to give unique id to each item
    */

--- a/packages/elements/src/list/index.ts
+++ b/packages/elements/src/list/index.ts
@@ -2,6 +2,6 @@ import type { ListData } from './helpers/types';
 
 export * from './elements/list.js';
 export * from './elements/list-item.js';
-export { ListRenderer } from './helpers/renderer.js';
+export { ListRenderer, createListRenderer } from './helpers/renderer.js';
 
 export type { ListData };

--- a/packages/elements/src/list/renderer.ts
+++ b/packages/elements/src/list/renderer.ts
@@ -1,7 +1,7 @@
 import { ExtensibleFunction } from './extensible-function.js';
 
 /**
- * Renderer is not CSP compliant. Do not use.
+ * Do not use: Renderer is not CSP compliant. 
  * Used for creating renderers to render data items.
  * @deprecate Renderer is deprecated.
  */

--- a/packages/elements/src/list/renderer.ts
+++ b/packages/elements/src/list/renderer.ts
@@ -1,7 +1,7 @@
 import { ExtensibleFunction } from './extensible-function.js';
 
 /**
- * Do not use: Renderer is not CSP compliant. 
+ * Do not use: Renderer is not CSP compliant.
  * Used for creating renderers to render data items.
  * @deprecate Renderer is deprecated.
  */

--- a/packages/elements/src/list/renderer.ts
+++ b/packages/elements/src/list/renderer.ts
@@ -1,7 +1,7 @@
 import { ExtensibleFunction } from './extensible-function.js';
 
 /**
- * Renderer base class.
+ * Renderer is not CSP compliant. Do not use.
  * Used for creating renderers to render data items.
  * @deprecate Renderer is deprecated.
  */

--- a/packages/elements/src/list/renderer.ts
+++ b/packages/elements/src/list/renderer.ts
@@ -1,39 +1,8 @@
-import type { CollectionComposer, DataItem } from '@refinitiv-ui/utils/collection.js';
-
 import { ExtensibleFunction } from './extensible-function.js';
-
-/**
- * Render function interface
- * TODO: Move this to @refinitiv-ui/utils
- * ! Do not import this module !
- */
-export interface RenderFunction {
-  /**
-   * Renders data items into elements
-   * @param item Data item context
-   * @param composer Composer context
-   * @param element Reusable element. This element tries to be the same as was used before.
-   * @returns List item element
-   */
-  (item: DataItem, composer: CollectionComposer, element?: HTMLElement): HTMLElement;
-}
-
-/**
- * Render constructor interface
- * TODO: Move this to @refinitiv-ui/utils
- * ! Do not import this module !
- */
-export interface RendererConstructor {
-  /**
-   * @param fn Render function to use as the instance
-   */
-  new (fn: RenderFunction): RenderFunction;
-}
 
 /**
  * Renderer base class.
  * Used for creating renderers to render data items.
- * TODO: Move this to @refinitiv-ui/utils
- * ! Do not import this module !
+ * @deprecate Don't use this! It causes uncaught EvalError when using script-src 'self' CSP.
  */
 export abstract class Renderer extends ExtensibleFunction {}

--- a/packages/elements/src/list/renderer.ts
+++ b/packages/elements/src/list/renderer.ts
@@ -3,6 +3,6 @@ import { ExtensibleFunction } from './extensible-function.js';
 /**
  * Renderer base class.
  * Used for creating renderers to render data items.
- * @deprecate Don't use this! It causes uncaught EvalError when using script-src 'self' CSP.
+ * @deprecate Renderer is deprecated.
  */
 export abstract class Renderer extends ExtensibleFunction {}

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -26,7 +26,6 @@ import '../icon/index.js';
 import type { Overlay } from '../overlay';
 import type { Pill } from '../pill';
 import '../pill/index.js';
-import '../tree/index.js';
 import {
   TreeRenderer as TreeSelectRenderer,
   createTreeRenderer as createTreeSelectRenderer

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -239,7 +239,6 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
 
   /**
    * Renderer used to render tree item elements
-   * @type {TreeSelectRenderer}
    */
   @property({ type: Function, attribute: false })
   public override renderer = createTreeSelectRenderer(this);

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -240,7 +240,7 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
    * Renderer used to render tree item elements
    */
   @property({ type: Function, attribute: false })
-  public override renderer = createTreeSelectRenderer(this);
+  public override renderer = createTreeSelectRenderer<TreeSelectDataItem>(this);
 
   private _max: string | null = null;
   /**

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -27,13 +27,16 @@ import type { Overlay } from '../overlay';
 import type { Pill } from '../pill';
 import '../pill/index.js';
 import '../tree/index.js';
-import { TreeRenderer as TreeSelectRenderer } from '../tree/index.js';
+import {
+  TreeRenderer as TreeSelectRenderer,
+  createTreeRenderer as createTreeSelectRenderer
+} from '../tree/index.js';
 import type { Tree } from '../tree/index.js';
 import { CheckedState, TreeManager, TreeManagerMode } from '../tree/managers/tree-manager.js';
 import { VERSION } from '../version.js';
 import type { TreeSelectData, TreeSelectDataItem } from './helpers/types';
 
-export { TreeSelectRenderer };
+export { TreeSelectRenderer, createTreeSelectRenderer };
 export type { TreeSelectFilter, TreeSelectDataItem, TreeSelectData };
 
 const MEMO_THROTTLE = 16;
@@ -239,7 +242,7 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
    * @type {TreeSelectRenderer}
    */
   @property({ type: Function, attribute: false })
-  public override renderer = new TreeSelectRenderer(this);
+  public override renderer = createTreeSelectRenderer(this);
 
   private _max: string | null = null;
   /**

--- a/packages/elements/src/tree/__demo__/index.html
+++ b/packages/elements/src/tree/__demo__/index.html
@@ -32,7 +32,7 @@
       import(`../../../lib/tree/themes/${theme}/${variant}/index.js`);
     </script>
     <script type="module">
-      import { TreeRenderer } from '@refinitiv-ui/elements/tree';
+      import { createTreeRenderer } from '@refinitiv-ui/elements/tree';
 
       let nextId = 0;
       const makeData = (depth = 0, detail = { count: 0 }) => {
@@ -92,7 +92,7 @@
       }
 
       const custom = document.getElementById('renderer');
-      const renderer = new TreeRenderer(custom);
+      const renderer = createTreeRenderer(custom);
       const knownElements = new WeakSet();
 
       custom.renderer = function (item, composer, element) {

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -69,7 +69,6 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
 
   /**
    * Renderer used for generating tree items
-   * @type {TreeRenderer}
    */
   @property({ attribute: false })
   public override renderer = createTreeRenderer(this);

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -7,7 +7,7 @@ import { CollectionComposer } from '@refinitiv-ui/utils/collection.js';
 import { List, valueFormatWarning } from '../../list/index.js';
 import { VERSION } from '../../version.js';
 import { defaultFilter } from '../helpers/filter.js';
-import { TreeRenderer } from '../helpers/renderer.js';
+import { TreeRenderer, createTreeRenderer } from '../helpers/renderer.js';
 import type { TreeData, TreeDataItem, TreeFilter } from '../helpers/types';
 import { TreeManager, TreeManagerMode } from '../managers/tree-manager.js';
 import './tree-item.js';
@@ -72,7 +72,7 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
    * @type {TreeRenderer}
    */
   @property({ attribute: false })
-  public override renderer = new TreeRenderer(this);
+  public override renderer = createTreeRenderer(this);
 
   /**
    * Expands all groups

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -7,7 +7,7 @@ import { CollectionComposer } from '@refinitiv-ui/utils/collection.js';
 import { List, valueFormatWarning } from '../../list/index.js';
 import { VERSION } from '../../version.js';
 import { defaultFilter } from '../helpers/filter.js';
-import { TreeRenderer, createTreeRenderer } from '../helpers/renderer.js';
+import { createTreeRenderer } from '../helpers/renderer.js';
 import type { TreeData, TreeDataItem, TreeFilter } from '../helpers/types';
 import { TreeManager, TreeManagerMode } from '../managers/tree-manager.js';
 import './tree-item.js';

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -71,7 +71,7 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
    * Renderer used for generating tree items
    */
   @property({ attribute: false })
-  public override renderer = createTreeRenderer(this);
+  public override renderer = createTreeRenderer<T>(this);
 
   /**
    * Expands all groups

--- a/packages/elements/src/tree/helpers/renderer.ts
+++ b/packages/elements/src/tree/helpers/renderer.ts
@@ -28,7 +28,7 @@ export const createTreeRenderer = <T extends TreeDataItem = TreeDataItem>(
   return (
     item: T,
     composer: CollectionComposer<T>,
-    element = document.createElement('ef-tree-item')
+    element: HTMLElement = document.createElement('ef-tree-item')
   ): HTMLElement => {
     // cast type to element to not break List api.
     const _element = element as TreeItem;

--- a/packages/elements/src/tree/helpers/renderer.ts
+++ b/packages/elements/src/tree/helpers/renderer.ts
@@ -1,8 +1,11 @@
+import { DeprecationNotice } from '@refinitiv-ui/core';
+
 import type { CollectionComposer } from '@refinitiv-ui/utils/collection.js';
 import { uuid } from '@refinitiv-ui/utils/uuid.js';
 
 import { getItemId } from '../../list/helpers/item-id.js';
 import { Renderer } from '../../list/renderer.js';
+import type { TreeItem } from '../elements/tree-item';
 import { CheckedState, TreeManager, TreeManagerMode } from '../managers/tree-manager.js';
 import type { TreeDataItem } from './types';
 
@@ -11,49 +14,59 @@ type RendererScope = {
   noRelation?: boolean;
 };
 
+export const createTreeRenderer = <T extends TreeDataItem = TreeDataItem>(
+  scope?: unknown
+): ((item: T, composer: CollectionComposer<T>, element?: HTMLElement) => HTMLElement) => {
+  /**
+   * Renderer key prefix, used in combination with item value to give unique id to each item
+   */
+  const key: string = uuid();
+
+  let manager: TreeManager<T>;
+  let currentMode: TreeManagerMode;
+  let currentComposer: CollectionComposer<T>;
+  return (
+    item: T,
+    composer: CollectionComposer<T>,
+    element = document.createElement('ef-tree-item')
+  ): HTMLElement => {
+    // cast type to element to not break List api.
+    const _element = element as TreeItem;
+    const multiple = !!scope && (scope as RendererScope).multiple === true;
+    const noRelation = !!scope && (scope as RendererScope).noRelation === true;
+    const mode = !multiple || !noRelation ? TreeManagerMode.RELATIONAL : TreeManagerMode.INDEPENDENT;
+
+    if (currentComposer !== composer || currentMode !== mode) {
+      currentMode = mode;
+      currentComposer = composer;
+      manager = new TreeManager(composer, mode);
+    }
+
+    _element.multiple = multiple;
+    _element.item = item;
+    _element.id = getItemId(key, item.value);
+    _element.depth = composer.getItemDepth(item);
+    _element.parent = composer.getItemChildren(item).length > 0;
+    _element.expanded = manager.isItemExpanded(item);
+    _element.checkedState =
+      !multiple && _element.parent ? CheckedState.UNCHECKED : manager.getItemCheckedState(item);
+    _element.icon = composer.getItemPropertyValue(item, 'icon') as string;
+    _element.label = composer.getItemPropertyValue(item, 'label') as string;
+    _element.disabled = composer.getItemPropertyValue(item, 'disabled') === true;
+    _element.readonly = composer.getItemPropertyValue(item, 'readonly') === true;
+    _element.highlighted = composer.getItemPropertyValue(item, 'highlighted') === true;
+
+    return _element;
+  };
+};
+
+const deprecationNotice = new DeprecationNotice(
+  'TreeRenderer is deprecated. Use createTreeRenderer instead.'
+);
+
 export class TreeRenderer extends Renderer {
-  constructor(scope?: unknown) {
-    /**
-     * Renderer key prefix, used in combination with item value to give unique id to each item
-     */
-    const key: string = uuid();
-
-    let manager: TreeManager<TreeDataItem>;
-    let currentMode: TreeManagerMode;
-    let currentComposer: CollectionComposer<TreeDataItem>;
-
-    super(
-      (
-        item: TreeDataItem,
-        composer: CollectionComposer<TreeDataItem>,
-        element = document.createElement('ef-tree-item')
-      ): HTMLElement => {
-        const multiple = !!scope && (scope as RendererScope).multiple === true;
-        const noRelation = !!scope && (scope as RendererScope).noRelation === true;
-        const mode = !multiple || !noRelation ? TreeManagerMode.RELATIONAL : TreeManagerMode.INDEPENDENT;
-
-        if (currentComposer !== composer || currentMode !== mode) {
-          currentMode = mode;
-          currentComposer = composer;
-          manager = new TreeManager(composer, mode);
-        }
-
-        element.multiple = multiple;
-        element.item = item;
-        element.id = getItemId(key, item.value);
-        element.depth = composer.getItemDepth(item);
-        element.parent = composer.getItemChildren(item).length > 0;
-        element.expanded = manager.isItemExpanded(item);
-        element.checkedState =
-          !multiple && element.parent ? CheckedState.UNCHECKED : manager.getItemCheckedState(item);
-        element.icon = composer.getItemPropertyValue(item, 'icon') as string;
-        element.label = composer.getItemPropertyValue(item, 'label') as string;
-        element.disabled = composer.getItemPropertyValue(item, 'disabled') === true;
-        element.readonly = composer.getItemPropertyValue(item, 'readonly') === true;
-        element.highlighted = composer.getItemPropertyValue(item, 'highlighted') === true;
-
-        return element;
-      }
-    );
+  constructor(context?: unknown) {
+    super(createTreeRenderer(context));
+    deprecationNotice.show();
   }
 }

--- a/packages/elements/src/tree/helpers/renderer.ts
+++ b/packages/elements/src/tree/helpers/renderer.ts
@@ -14,9 +14,7 @@ type RendererScope = {
   noRelation?: boolean;
 };
 
-export const createTreeRenderer = <T extends TreeDataItem = TreeDataItem>(
-  scope?: unknown
-) => {
+export const createTreeRenderer = <T extends TreeDataItem = TreeDataItem>(context?: unknown) => {
   /**
    * Renderer key prefix, used in combination with item value to give unique id to each item
    */
@@ -32,8 +30,8 @@ export const createTreeRenderer = <T extends TreeDataItem = TreeDataItem>(
   ): HTMLElement => {
     // cast type to element to not break List api.
     const _element = element as TreeItem;
-    const multiple = !!scope && (scope as RendererScope).multiple === true;
-    const noRelation = !!scope && (scope as RendererScope).noRelation === true;
+    const multiple = !!context && (context as RendererScope).multiple === true;
+    const noRelation = !!context && (context as RendererScope).noRelation === true;
     const mode = !multiple || !noRelation ? TreeManagerMode.RELATIONAL : TreeManagerMode.INDEPENDENT;
 
     if (currentComposer !== composer || currentMode !== mode) {

--- a/packages/elements/src/tree/helpers/renderer.ts
+++ b/packages/elements/src/tree/helpers/renderer.ts
@@ -16,7 +16,7 @@ type RendererScope = {
 
 export const createTreeRenderer = <T extends TreeDataItem = TreeDataItem>(
   scope?: unknown
-): ((item: T, composer: CollectionComposer<T>, element?: HTMLElement) => HTMLElement) => {
+) => {
   /**
    * Renderer key prefix, used in combination with item value to give unique id to each item
    */

--- a/packages/elements/src/tree/helpers/renderer.ts
+++ b/packages/elements/src/tree/helpers/renderer.ts
@@ -62,6 +62,9 @@ const deprecationNotice = new DeprecationNotice(
   'TreeRenderer is deprecated. Use createTreeRenderer instead.'
 );
 
+/**
+ * @deprecate Don't use this! It causes uncaught EvalError when using script-src 'self' CSP.
+ */
 export class TreeRenderer extends Renderer {
   constructor(context?: unknown) {
     super(createTreeRenderer(context));

--- a/packages/elements/src/tree/helpers/renderer.ts
+++ b/packages/elements/src/tree/helpers/renderer.ts
@@ -63,7 +63,7 @@ const deprecationNotice = new DeprecationNotice(
 );
 
 /**
- * @deprecate Don't use this! It causes uncaught EvalError when using script-src 'self' CSP.
+ * @deprecate TreeRenderer is deprecated. Use createTreeRenderer instead.
  */
 export class TreeRenderer extends Renderer {
   constructor(context?: unknown) {

--- a/packages/elements/src/tree/index.ts
+++ b/packages/elements/src/tree/index.ts
@@ -2,7 +2,7 @@ import type { TreeData, TreeDataItem } from './helpers/types';
 
 export * from './elements/tree.js';
 export * from './elements/tree-item.js';
-export { TreeRenderer } from './helpers/renderer.js';
+export { TreeRenderer, createTreeRenderer } from './helpers/renderer.js';
 export { TreeManager, TreeManagerMode, CheckedState } from './managers/tree-manager.js';
 
 export type { TreeData, TreeDataItem };


### PR DESCRIPTION
## Description

Uncaught EvalError deploying apps with Content-Security-Policy, affecting ef-combo-box and potentially list-related elements.

**Reproduce steps:**

1. Add ef-combo-box to index.html.
2. Apply <meta http-equiv="Content-Security-Policy"content="script-src 'self' [https://*.refinitiv.com](https://%2A.refinitiv.com/)">
3. Observe Uncaught EvalError.

Fixes # ([DME-2088](https://jira.refinitiv.com/browse/DME-2088))

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
