### PR TITLE
fix(icon, flag, utils): resolve performance issue when rendering a lot of icons

### DIFF
--- a/packages/elements/src/flag/index.ts
+++ b/packages/elements/src/flag/index.ts
@@ -155,7 +155,7 @@ export class Flag extends BasicElement {
    * @returns {void}
    */
   private setPrefix(): void {
-    if (!FlagLoader.isPrefixSet) {
+    if (FlagLoader.isPrefixPending) {
       const CDNPrefix = this.getComputedVariable('--cdn-prefix').replace(/^('|")|('|")$/g, '');
 
       FlagLoader.setCdnPrefix(CDNPrefix);

--- a/packages/elements/src/icon/__test__/icon.cdn-prefix.test.js
+++ b/packages/elements/src/icon/__test__/icon.cdn-prefix.test.js
@@ -1,0 +1,51 @@
+import sinon from 'sinon';
+
+import '@refinitiv-ui/elements/configuration';
+import '@refinitiv-ui/elements/icon';
+
+import '@refinitiv-ui/elemental-theme/light/ef-icon.js';
+import { expect, fixture } from '@refinitiv-ui/test-helpers';
+
+import {
+  checkRequestedUrl,
+  createFakeResponse,
+  generateUniqueName,
+  iconName,
+  responseConfigSuccess,
+  tickSvgSprite
+} from './helpers/helpers.js';
+
+describe('icon/cdn-prefix', function () {
+  let fetch;
+  beforeEach(function () {
+    fetch = sinon.stub(window, 'fetch');
+  });
+  afterEach(function () {
+    window.fetch.restore(); // remove stub
+  });
+  it('Should make a correct server request based on cdn prefix and the icon if icon is specified', async function () {
+    createFakeResponse(tickSvgSprite, responseConfigSuccess);
+    const uniqueIconName = generateUniqueName(iconName); // to avoid caching
+    const MockCDNPrefix = 'https://mock.cdn.com/icons/';
+    const el = await fixture(
+      `<ef-icon style="--cdn-prefix:'${MockCDNPrefix}'" icon="${uniqueIconName}"></ef-icon>`
+    );
+    const CDNPrefix = el.getComputedVariable('--cdn-prefix');
+    const expectedSrc = `${CDNPrefix}${uniqueIconName}.svg`;
+
+    expect(fetch.callCount).to.equal(1, 'Should make one request');
+    expect(checkRequestedUrl(fetch.args, expectedSrc)).to.equal(
+      true,
+      `Requested URL should be ${expectedSrc} for the icon ${uniqueIconName}`
+    );
+  });
+
+  it('Should contain cdn sprite prefix', async function () {
+    createFakeResponse(tickSvgSprite, responseConfigSuccess);
+    const uniqueIconName = generateUniqueName(iconName); // to avoid caching
+    const el = await fixture(`<ef-icon icon="${uniqueIconName}"></ef-icon>`);
+    const CDNPrefix = el.getComputedVariable('--cdn-sprite-prefix');
+
+    expect(CDNPrefix).to.not.equal('', 'CDN prefix should not be empty string');
+  });
+});

--- a/packages/elements/src/icon/__test__/icon.test.js
+++ b/packages/elements/src/icon/__test__/icon.test.js
@@ -8,10 +8,8 @@ import '@refinitiv-ui/elemental-theme/light/ef-icon.js';
 import { elementUpdated, expect, fixture } from '@refinitiv-ui/test-helpers';
 
 import {
-  checkRequestedUrl,
   createFakeResponse,
   createMockSrc,
-  generateUniqueName,
   iconName,
   isEqualSvg,
   responseConfigError,
@@ -169,35 +167,9 @@ describe('icon/Icon', function () {
         );
       });
 
-      it('Should cdn prefix exist', async function () {
-        createFakeResponse(tickSvgSprite, responseConfigSuccess);
-        const uniqueIconName = generateUniqueName(iconName); // to avoid caching
-        const el = await fixture(`<ef-icon icon="${uniqueIconName}"></ef-icon>`);
-        const CDNPrefix = el.getComputedVariable('--cdn-prefix');
-
-        expect(CDNPrefix, 'CDN prefix should exist to create the src based on the icon').to.exist;
-      });
-
       it('Should not make request for empty icon', async function () {
         await fixture('<ef-icon></ef-icon>');
         expect(fetch.callCount).to.equal(0, 'No request should be sent for empty icon');
-      });
-
-      it('Should make a correct server request based on cdn prefix and the icon if icon is specified', async function () {
-        createFakeResponse(tickSvgSprite, responseConfigSuccess);
-        const uniqueIconName = generateUniqueName(iconName); // to avoid caching
-        const MockCDNPrefix = 'https://mock.cdn.com/icons/';
-        const el = await fixture(
-          `<ef-icon style="--cdn-prefix:'${MockCDNPrefix}'" icon="${uniqueIconName}"></ef-icon>`
-        );
-        const CDNPrefix = el.getComputedVariable('--cdn-prefix');
-        const expectedSrc = `${CDNPrefix}${uniqueIconName}.svg`;
-
-        expect(fetch.callCount).to.equal(1, 'Should make one request');
-        expect(checkRequestedUrl(fetch.args, expectedSrc)).to.equal(
-          true,
-          `Requested URL should be ${expectedSrc} for the icon ${uniqueIconName}`
-        );
       });
     });
   });

--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -230,10 +230,7 @@ export class Icon extends BasicElement {
    * @returns {void}
    */
   private setPrefix(): void {
-    /**
-     * This prefix for individual icons allows supporting custom prefix of self-managed icons.
-     * One of the use case is building EFX components.
-     */
+    // This prefix for individual icons allows supporting custom prefix of self-managed icons.
     if (IconLoader.isPrefixPending) {
       const CDNPrefix = this.getComputedVariable('--cdn-prefix');
       IconLoader.setCdnPrefix(CDNPrefix);

--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -180,10 +180,10 @@ export class Icon extends BasicElement {
     const iconProperty = this._icon!;
     if (this.iconMap) {
       void this.loadAndRenderIcon(this.iconMap);
-    } else if (isUrl(iconProperty) || IconLoader.isPrefixSet) {
-      void this.loadAndRenderIcon(iconProperty);
-    } else {
+    } else if (!isUrl(iconProperty) && SpriteLoader.isPrefixResolved) {
       void this.loadAndRenderSpriteIcon(iconProperty);
+    } else {
+      void this.loadAndRenderIcon(iconProperty);
     }
   }
 
@@ -230,11 +230,11 @@ export class Icon extends BasicElement {
    * @returns {void}
    */
   private setPrefix(): void {
-    if (!IconLoader.isPrefixSet) {
+    if (IconLoader.isPrefixPending) {
       const CDNPrefix = this.getComputedVariable('--cdn-prefix');
       IconLoader.setCdnPrefix(CDNPrefix);
     }
-    if (!SpriteLoader.isPrefixSet) {
+    if (SpriteLoader.isPrefixPending) {
       const CDNSpritePrefix = this.getComputedVariable('--cdn-sprite-prefix');
       SpriteLoader.setCdnPrefix(CDNSpritePrefix);
     }

--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -230,10 +230,15 @@ export class Icon extends BasicElement {
    * @returns {void}
    */
   private setPrefix(): void {
+    /**
+     * This prefix for individual icons allows supporting custom prefix of self-managed icons.
+     * One of the use case is building EFX components.
+     */
     if (IconLoader.isPrefixPending) {
       const CDNPrefix = this.getComputedVariable('--cdn-prefix');
       IconLoader.setCdnPrefix(CDNPrefix);
     }
+
     if (SpriteLoader.isPrefixPending) {
       const CDNSpritePrefix = this.getComputedVariable('--cdn-sprite-prefix');
       SpriteLoader.setCdnPrefix(CDNSpritePrefix);

--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -180,10 +180,10 @@ export class Icon extends BasicElement {
     const iconProperty = this._icon!;
     if (this.iconMap) {
       void this.loadAndRenderIcon(this.iconMap);
-    } else if (!isUrl(iconProperty) && SpriteLoader.isPrefixResolved) {
-      void this.loadAndRenderSpriteIcon(iconProperty);
-    } else {
+    } else if (isUrl(iconProperty) || IconLoader.isPrefixResolved) {
       void this.loadAndRenderIcon(iconProperty);
+    } else {
+      void this.loadAndRenderSpriteIcon(iconProperty);
     }
   }
 

--- a/packages/utils/src/loader/cdn-loader.ts
+++ b/packages/utils/src/loader/cdn-loader.ts
@@ -17,7 +17,7 @@ export class CDNLoader {
   private cdnPrefix = new Deferred<string>();
 
   /**
-   * @returns {boolean} clarify whether the prefix has been resolved and ready to use or not.
+   * @returns {boolean} clarify whether the prefix has been resolved or not.
    */
   public get isPrefixResolved(): boolean {
     return this.cdnPrefix.isResolved();
@@ -38,7 +38,8 @@ export class CDNLoader {
 
   /**
    * Sets CDN prefix to load source.
-   * Resolves deferred promise with CDN prefix and sets src used to check whether prefix is already set or not.
+   * Resolves deferred promise with the provided CDN prefix.
+   * If the prefix is falsy, reject instead.
    * @param prefix - CDN prefix.
    * @returns {void}
    */

--- a/packages/utils/src/loader/cdn-loader.ts
+++ b/packages/utils/src/loader/cdn-loader.ts
@@ -44,6 +44,11 @@ export class CDNLoader {
    * @returns {void}
    */
   public setCdnPrefix(prefix: string): void {
+    /**
+     * CDN prefix comes from a value of CSS custom property.
+     * As this retrieval is expensive performance-wise,
+     * its value would be settled in a single call.
+     */
     if (prefix) {
       this.cdnPrefix.resolve(prefix);
     } else {

--- a/packages/utils/src/loader/cdn-loader.ts
+++ b/packages/utils/src/loader/cdn-loader.ts
@@ -46,7 +46,7 @@ export class CDNLoader {
     if (prefix) {
       this.cdnPrefix.resolve(prefix);
     } else {
-      this.cdnPrefix.reject('prefix is unavailable');
+      this.cdnPrefix.reject('');
     }
   }
 

--- a/packages/utils/src/loader/cdn-loader.ts
+++ b/packages/utils/src/loader/cdn-loader.ts
@@ -6,8 +6,6 @@ const FETCH_API_TIMEOUT = 300_000; /* 5 mins */
  * Caches and provides any load results, Loaded either by name from CDN or directly by URL.
  */
 export class CDNLoader {
-  private _isPrefixSet = false;
-
   /**
    * Internal response cache
    */
@@ -19,12 +17,18 @@ export class CDNLoader {
   private cdnPrefix = new Deferred<string>();
 
   /**
-   * @returns {boolean} clarify whether prefix has been set or not.
+   * @returns {boolean} clarify whether the prefix has been resolved and ready to use or not.
    */
-  public get isPrefixSet(): boolean {
-    return this._isPrefixSet;
+  public get isPrefixResolved(): boolean {
+    return this.cdnPrefix.isResolved();
   }
 
+  /**
+   * @returns {boolean} clarify whether the prefix is pending or not.
+   */
+  public get isPrefixPending(): boolean {
+    return this.cdnPrefix.isPending();
+  }
   /**
    * @returns promise, which will be resolved with CDN prefix, once set.
    */
@@ -41,7 +45,8 @@ export class CDNLoader {
   public setCdnPrefix(prefix: string): void {
     if (prefix) {
       this.cdnPrefix.resolve(prefix);
-      this._isPrefixSet = true;
+    } else {
+      this.cdnPrefix.reject('prefix is unavailable');
     }
   }
 

--- a/packages/utils/src/loader/deferred.ts
+++ b/packages/utils/src/loader/deferred.ts
@@ -19,7 +19,7 @@ export class Deferred<T> {
   private _promise: Promise<T> = new Promise<T>((resolve, reject) => {
     this._reject = reject;
     this._resolve = resolve;
-  });
+  }).catch((value: T) => value); /* prevent uncaught promise console error upon rejection */
 
   public get promise(): Promise<T> {
     return this._promise;

--- a/packages/utils/src/loader/svg-loader.ts
+++ b/packages/utils/src/loader/svg-loader.ts
@@ -5,7 +5,7 @@ import { CDNLoader } from './cdn-loader.js';
  * @param str String to test
  * @returns is URL
  */
-export const isUrl = (str: string): boolean => /^(?:https:\/{2}|\.?\/).*.svg/i.test(str);
+export const isUrl = (str: string): boolean => /^(?:https:\/{2}|\.?\/).*\.svg/i.test(str);
 
 /**
  * Checks a string to see if it's a base64 URL


### PR DESCRIPTION
## Description

improve large number of icons rendering performance by settling cdn prefix during its setter call. This prevents additional `getComputedStyle()` calls of Icon forcing style recalcuation.

Fixes https://jira.refinitiv.com/browse/DME-13581

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
