### PR TITLE
refactor(overlay): improve non-standard css zoom handling

### DIFF
--- a/documents/src/pages/elements/overlay.md
+++ b/documents/src/pages/elements/overlay.md
@@ -363,16 +363,14 @@ section {
 
 `ef-overlay` calculates `x` and `y` coordinates based on screen dimension and position target (if any). An overlay using `position: fixed` is removed from the normal document flow and is positioned relative to the initial containing block established by the viewport. The positioning algorithm assumes that overlay, viewport and positionTarget are located within the same coordinate system.
 
-However, there are exceptions when the positioning algorithm may behave differently, or may not work at all. According to [CSS Transforms Specs](https://www.w3.org/TR/css-transforms-1/#propdef-transform), if `transform`, `perspective` or `filter` properties are set to something other than `none`, then that ancestor behaves as the containing block. In addition, if the `zoom` property is set on anything other than the `html` or `body` tag, then the coordinate system will be different for different parts of the document, and the overlay may not be positioned correctly.
+However, there are exceptions when the positioning algorithm may behave differently, or may not work at all. According to [CSS Transforms Specs](https://www.w3.org/TR/css-transforms-1/#propdef-transform), if `transform`, `perspective` or `filter` properties are set to something other than `none`, then that ancestor behaves as the containing block with its own coordinate system. With different coordinate systems for different parts of the document, and the overlay may not be positioned correctly.
 
 While the above is true for most modern browsers, the actual implementation may differ between browsers and versions.
 
 Below is a brief summary of supported use cases.
 
-
 |   | CSS Property | Status | Notes |
 | - | ------------ | ------ | ----- |
-| ✓ | zoom | Partial Support | Property is only supported on `html` and `body` elements. |
 | ✓ | filter | Partial Support | Overlay position/size is relative to the _filter container_.<br/><br/>If filter is applied to `html` element, overlay size is not restricted by window size. |
 | ✓ | transform:translate<br/>transform:translate3d<br/> | Partial Support | Overlay position/size is relative to the _transform container_.<br/><br/>If transform is applied to `html` element, overlay size is not restricted by window size.<br/><br/>Translating z-axis is not supported. |
 | ✗ | transform:rotate<br/>transform:rotate3d | No Support | - |
@@ -381,6 +379,7 @@ Below is a brief summary of supported use cases.
 | ✗ | transform:skew | No Support | - |
 | ✗ | transform:perspective | No Support | - |
 | ✗ | perspective | No Support | - |
+| ✗ | zoom | No Support | - |
 
 ## Advanced attributes
 

--- a/packages/elements/src/overlay/managers/viewport-manager.ts
+++ b/packages/elements/src/overlay/managers/viewport-manager.ts
@@ -108,11 +108,11 @@ export class ViewportManager {
     // Firefox doesn't implement this property.
     // Safari does but zooming doesn't update this property value
 
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    // TODO: Remove @ts-ignore and re-test again when standardized zoom is implemented across major browsers and TypeScript, https://github.com/w3c/csswg-drafts/issues/5623
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    const zoom = document.body ? parseFloat(window.getComputedStyle(document.body).zoom) : 1;
+    // TODO: re-test again when standardized zoom is implemented across major browsers and TypeScript.
+    // https://github.com/w3c/csswg-drafts/issues/5623
+    const zoom = document.body
+      ? parseFloat(window.getComputedStyle(document.body).getPropertyValue('zoom')) || 1
+      : 1;
     const screenHeight = screenRect.height / zoom;
     const screenWidth = screenRect.width / zoom;
 

--- a/packages/elements/src/overlay/managers/viewport-manager.ts
+++ b/packages/elements/src/overlay/managers/viewport-manager.ts
@@ -100,16 +100,14 @@ export class ViewportManager {
 
     const screenRect = this.screenViewport.getBoundingClientRect();
 
-    // since screenViewport is applied on html element, it does not include body zoom
-    // Zoom is a legacy feature and must not be used by any means.
-    // Kept here for compatibility with old apps
-
-    // only Chromium-based browsers update css zoom property after using ctrl/cmd + (+) or (-)
-    // Firefox doesn't implement this property.
-    // Safari does but zooming doesn't update this property value
-
-    // TODO: re-test again when standardized zoom is implemented across major browsers and TypeScript.
-    // https://github.com/w3c/csswg-drafts/issues/5623
+    /**
+     * since screenViewport is applied on html element, it does not include body zoom.
+     * Zoom is a legacy feature and must not be used by any means.
+     * Kept here for compatibility with old apps.
+     *
+     * TODO: re-visit once the standardized zoom is implemented across major browsers.
+     * https://github.com/w3c/csswg-drafts/issues/5623
+     */
     const zoom = document.body
       ? parseFloat(window.getComputedStyle(document.body).getPropertyValue('zoom')) || 1
       : 1;


### PR DESCRIPTION
## Description

- refactor: remove @ts-ignore usage
- docs: remove zoom css property support from docs

Fixes # (issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
