### PR TITLE
fix(datetime-picker): validate values for weekendsonly and weekdaysonly

### DIFF
--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -303,7 +303,7 @@ describe('datetime-picker/Value', function () {
       await elementUpdated(el);
       expect(el.error).to.be.equal(true);
     });
-    it('It must error when weekdays-only is set and values are not in weekday period with range mode', async function () {
+    it('It should error when weekdays-only is true and values are not in weekday period with range mode', async function () {
       const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
 
       el.values = ['2024-03-04', '2024-03-08'];

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -261,7 +261,7 @@ describe('datetime-picker/Value', function () {
       await elementUpdated(el);
       expect(el.error).to.be.equal(false);
     });
-    it('It must error when weekdays-only is set and value is not in weekday period', async function () {
+    it('It should error when weekdays-only is true and value is not in weekday period', async function () {
       const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
 
       el.value = '2024-03-01';

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -246,5 +246,89 @@ describe('datetime-picker/Value', function () {
       typeText(timePicker, '16:17:18');
       expect(el.value).to.equal('2020-04-21T16:17:18');
     });
+    it('It must error when weekends-only is set and value is not in weekend period', async function () {
+      const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
+
+      el.value = '2024-03-02';
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(false);
+
+      el.value = '2024-03-01';
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(true);
+
+      el.value = '2024-03-02';
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(false);
+    });
+    it('It must error when weekdays-only is set and value is not in weekday period', async function () {
+      const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
+
+      el.value = '2024-03-01';
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(false);
+
+      el.value = '2024-03-02';
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(true);
+
+      el.value = '2024-03-01';
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(false);
+    });
+    it('It must error when weekends-only is set and values are not in weekend period with range mode', async function () {
+      const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
+
+      el.values = ['2024-03-02', '2024-03-03'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(false);
+
+      el.values = ['2024-03-01', '2024-03-03'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(true);
+
+      el.values = ['2024-03-02', '2024-03-03'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(false);
+
+      el.values = ['2024-03-02', '2024-03-04'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(true);
+
+      el.values = ['2024-03-02', '2024-03-03'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(false);
+
+      el.values = ['2024-03-04', '2024-03-05'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(true);
+    });
+    it('It must error when weekdays-only is set and values are not in weekday period with range mode', async function () {
+      const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
+
+      el.values = ['2024-03-04', '2024-03-08'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(false);
+
+      el.values = ['2024-03-03', '2024-03-08'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(true);
+
+      el.values = ['2024-03-04', '2024-03-08'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(false);
+
+      el.values = ['2024-03-04', '2024-03-09'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(true);
+
+      el.values = ['2024-03-04', '2024-03-08'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(false);
+
+      el.values = ['2024-03-03', '2024-03-09'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(true);
+    });
   });
 });

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -276,7 +276,7 @@ describe('datetime-picker/Value', function () {
       await elementUpdated(el);
       expect(el.error).to.be.equal(false);
     });
-    it('It must error when weekends-only is set and values are not in weekend period with range mode', async function () {
+    it('It should error when weekends-only is true and values are not in weekend period with range mode', async function () {
       const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
 
       el.values = ['2024-03-02', '2024-03-03'];

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -376,6 +376,6 @@ describe('datetime-picker/Value', function () {
         'error state should return to false when both inputs value are valid'
       );
     });
-    // TODO: For now, we can't mock blur input to validate typing input by user
+    // TODO: add input validation test cases when the value update is originated from typing input
   });
 });

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -246,105 +246,131 @@ describe('datetime-picker/Value', function () {
       typeText(timePicker, '16:17:18');
       expect(el.value).to.equal('2020-04-21T16:17:18');
     });
-    it('It should error when weekends-only attribute is set and value is not in weekend period', async function () {
+    it('It should not error when weekends-only attribute is set and value is within weekend period', async function () {
       const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
-
       el.value = '2024-03-02';
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false, 'error state should be false when value is valid');
 
+      expect(el.error).to.be.equal(false, 'error state should be false when value is valid');
+    });
+    it('It should error when weekends-only attribute is set and value is not within weekend period', async function () {
+      const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
       el.value = '2024-03-01';
       await elementUpdated(el);
+
       expect(el.error).to.be.equal(true, 'error state should be true when value is invalid');
+    });
+    it('It should not error when weekends-only attribute is set and set value back to within weekend period', async function () {
+      const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
+      el.value = '2024-03-01';
+      await elementUpdated(el);
 
       el.value = '2024-03-02';
       await elementUpdated(el);
+
       expect(el.error).to.be.equal(false, 'error state should return to false when value is valid');
     });
-    it('It should error when weekdays-only attribute is set and value is not in weekday period', async function () {
+    it('It should not error when weekdays-only attribute is set and value is within weekdays period', async function () {
       const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
-
       el.value = '2024-03-01';
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false, 'error state should be false when value is valid');
 
+      expect(el.error).to.be.equal(false, 'error state should be false when value is valid');
+    });
+    it('It should error when weekdays-only attribute is set and value is not within weekdays period', async function () {
+      const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
       el.value = '2024-03-02';
       await elementUpdated(el);
+
       expect(el.error).to.be.equal(true, 'error state should be true when value is invalid');
+    });
+    it('It should not error when weekdays-only attribute is set and set value back to within weekdays period', async function () {
+      const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
+      el.value = '2024-03-02';
+      await elementUpdated(el);
 
       el.value = '2024-03-01';
       await elementUpdated(el);
+
       expect(el.error).to.be.equal(false, 'error state should return to false when value is valid');
     });
-    it('It should error when weekends-only attribute is set and values are not in weekend period with range mode', async function () {
+    it('It should not error when weekends-only attribute is set and values are within weekends period with range mode', async function () {
       const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
-
       el.values = ['2024-03-02', '2024-03-03'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false, 'error state should be false when both values are valid');
 
+      expect(el.error).to.be.equal(false, 'error state should be false when both values are valid');
+    });
+    it('It should error when weekends-only attribute is set and from value is not within weekends period with range mode', async function () {
+      const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
       el.values = ['2024-03-01', '2024-03-03'];
       await elementUpdated(el);
+
       expect(el.error).to.be.equal(true, 'error state should be true when input from value is invalid');
-
-      el.values = ['2024-03-02', '2024-03-03'];
-      await elementUpdated(el);
-      expect(el.error).to.be.equal(
-        false,
-        'error state should return to false when input from value is valid'
-      );
-
+    });
+    it('It should error when weekends-only attribute is set and to value is not within weekends period with range mode', async function () {
+      const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
       el.values = ['2024-03-02', '2024-03-04'];
       await elementUpdated(el);
+
       expect(el.error).to.be.equal(true, 'error state should be true when input to value is invalid');
-
-      el.values = ['2024-03-02', '2024-03-03'];
-      await elementUpdated(el);
-      expect(el.error).to.be.equal(false, 'error state should return to false when input to value is valid');
-
+    });
+    it('It should error when weekends-only attribute is set and values are not within weekends period with range mode', async function () {
+      const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
       el.values = ['2024-03-04', '2024-03-05'];
       await elementUpdated(el);
+
       expect(el.error).to.be.equal(true, 'error state should be true when both inputs value are invalid');
+    });
+    it('It should not error when weekends-only attribute is set and set values back to within weekends period with range mode', async function () {
+      const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
+      el.values = ['2024-03-04', '2024-03-05'];
+      await elementUpdated(el);
 
       el.values = ['2024-03-02', '2024-03-03'];
       await elementUpdated(el);
+
       expect(el.error).to.be.equal(
         false,
         'error state should return to false when both inputs value are valid'
       );
     });
-    it('It should error when weekdays-only attribute is set and values are not in weekday period with range mode', async function () {
+    it('It should not error when weekdays-only attribute is set and values are within weekdays period with range mode', async function () {
       const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
-
       el.values = ['2024-03-04', '2024-03-08'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false, 'error state should be false when both values are valid');
 
+      expect(el.error).to.be.equal(false, 'error state should be false when both values are valid');
+    });
+    it('It should error when weekdays-only attribute is set and from value is not within weekdays period with range mode', async function () {
+      const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
       el.values = ['2024-03-03', '2024-03-08'];
       await elementUpdated(el);
+
       expect(el.error).to.be.equal(true, 'error state should be true when input from value is invalid');
-
-      el.values = ['2024-03-04', '2024-03-08'];
-      await elementUpdated(el);
-      expect(el.error).to.be.equal(
-        false,
-        'error state should return to false when input from value is valid'
-      );
-
+    });
+    it('It should error when weekdays-only attribute is set and to value is not within weekdays period with range mode', async function () {
+      const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
       el.values = ['2024-03-04', '2024-03-09'];
       await elementUpdated(el);
+
       expect(el.error).to.be.equal(true, 'error state should be true when input to value is invalid');
-
-      el.values = ['2024-03-04', '2024-03-08'];
-      await elementUpdated(el);
-      expect(el.error).to.be.equal(false, 'error state should return to false when input to value is valid');
-
+    });
+    it('It should error when weekdays-only attribute is set and values are not within weekdays period with range mode', async function () {
+      const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
       el.values = ['2024-03-03', '2024-03-09'];
       await elementUpdated(el);
+
       expect(el.error).to.be.equal(true, 'error state should be true when both inputs value are invalid');
+    });
+    it('It should not error when weekdays-only attribute is set and set values back to within weekdays period with range mode', async function () {
+      const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
+      el.values = ['2024-03-03', '2024-03-09'];
+      await elementUpdated(el);
 
       el.values = ['2024-03-04', '2024-03-08'];
       await elementUpdated(el);
+
       expect(el.error).to.be.equal(
         false,
         'error state should return to false when both inputs value are valid'

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -246,89 +246,109 @@ describe('datetime-picker/Value', function () {
       typeText(timePicker, '16:17:18');
       expect(el.value).to.equal('2020-04-21T16:17:18');
     });
-    it('It should error when weekends-only is true and value is not in weekend period', async function () {
+    it('It should error when weekends-only attribute is set and value is not in weekend period', async function () {
       const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
 
       el.value = '2024-03-02';
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false);
+      expect(el.error).to.be.equal(false, 'error state should be false when value is valid');
 
       el.value = '2024-03-01';
       await elementUpdated(el);
-      expect(el.error).to.be.equal(true);
+      expect(el.error).to.be.equal(true, 'error state should be true when value is invalid');
 
       el.value = '2024-03-02';
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false);
+      expect(el.error).to.be.equal(false, 'error state should return to false when value is valid');
     });
-    it('It should error when weekdays-only is true and value is not in weekday period', async function () {
+    it('It should error when weekdays-only attribute is set and value is not in weekday period', async function () {
       const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
 
       el.value = '2024-03-01';
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false);
+      expect(el.error).to.be.equal(false, 'error state should be false when value is valid');
 
       el.value = '2024-03-02';
       await elementUpdated(el);
-      expect(el.error).to.be.equal(true);
+      expect(el.error).to.be.equal(true, 'error state should be true when value is invalid');
 
       el.value = '2024-03-01';
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false);
+      expect(el.error).to.be.equal(false, 'error state should return to false when value is valid');
     });
-    it('It should error when weekends-only is true and values are not in weekend period with range mode', async function () {
+    it('It should error when weekends-only attribute is set and values are not in weekend period with range mode', async function () {
       const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
 
       el.values = ['2024-03-02', '2024-03-03'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false);
+      expect(el.error).to.be.equal(false, 'error state should be false when both values are valid');
 
       el.values = ['2024-03-01', '2024-03-03'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(true);
+      expect(el.error).to.be.equal(true, 'error state should be true when input from value is invalid');
 
       el.values = ['2024-03-02', '2024-03-03'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false);
+      expect(el.error).to.be.equal(
+        false,
+        'error state should return to false when input from value is valid'
+      );
 
       el.values = ['2024-03-02', '2024-03-04'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(true);
+      expect(el.error).to.be.equal(true, 'error state should be true when input to value is invalid');
 
       el.values = ['2024-03-02', '2024-03-03'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false);
+      expect(el.error).to.be.equal(false, 'error state should return to false when input to value is valid');
 
       el.values = ['2024-03-04', '2024-03-05'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(true);
+      expect(el.error).to.be.equal(true, 'error state should be true when both inputs value are invalid');
+
+      el.values = ['2024-03-02', '2024-03-03'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(
+        false,
+        'error state should return to false when both inputs value are valid'
+      );
     });
-    it('It should error when weekdays-only is true and values are not in weekday period with range mode', async function () {
+    it('It should error when weekdays-only attribute is set and values are not in weekday period with range mode', async function () {
       const el = await fixture('<ef-datetime-picker weekdays-only lang="en-gb" opened></ef-datetime-picker>');
 
       el.values = ['2024-03-04', '2024-03-08'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false);
+      expect(el.error).to.be.equal(false, 'error state should be false when both values are valid');
 
       el.values = ['2024-03-03', '2024-03-08'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(true);
+      expect(el.error).to.be.equal(true, 'error state should be true when input from value is invalid');
 
       el.values = ['2024-03-04', '2024-03-08'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false);
+      expect(el.error).to.be.equal(
+        false,
+        'error state should return to false when input from value is valid'
+      );
 
       el.values = ['2024-03-04', '2024-03-09'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(true);
+      expect(el.error).to.be.equal(true, 'error state should be true when input to value is invalid');
 
       el.values = ['2024-03-04', '2024-03-08'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(false);
+      expect(el.error).to.be.equal(false, 'error state should return to false when input to value is valid');
 
       el.values = ['2024-03-03', '2024-03-09'];
       await elementUpdated(el);
-      expect(el.error).to.be.equal(true);
+      expect(el.error).to.be.equal(true, 'error state should be true when both inputs value are invalid');
+
+      el.values = ['2024-03-04', '2024-03-08'];
+      await elementUpdated(el);
+      expect(el.error).to.be.equal(
+        false,
+        'error state should return to false when both inputs value are valid'
+      );
     });
   });
 });

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -376,5 +376,6 @@ describe('datetime-picker/Value', function () {
         'error state should return to false when both inputs value are valid'
       );
     });
+    // TODO: For now, we can't mock blur input to validate typing input by user
   });
 });

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -246,7 +246,7 @@ describe('datetime-picker/Value', function () {
       typeText(timePicker, '16:17:18');
       expect(el.value).to.equal('2020-04-21T16:17:18');
     });
-    it('It must error when weekends-only is set and value is not in weekend period', async function () {
+    it('It should error when weekends-only is true and value is not in weekend period', async function () {
       const el = await fixture('<ef-datetime-picker weekends-only lang="en-gb" opened></ef-datetime-picker>');
 
       el.value = '2024-03-02';

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -29,6 +29,7 @@ import {
   isBefore,
   isValidDate,
   isValidDateTime,
+  isWeekend,
   parse,
   subMonths
 } from '@refinitiv-ui/utils/date.js';
@@ -1116,11 +1117,45 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
   }
 
   /**
+   * Check if `values` are within the weekend period or not
+   * @returns false if `values` are not within the weekend period
+   */
+  private isWeekendsOnly(): boolean {
+    for (let i = 0; i < this.values.length; i += 1) {
+      if (this.weekendsOnly && !isWeekend(this.values[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Check if `values` are within the weekday period or not
+   * @returns false if `values` are not within the weekday period
+   */
+  private isWeekdaysOnly(): boolean {
+    for (let i = 0; i < this.values.length; i += 1) {
+      if (this.weekdaysOnly && isWeekend(this.values[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
    * Check if datetime picker has an error
    * @returns true if error
    */
   private hasError(): boolean {
-    return !(this.isValidFormat() && this.isValueWithinMinMax() && this.isFromBeforeTo());
+    return !(
+      this.isValidFormat() &&
+      this.isValueWithinMinMax() &&
+      this.isFromBeforeTo() &&
+      this.isWeekendsOnly() &&
+      this.isWeekdaysOnly()
+    );
   }
 
   /**

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -1120,7 +1120,7 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
    * Check if `values` correspond to dates that are allowed within the conditions of weekdays or weekends
    * @returns false if `values` don't correspond to dates that are allowed within the conditions of weekdays or weekends.
    */
-  private isAllowSelectedDay(): boolean {
+  private isValidDay(): boolean {
     for (const value of this.values) {
       if (this.weekdaysOnly && isWeekend(value)) {
         return false;
@@ -1142,7 +1142,7 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
       this.isValidFormat() &&
       this.isValueWithinMinMax() &&
       this.isFromBeforeTo() &&
-      this.isAllowSelectedDay()
+      this.isValidDay()
     );
   }
 

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -1117,30 +1117,18 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
   }
 
   /**
-   * Check if `values` are within the weekend period or not
-   * @returns false if `values` are not within the weekend period
+   * Check if `values` correspond to dates that are allowed within the conditions of weekdays or weekends
+   * @returns false if `values` don't correspond to dates that are allowed within the conditions of weekdays or weekends.
    */
-  private isWeekendsOnly(): boolean {
-    for (let i = 0; i < this.values.length; i += 1) {
-      if (this.weekendsOnly && !isWeekend(this.values[i])) {
+  private isAllowSelectedDay(): boolean {
+    for (const value of this.values) {
+      if (this.weekdaysOnly && isWeekend(value)) {
+        return false;
+      }
+      if (this.weekendsOnly && !isWeekend(value)) {
         return false;
       }
     }
-
-    return true;
-  }
-
-  /**
-   * Check if `values` are within the weekday period or not
-   * @returns false if `values` are not within the weekday period
-   */
-  private isWeekdaysOnly(): boolean {
-    for (let i = 0; i < this.values.length; i += 1) {
-      if (this.weekdaysOnly && isWeekend(this.values[i])) {
-        return false;
-      }
-    }
-
     return true;
   }
 
@@ -1153,8 +1141,7 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
       this.isValidFormat() &&
       this.isValueWithinMinMax() &&
       this.isFromBeforeTo() &&
-      this.isWeekendsOnly() &&
-      this.isWeekdaysOnly()
+      this.isAllowSelectedDay()
     );
   }
 

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -1129,6 +1129,7 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
         return false;
       }
     }
+
     return true;
   }
 

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -597,7 +597,9 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
       (changedProperties.has('_values') && changedProperties.get('_values') !== undefined) ||
       (changedProperties.has('min') && changedProperties.get('min') !== undefined) ||
       (changedProperties.has('max') && changedProperties.get('max') !== undefined) ||
-      (changedProperties.has('showSeconds') && changedProperties.get('showSeconds') !== undefined)
+      (changedProperties.has('showSeconds') && changedProperties.get('showSeconds') !== undefined) ||
+      (changedProperties.has('weekdaysOnly') && changedProperties.get('weekdaysOnly') !== undefined) ||
+      (changedProperties.has('weekendsOnly') && changedProperties.get('weekendsOnly') !== undefined)
     ) {
       return true;
     }


### PR DESCRIPTION
## Description

Previously, datetime-picker was not validating values that within condition of `weekends-only` and `weekdays-only`. To fix this issue, we just simply add validation of `weekdays-only` and `weekends-only` to `validateInput` method. This method will be calling every time that input has change.

Expected behavior of this change:
1. `weekdaysOnly` or `weekendsOnly` behavior should be same to min/max property.
2. error property should be true if user select disabled dates through typing or setting value via API.
3. UI still show selected cell but control also show error state (red border)
4. Incorrect value is still set to `value`. It's now assume that this will be handle by app e.g. to revert the value back or to set value to empty, etc.

Fixes # (issue)
DME-9462

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
