### PR TITLE
docs: improve accessibility section including promoting <label for> labeling method

### DIFF
--- a/documents/src/pages/elements/email-field.md
+++ b/documents/src/pages/elements/email-field.md
@@ -544,7 +544,17 @@ emailField?.addEventListener("icon-click", () => {
 
 `ef-email-field` is assigned `role="textbox"`. States such as `disabled` or `readonly` are programmatically updated to match the element’s visual state.
 
-`ef-email-field` has already managed the role and states but you must ensure that the element has associated label by using `placeholder`, `aria-label`, `aria-labelledby` or `label[for="<element.id>"]`
+`ef-email-field` has already managed the role and states but you must ensure that the element has associated label by using `label[for="<element.id>"],``aria-label` or `aria-labelledby`.
+
+`placeholder` should be used for supporting information only.
+
+```html
+<label for="email">Email</label>
+<ef-email-field
+  id="email"
+  placeholder="Enter your email">
+</ef-email-field>
+```
 
 ```html
 <ef-email-field 
@@ -552,17 +562,11 @@ emailField?.addEventListener("icon-click", () => {
   placeholder="Enter your email">
 </ef-email-field>
 ```
+
 ```html
 <label id="email">Email</label>
 <ef-email-field 
   aria-labelledby="email"
-  placeholder="Enter your email">
-</ef-email-field>
-```
-```html
-<label for="email">Email</label>
-<ef-email-field
-  id="email"
   placeholder="Enter your email">
 </ef-email-field>
 ```

--- a/documents/src/pages/elements/email-field.md
+++ b/documents/src/pages/elements/email-field.md
@@ -102,7 +102,7 @@ emailField?.addEventListener("value-changed", (event) => {
 ## Input validation
 `ef-email-field` has validation logic similar to a [native input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email). When a user types an invalid value into the control, error style will be shown to notify the user.
 
-You can call `reportValidity()` to trigger the validation anytime and it will set error style if input is invalid. In case that the input is initialised with an invalid value and you need to show the error style, you must call `reportValidity()` once the input is defined on the page.
+You can call `reportValidity()` to trigger the validation anytime and it will set error style if input is invalid. In case that the input is initially or programmatically set to an invalid value, you must call `reportValidity()` to show the error style. Make sure that the element has been defined before calling the method.
 
 Whenever input is invalid, the `error` attribute will be added to the element. You can use the `error` property to check whether input is currently in the error state or not.
 

--- a/documents/src/pages/elements/number-field.md
+++ b/documents/src/pages/elements/number-field.md
@@ -125,7 +125,7 @@ numberField?.addEventListener("value-changed", (event) => {
 ## Input validation
 `ef-number-field` has validation logic similar to a [native input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number). When a user types an invalid value into the control, error style will be shown to notify the user.
 
-You can call `reportValidity()` to trigger the validation anytime and it will set error style if input is invalid. In case that the input is initialised with an invalid value and you need to show the error style, you must call `reportValidity()` once the input is defined on the page.
+You can call `reportValidity()` to trigger the validation anytime and it will set error style if input is invalid. In case that the input is initially or programmatically set to an invalid value, you must call `reportValidity()` to show the error style. Make sure that the element has been defined before calling the method.
 
 Whenever input is invalid, the `error` attribute will be added to the element. You can use the `error` property to check whether input is currently in the error state or not.
 

--- a/documents/src/pages/elements/number-field.md
+++ b/documents/src/pages/elements/number-field.md
@@ -402,9 +402,19 @@ numberField.addEventListener("input", () => {
 ## Accessibility
 ::a11y-intro::
 
-`ef-number-field` is assigned `role="spinbutton"`. States such as `disabled` or `readonly` are programmatically updated to match the element’s visual state. 
+`ef-number-field` is assigned `role="spinbutton"`. States such as `disabled` or `readonly` are programmatically updated to match the element’s visual state.
 
-`ef-number-field` has already managed the role and states but you must ensure that the element has associated label by using `placeholder`, `aria-label`, `aria-labelledby` or `label[for="<element.id>"]`
+`ef-number-field` has already managed the role and states but you must ensure that the element has associated label by using `label[for="<element.id>"]`, `aria-label` or `aria-labelledby`.
+
+`placeholder` should  be used for supporting information only.
+
+```html
+<label for="total">Total items</label>
+<ef-number-field
+  id="total"
+  placeholder="Enter total items">
+</ef-number-field>
+```
 
 ```html
 <ef-number-field 
@@ -412,17 +422,11 @@ numberField.addEventListener("input", () => {
   placeholder="Enter total items">
 </ef-number-field>
 ```
+
 ```html
 <label id="total">Total items</label>
 <ef-number-field 
   aria-labelledby="total"
-  placeholder="Enter total items">
-</ef-number-field>
-```
-```html
-<label for="total">Total items</label>
-<ef-number-field
-  id="total"
   placeholder="Enter total items">
 </ef-number-field>
 ```

--- a/documents/src/pages/elements/password-field.md
+++ b/documents/src/pages/elements/password-field.md
@@ -162,7 +162,7 @@ passwordField?.addEventListener("value-changed", (event) => {
 ## Input validation
 `ef-password-field` has validation logic similar to a [native input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password). When a user types an invalid value into the control, error style will be shown to notify the user.
 
-You can call `reportValidity()` to trigger the validation anytime and it will set error style if input is invalid. In case that the input is initialised with an invalid value and you need to show the error style, you must call `reportValidity()` once the input is defined on the page.
+You can call `reportValidity()` to trigger the validation anytime and it will set error style if input is invalid. In case that the input is initially or programmatically set to an invalid value, you must call `reportValidity()` to show the error style. Make sure that the element has been defined before calling the method.
 
 Whenever input is invalid, the `error` attribute will be added to the element. You can use the `error` property to check whether input is currently in the error state or not.
 

--- a/documents/src/pages/elements/password-field.md
+++ b/documents/src/pages/elements/password-field.md
@@ -514,7 +514,17 @@ confirmPassword.addEventListener("input", inputHandler);
 
 `ef-password-field` is assigned  `role="textbox"`. States such as `disabled` and `pressed` are updated to match the visual state of the Password Field element and its “Show password” button. The password recommendation can be communicated to screen readers through a live region whenever the context changes.
 
-`ef-password-field` has already managed the role and states but you must ensure that the element has associated label by using `placeholder`, `aria-label`, `aria-labelledby` or `label[for="<element.id>"]`
+`ef-password-field` has already managed the role and states but you must ensure that the element has associated label by using `label[for="<element.id>"]`, `aria-label`, `aria-labelledby`.
+
+`placeholder` should be used for supporting information only.
+
+```html
+<label for="password">Password</label>
+<ef-password-field
+  id="password"
+  placeholder="Enter your password">
+</ef-password-field>
+```
 
 ```html
 <ef-password-field 
@@ -522,17 +532,11 @@ confirmPassword.addEventListener("input", inputHandler);
   placeholder="Enter your password">
 </ef-password-field>
 ```
+
 ```html
 <label id="password">Password</label>
 <ef-password-field 
   aria-labelledby="password"
-  placeholder="Enter your password">
-</ef-password-field>
-```
-```html
-<label for="password">Password</label>
-<ef-password-field
-  id="password"
   placeholder="Enter your password">
 </ef-password-field>
 ```

--- a/documents/src/pages/elements/search-field.md
+++ b/documents/src/pages/elements/search-field.md
@@ -91,7 +91,7 @@ searchField?.addEventListener("value-changed", (event) => {
 ## Input validation
 `ef-search-field` has validation logic similar to a [native input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search). When a user types an invalid value into the control, error style will be shown to notify the user.
 
-You can call `reportValidity()` to trigger the validation anytime and it will set error style if input is invalid. In case that the input is initialised with an invalid value and you need to show the error style, you must call `reportValidity()` once the input is defined on the page.
+You can call `reportValidity()` to trigger the validation anytime and it will set error style if input is invalid. In case that the input is initially or programmatically set to an invalid value, you must call `reportValidity()` to show the error style. Make sure that the element has been defined before calling the method.
 
 Whenever input is invalid, the `error` attribute will be added to the element. You can use the `error` property to check whether input is currently in the error state or not.
 

--- a/documents/src/pages/elements/search-field.md
+++ b/documents/src/pages/elements/search-field.md
@@ -477,7 +477,17 @@ searchField.addEventListener("value-changed", (event) => {
 
 `ef-search-field` is assigned `role="textbox"`. States such as `disabled` or `readonly` are programmatically updated to match the element’s visual state. Dynamic updates such as a validation message are communicated to screen readers through a live region.
 
-`ef-search-field` has managed the role and states but you must ensure that the element has associated label by using `placeholder`, `aria-label`, `aria-labelledby` or `label[for="<element.id>"]`
+`ef-search-field` has managed the role and states but you must ensure that the element has associated label by using `label[for="<element.id>"]`, `aria-label` or `aria-labelledby`.
+
+`placeholder` should be used for supporting information only.
+
+```html
+<label for="keyword">Search</label>
+<ef-search-field
+  id="keyword"
+  placeholder="Enter word to search">
+</ef-search-field>
+```
 
 ```html
 <ef-search-field 
@@ -485,17 +495,11 @@ searchField.addEventListener("value-changed", (event) => {
   placeholder="Enter word to search">
 </ef-search-field>
 ```
+
 ```html
 <label id="keyword">Search</label>
 <ef-search-field 
   aria-labelledby="keyword"
-  placeholder="Enter word to search">
-</ef-search-field>
-```
-```html
-<label for="keyword">Search</label>
-<ef-search-field
-  id="keyword"
   placeholder="Enter word to search">
 </ef-search-field>
 ```

--- a/documents/src/pages/elements/text-field.md
+++ b/documents/src/pages/elements/text-field.md
@@ -532,11 +532,19 @@ feedback.addEventListener("icon-click", (e) => {
 
 `ef-text-field` is assigned `role="textbox"`. States such as `disabled` or `readonly` are programmatically updated to match the element’s visual state.
 
-`ef-text-field` has already managed the role and states but you must ensure that the element has associated label by using `aria-label`, `aria-labelledby` or `label[for="<element.id>"]`.
+`ef-text-field` has already managed the role and states but you must ensure that the element has associated label by using `label[for="<element.id>"]`, `aria-label` or `aria-labelledby`.
 
-`placeholder` attributes should not be used as a label. Use `placeholder` for supporting information only.
+`placeholder` should be used for supporting information only.
 
 If there is an element displaying error of `ef-text-field`, `aria-describedby` should be added to the text field.
+
+```html
+<label for="name">Full Name</label>
+<ef-text-field
+  id="name"
+  placeholder="Your name as shown on your passport">
+</ef-text-field>
+```
 
 ```html
 <ef-text-field 
@@ -549,14 +557,6 @@ If there is an element displaying error of `ef-text-field`, `aria-describedby` s
 <label id="name">Full Name</label>
 <ef-text-field 
   aria-labelledby="name"
-  placeholder="Your name as shown on your passport">
-</ef-text-field>
-```
-
-```html
-<label for="name">Full Name</label>
-<ef-text-field
-  id="name"
   placeholder="Your name as shown on your passport">
 </ef-text-field>
 ```

--- a/documents/src/pages/elements/text-field.md
+++ b/documents/src/pages/elements/text-field.md
@@ -91,7 +91,7 @@ textField?.addEventListener("value-changed", (event) => {
 ## Input validation
 `ef-text-field` has validation logic similar to a [native input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text). When a user types an invalid value into the control, error style will be shown to notify the user.
 
-You can call `reportValidity()` to trigger the validation anytime and it will set error style if input is invalid. In case that the input is initialised with an invalid value and you need to show the error style, you must call `reportValidity()` once the input is defined on the page.
+You can call `reportValidity()` to trigger the validation anytime and it will set error style if input is invalid. In case that the input is initially or programmatically set to an invalid value, you must call `reportValidity()` to show the error style. Make sure that the element has been defined before calling the method.
 
 Whenever input is invalid, the `error` attribute will be added to the element. You can use the `error` property to check whether input is currently in the error state or not.
 


### PR DESCRIPTION
## Description

* clarify that error state update won't be triggered via programmatic value update
* promote <label for> pattern for form control labelling

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
