### PR TITLE
fix(core): prevent error notice when define duplicate custom element into the registry

### DIFF
--- a/packages/core/__test__/elements/ControlElement.test.js
+++ b/packages/core/__test__/elements/ControlElement.test.js
@@ -1,8 +1,16 @@
-import { elementUpdated, expect, fixture, html, oneEvent, triggerFocusFor } from '@refinitiv-ui/test-helpers';
+import {
+  elementUpdated,
+  expect,
+  fixture,
+  html,
+  nextFrame,
+  oneEvent,
+  triggerFocusFor
+} from '@refinitiv-ui/test-helpers';
 
 import { customElement } from '../../lib/decorators/custom-element.js';
 import { ControlElement } from '../../lib/elements/ControlElement.js';
-import { asyncFrames, elementUpdatedWithAsyncFrames, isChrome } from '../helper.js';
+import { elementUpdatedWithAsyncFrames, isChrome } from '../helper.js';
 
 const MOCKED_COMPARE_LENGTH_VALUE = 12;
 
@@ -239,7 +247,7 @@ describe('TestControlElement', function () {
         const el = await fixture('<control-element-test autofocus></control-element-test>');
         await elementUpdated(el);
 
-        await asyncFrames();
+        await nextFrame(2);
 
         expect(el.autofocus).to.equal(true, 'property "autofocus" should be setted');
         expect(el.getAttribute('autofocus')).to.equal('', 'attribute "autofocus" should equal empty string');
@@ -781,7 +789,7 @@ describe('TestControlElement', function () {
         expect(blurEvent.type).to.equal('blur', 'blur event should be fired on disabled set to true');
 
         expect(el.disabled).to.equal(true, 'property disabled should be equal true');
-        await asyncFrames();
+        await nextFrame(2);
         expect(el.hasAttribute('focused')).to.equal(
           false,
           'element attribute focused should be set to false when disabled'

--- a/packages/core/__test__/elements/ResponsiveElement.test.js
+++ b/packages/core/__test__/elements/ResponsiveElement.test.js
@@ -1,10 +1,9 @@
-import { expect, fixture, html, oneEvent } from '@refinitiv-ui/test-helpers';
+import { expect, fixture, html, nextFrame, oneEvent } from '@refinitiv-ui/test-helpers';
 import { isSafari } from '@refinitiv-ui/utils';
 
 import { customElement } from '../../lib/decorators/custom-element.js';
 import { ResponsiveElement } from '../../lib/elements/ResponsiveElement.js';
 import { css } from '../../lib/index.js';
-import { asyncFrames } from '../helper.js';
 
 class ResponsiveElementTest extends ResponsiveElement {
   static get styles() {
@@ -45,7 +44,7 @@ describe('TestResponsiveElement', function () {
       this.skip();
     }
     const element = await fixture('<responsive-element-test></responsive-element-test>');
-    await asyncFrames();
+    await nextFrame(2);
 
     setTimeout(() => {
       element.style.width = '100px';
@@ -61,7 +60,7 @@ describe('TestResponsiveElement', function () {
 
   it('Test resized callback', async function () {
     const element = await fixture('<responsive-element-test></responsive-element-test>');
-    await asyncFrames();
+    await nextFrame(2);
 
     let updatedSize = { width: null, height: null };
 
@@ -73,7 +72,7 @@ describe('TestResponsiveElement', function () {
       element.style.width = '100px';
     });
 
-    await asyncFrames();
+    await nextFrame(2);
 
     expect(updatedSize.width).to.equal(100, 'width was not set from callback');
     expect(updatedSize.height).to.equal(0, 'height was not set from callback');

--- a/packages/core/__test__/helper.js
+++ b/packages/core/__test__/helper.js
@@ -2,20 +2,16 @@ import { elementUpdated, expect, nextFrame } from '@refinitiv-ui/test-helpers';
 
 const data = {
   errorCount: 0,
-  errorMessage: ''
+  errorMessage: '',
+  errorObject: undefined
 };
 
 let oldHandler;
 
-export const asyncFrames = async () => {
-  await nextFrame();
-  await nextFrame();
-};
-
 export const elementUpdatedWithAsyncFrames = async (element) => {
   await elementUpdated(element);
 
-  await asyncFrames();
+  await nextFrame(2);
 };
 
 const checkNoGlobalError = () => {
@@ -26,6 +22,7 @@ const checkNoGlobalError = () => {
 const errorHandler = (msg, url, line, col, error) => {
   data.errorCount += 1;
   data.errorMessage = error.message;
+  data.errorObject = error;
   return true;
 };
 
@@ -35,13 +32,14 @@ export const mockCssString = ':host { margin: 0; }';
 beforeEach(() => {
   data.errorCount = 0;
   data.errorMessage = '';
+  data.errorInstance = undefined;
 
   oldHandler = window.onerror;
   window.onerror = errorHandler;
 });
 
 afterEach(async () => {
-  await asyncFrames();
+  await nextFrame(2);
 
   window.onerror = oldHandler;
 
@@ -52,9 +50,12 @@ export const getErrors = () => {
   return Object.assign({}, data);
 };
 
-export const setErrors = (errorCount = 0, errorMessage = '') => {
+export const setErrors = (errorCount = 0, errorMessage = '', errorObject = undefined) => {
   data.errorCount = errorCount;
   data.errorMessage = errorMessage;
+  data.errorObject = errorObject;
 };
 
 export const isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
+
+export const isLocalhost = /^(localhost|127\.0\.0\.1)$/.test(location.hostname);

--- a/packages/core/__test__/registries/CustomStyleRegistry.test.js
+++ b/packages/core/__test__/registries/CustomStyleRegistry.test.js
@@ -2,18 +2,8 @@ import { expect } from '@refinitiv-ui/test-helpers';
 
 import { DuplicateStyleError } from '../../lib/errors/DuplicateStyleError.js';
 import { CustomStyleRegistry } from '../../lib/registries/CustomStyleRegistry.js';
-import { mockCssString } from '../helper.js';
+import { isLocalhost, mockCssString } from '../helper.js';
 
-const duplicateStyleErrorMessage = `Only one theme file can be loaded per element
-
-[TestCustomStyleRegistry_2] has already been defined.
-
-Potential causes:
-1. You are trying to load a multiple variants of a theme
-2. You have loaded multiple or duplicate themes in your application bundle
-
-https://ui.refinitiv.com/kb/duplicate-styles
-`;
 describe('TestCustomStyleRegistry', function () {
   let testNum = 0;
   const baseName = 'TestCustomStyleRegistry_';
@@ -39,14 +29,17 @@ describe('TestCustomStyleRegistry', function () {
     expect(fetchedCssString).to.equal('');
   });
 
-  it('Test define twice same name', async function () {
+  it('Test define twice same name', function () {
     CustomStyleRegistry.define(testName, mockCssString);
 
-    try {
-      CustomStyleRegistry.define(testName, mockCssString);
-    } catch (error) {
-      expect(error).instanceOf(DuplicateStyleError);
-      await expect(error.message).to.equal(duplicateStyleErrorMessage);
+    if (isLocalhost) {
+      expect(() => {
+        CustomStyleRegistry.define(testName, mockCssString);
+      }).to.throw(DuplicateStyleError);
+    } else {
+      expect(() => {
+        CustomStyleRegistry.define(testName, mockCssString);
+      }).not.to.throw(DuplicateStyleError);
     }
   });
 });

--- a/packages/core/__test__/registries/NativeStyleRegistry.test.js
+++ b/packages/core/__test__/registries/NativeStyleRegistry.test.js
@@ -2,18 +2,8 @@ import { expect } from '@refinitiv-ui/test-helpers';
 
 import { DuplicateStyleError } from '../../lib/errors/DuplicateStyleError.js';
 import { NativeStyleRegistry } from '../../lib/registries/NativeStyleRegistry.js';
-import { mockCssString } from '../helper.js';
+import { isLocalhost, mockCssString } from '../helper.js';
 
-const duplicateStyleErrorMessage = `Only one theme file can be loaded per element
-
-[TestNativeStyleRegistry_2] has already been defined.
-
-Potential causes:
-1. You are trying to load a multiple variants of a theme
-2. You have loaded multiple or duplicate themes in your application bundle
-
-https://ui.refinitiv.com/kb/duplicate-styles
-`;
 describe('TestNativeStyleRegistry', function () {
   let testNum = 0;
   const baseName = 'TestNativeStyleRegistry_';
@@ -38,14 +28,17 @@ describe('TestNativeStyleRegistry', function () {
     expect(fetchedCssString).to.equal('');
   });
 
-  it('Test define twice same name', async function () {
+  it('Test define twice same name', function () {
     NativeStyleRegistry.define(testName, mockCssString);
 
-    try {
-      NativeStyleRegistry.define(testName, mockCssString);
-    } catch (error) {
-      expect(error).instanceOf(DuplicateStyleError);
-      await expect(error.message).to.equal(duplicateStyleErrorMessage);
+    if (isLocalhost) {
+      expect(() => {
+        NativeStyleRegistry.define(testName, mockCssString);
+      }).to.throw(DuplicateStyleError);
+    } else {
+      expect(() => {
+        NativeStyleRegistry.define(testName, mockCssString);
+      }).not.to.throw(DuplicateStyleError);
     }
   });
 

--- a/packages/core/__test__/utils/elementReady.test.js
+++ b/packages/core/__test__/utils/elementReady.test.js
@@ -56,7 +56,7 @@ describe('TestReady', function () {
     const { errorMessage, errorCount } = getErrors();
 
     expect(errorCount).to.equal(1, 'Error not thrown');
-    expect(errorMessage).to.equal('test', 'duplication error not thrown');
+    expect(errorMessage).to.equal('test', 'test error not thrown');
 
     setErrors();
   });

--- a/packages/core/__test__/utils/elementReady.test.js
+++ b/packages/core/__test__/utils/elementReady.test.js
@@ -1,7 +1,7 @@
-import { expect } from '@refinitiv-ui/test-helpers';
+import { expect, nextFrame } from '@refinitiv-ui/test-helpers';
 
 import { ready } from '../../lib/utils/elementReady.js';
-import { asyncFrames, getErrors, setErrors } from '../helper.js';
+import { getErrors, setErrors } from '../helper.js';
 
 describe('TestReady', function () {
   const baseName = 'TestReady_';
@@ -51,12 +51,12 @@ describe('TestReady', function () {
 
     expect(callbackCallCount).to.equal(1, 'First callback was not called before throw error');
 
-    await asyncFrames();
+    await nextFrame(2);
 
     const { errorMessage, errorCount } = getErrors();
 
-    expect(errorMessage).to.equal('test');
-    expect(errorCount).to.equal(1);
+    expect(errorCount).to.equal(1, 'Error not thrown');
+    expect(errorMessage).to.equal('test', 'duplication error not thrown');
 
     setErrors();
   });

--- a/packages/core/src/registries/CustomStyleRegistry.ts
+++ b/packages/core/src/registries/CustomStyleRegistry.ts
@@ -1,5 +1,6 @@
 import { DuplicateStyleError } from '../errors/DuplicateStyleError.js';
 import { ready } from '../utils/elementReady.js';
+import { isLocalhost } from '../utils/helpers.js';
 
 const register = new Map<string, string>();
 
@@ -16,8 +17,14 @@ export abstract class CustomStyleRegistry {
    */
   public static define(name: string, css: string): void {
     if (register.has(name)) {
-      throw new DuplicateStyleError(name);
+      if (isLocalhost) {
+        throw new DuplicateStyleError(name);
+      }
+      /* c8 ignore start */
+      return;
+      /* c8 ignore stop */
     }
+
     register.set(name, css);
     ready(name);
   }

--- a/packages/core/src/registries/NativeStyleRegistry.ts
+++ b/packages/core/src/registries/NativeStyleRegistry.ts
@@ -1,4 +1,5 @@
 import { DuplicateStyleError } from '../errors/DuplicateStyleError.js';
+import { isLocalhost } from '../utils/helpers.js';
 
 const register = new Map<string, string>();
 
@@ -15,8 +16,14 @@ export abstract class NativeStyleRegistry {
    */
   public static define(name: string, css: string): void {
     if (register.has(name)) {
-      throw new DuplicateStyleError(name);
+      if (isLocalhost) {
+        throw new DuplicateStyleError(name);
+      }
+      /* c8 ignore start */
+      return;
+      /* c8 ignore stop */
     }
+
     register.set(name, css);
     // Skip if style has empty content
     if (!css) {

--- a/packages/core/src/utils/helpers.ts
+++ b/packages/core/src/utils/helpers.ts
@@ -1,6 +1,9 @@
 import type { BasicElement } from '../elements/BasicElement';
 
 const BasicElementSymbol = Symbol('BasicElement');
+/* c8 ignore start */
+const isLocalhost = /^(localhost|127\.0\.0\.1)$/.test(location.hostname);
+/* c8 ignore stop */
 
 /**
  * Check if a passed node is of basic element.
@@ -12,4 +15,4 @@ const isBasicElement = (element: unknown): element is BasicElement => {
   return element instanceof HTMLElement && BasicElementSymbol in element.constructor;
 };
 
-export { BasicElementSymbol, isBasicElement };
+export { BasicElementSymbol, isBasicElement, isLocalhost };


### PR DESCRIPTION
## Description
To prevent element to throw error when custom element into registry on the production, we need to check environment before throw error to notice the developer.

Fixes # (issue)
DME-14858

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
