### PR TITLE
fix(core): prevent error notice when define duplicate custom element into the registry

### DIFF
--- a/packages/core/__test__/decorators/CustomElement.test.js
+++ b/packages/core/__test__/decorators/CustomElement.test.js
@@ -4,7 +4,7 @@ import { customElement } from '../../lib/decorators/custom-element.js';
 import { DuplicateStyleError } from '../../lib/errors/DuplicateStyleError.js';
 import { BasicElement } from '../../lib/index.js';
 import { CustomStyleRegistry } from '../../lib/registries/CustomStyleRegistry.js';
-import { asyncFrames, getErrors, mockCssString, setErrors } from '../helper.js';
+import { getErrors, isLocalhost, mockCssString, setErrors } from '../helper.js';
 
 const duplicationMessage = `Only one version of a Custom Element can be registered in the browser
 
@@ -77,19 +77,27 @@ describe('TestCustomElement', function () {
 
     elementDefineFunction(MockBasicElement);
 
-    expect(() => {
-      elementDefineFunction(MockBasicElement);
-    }).to.throw(DuplicateStyleError);
+    if (isLocalhost) {
+      expect(() => {
+        elementDefineFunction(MockBasicElement);
+      }).to.throw(DuplicateStyleError);
+    } else {
+      expect(() => {
+        elementDefineFunction(MockBasicElement);
+      }).not.to.throw(DuplicateStyleError);
+    }
 
-    await asyncFrames();
-
-    await nextFrame();
-    await nextFrame();
+    await nextFrame(2);
 
     const { errorMessage, errorCount } = getErrors();
 
-    expect(errorCount).to.equal(1, 'Error not thrown');
-    expect(errorMessage).to.equal(duplicationMessage);
+    if (isLocalhost) {
+      expect(errorCount).to.equal(1, 'Error not thrown');
+      expect(errorMessage).to.equal(duplicationMessage, 'duplication error not thrown in dev environment');
+    } else {
+      expect(errorCount).to.equal(0, 'Error thrown');
+      expect(errorMessage).to.equal('', 'duplication error thrown in other environment that was not dev');
+    }
 
     setErrors();
   });

--- a/packages/core/__test__/elements/BasicElement.test.js
+++ b/packages/core/__test__/elements/BasicElement.test.js
@@ -1,8 +1,7 @@
-import { elementUpdated, expect, fixture, isIE } from '@refinitiv-ui/test-helpers';
+import { elementUpdated, expect, fixture, isIE, nextFrame } from '@refinitiv-ui/test-helpers';
 
 import { customElement } from '../../lib/decorators/custom-element.js';
 import { BasicElement } from '../../lib/elements/BasicElement.js';
-import { asyncFrames } from '../helper.js';
 
 class BasicElementTest extends BasicElement {
   defaultRole = 'button';
@@ -109,7 +108,7 @@ describe('TestBasicElement', function () {
         const el = await fixture('<control-element-test autofocus></control-element-test>');
         await elementUpdated(el);
 
-        await asyncFrames();
+        await nextFrame(2);
 
         expect(el.autofocus).to.equal(true, 'property "autofocus" should be setted');
         expect(el.getAttribute('autofocus')).to.equal('', 'attribute "autofocus" should equal empty string');

--- a/packages/core/__test__/elements/ControlElement.test.js
+++ b/packages/core/__test__/elements/ControlElement.test.js
@@ -4,13 +4,14 @@ import {
   fixture,
   html,
   isIE,
+  nextFrame,
   oneEvent,
   triggerFocusFor
 } from '@refinitiv-ui/test-helpers';
 
 import { customElement } from '../../lib/decorators/custom-element.js';
 import { ControlElement } from '../../lib/elements/ControlElement.js';
-import { asyncFrames, elementUpdatedWithAsyncFrames, isChrome } from '../helper.js';
+import { elementUpdatedWithAsyncFrames, isChrome } from '../helper.js';
 
 const MOCKED_COMPARE_LENGTH_VALUE = 12;
 
@@ -717,7 +718,7 @@ describe('TestControlElement', function () {
         expect(blurEvent.type).to.equal('blur', 'blur event should be fired on disabled set to true');
 
         expect(el.disabled).to.equal(true, 'property disabled should be equal true');
-        await asyncFrames();
+        await nextFrame(2);
         expect(el.hasAttribute('focused')).to.equal(
           false,
           'element attribute focused should be set to false when disabled'

--- a/packages/core/__test__/elements/ResponsiveElement.test.js
+++ b/packages/core/__test__/elements/ResponsiveElement.test.js
@@ -1,9 +1,8 @@
-import { expect, fixture, html, oneEvent } from '@refinitiv-ui/test-helpers';
+import { expect, fixture, html, nextFrame, oneEvent } from '@refinitiv-ui/test-helpers';
 
 import { customElement } from '../../lib/decorators/custom-element.js';
 import { ResponsiveElement } from '../../lib/elements/ResponsiveElement.js';
 import { css } from '../../lib/index.js';
-import { asyncFrames } from '../helper.js';
 
 class ResponsiveElementTest extends ResponsiveElement {
   static get styles() {
@@ -40,7 +39,7 @@ describe('TestResponsiveElement', function () {
 
   it('Test resize event', async function () {
     const element = await fixture('<responsive-element-test></responsive-element-test>');
-    await asyncFrames();
+    await nextFrame(2);
 
     setTimeout(() => {
       element.style.width = '100px';
@@ -56,7 +55,7 @@ describe('TestResponsiveElement', function () {
 
   it('Test resized callback', async function () {
     const element = await fixture('<responsive-element-test></responsive-element-test>');
-    await asyncFrames();
+    await nextFrame(2);
 
     let updatedSize = { width: null, height: null };
 
@@ -68,7 +67,7 @@ describe('TestResponsiveElement', function () {
       element.style.width = '100px';
     });
 
-    await asyncFrames();
+    await nextFrame(2);
 
     expect(updatedSize.width).to.equal(100, 'width was not set from callback');
     expect(updatedSize.height).to.equal(0, 'height was not set from callback');

--- a/packages/core/__test__/helper.js
+++ b/packages/core/__test__/helper.js
@@ -2,20 +2,16 @@ import { elementUpdated, expect, nextFrame } from '@refinitiv-ui/test-helpers';
 
 const data = {
   errorCount: 0,
-  errorMessage: ''
+  errorMessage: '',
+  errorObject: undefined
 };
 
 let oldHandler;
 
-export const asyncFrames = async () => {
-  await nextFrame();
-  await nextFrame();
-};
-
 export const elementUpdatedWithAsyncFrames = async (element) => {
   await elementUpdated(element);
 
-  await asyncFrames();
+  await nextFrame(2);
 };
 
 const checkNoGlobalError = () => {
@@ -26,6 +22,7 @@ const checkNoGlobalError = () => {
 const errorHandler = (msg, url, line, col, error) => {
   data.errorCount += 1;
   data.errorMessage = error.message;
+  data.errorObject = error;
   return true;
 };
 
@@ -35,13 +32,14 @@ export const mockCssString = ':host { margin: 0; }';
 beforeEach(() => {
   data.errorCount = 0;
   data.errorMessage = '';
+  data.errorInstance = undefined;
 
   oldHandler = window.onerror;
   window.onerror = errorHandler;
 });
 
 afterEach(async () => {
-  await asyncFrames();
+  await nextFrame(2);
 
   window.onerror = oldHandler;
 
@@ -52,9 +50,12 @@ export const getErrors = () => {
   return Object.assign({}, data);
 };
 
-export const setErrors = (errorCount = 0, errorMessage = '') => {
+export const setErrors = (errorCount = 0, errorMessage = '', errorObject = undefined) => {
   data.errorCount = errorCount;
   data.errorMessage = errorMessage;
+  data.errorObject = errorObject;
 };
 
 export const isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
+
+export const isLocalhost = /^(localhost|127\.0\.0\.1)$/.test(location.hostname);

--- a/packages/core/__test__/registries/CustomStyleRegistry.test.js
+++ b/packages/core/__test__/registries/CustomStyleRegistry.test.js
@@ -2,18 +2,8 @@ import { expect } from '@refinitiv-ui/test-helpers';
 
 import { DuplicateStyleError } from '../../lib/errors/DuplicateStyleError.js';
 import { CustomStyleRegistry } from '../../lib/registries/CustomStyleRegistry.js';
-import { mockCssString } from '../helper.js';
+import { isLocalhost, mockCssString } from '../helper.js';
 
-const duplicateStyleErrorMessage = `Only one theme file can be loaded per element
-
-[TestCustomStyleRegistry_2] has already been defined.
-
-Potential causes:
-1. You are trying to load a multiple variants of a theme
-2. You have loaded multiple or duplicate themes in your application bundle
-
-https://ui.refinitiv.com/kb/duplicate-styles
-`;
 describe('TestCustomStyleRegistry', function () {
   let testNum = 0;
   const baseName = 'TestCustomStyleRegistry_';
@@ -42,11 +32,14 @@ describe('TestCustomStyleRegistry', function () {
   it('Test define twice same name', function () {
     CustomStyleRegistry.define(testName, mockCssString);
 
-    try {
-      CustomStyleRegistry.define(testName, mockCssString);
-    } catch (error) {
-      expect(error).instanceOf(DuplicateStyleError);
-      expect(error.message).to.equal(duplicateStyleErrorMessage);
+    if (isLocalhost) {
+      expect(() => {
+        CustomStyleRegistry.define(testName, mockCssString);
+      }).to.throw(DuplicateStyleError);
+    } else {
+      expect(() => {
+        CustomStyleRegistry.define(testName, mockCssString);
+      }).not.to.throw(DuplicateStyleError);
     }
   });
 });

--- a/packages/core/__test__/registries/NativeStyleRegistry.test.js
+++ b/packages/core/__test__/registries/NativeStyleRegistry.test.js
@@ -2,18 +2,8 @@ import { expect } from '@refinitiv-ui/test-helpers';
 
 import { DuplicateStyleError } from '../../lib/errors/DuplicateStyleError.js';
 import { NativeStyleRegistry } from '../../lib/registries/NativeStyleRegistry.js';
-import { mockCssString } from '../helper.js';
+import { isLocalhost, mockCssString } from '../helper.js';
 
-const duplicateStyleErrorMessage = `Only one theme file can be loaded per element
-
-[TestNativeStyleRegistry_2] has already been defined.
-
-Potential causes:
-1. You are trying to load a multiple variants of a theme
-2. You have loaded multiple or duplicate themes in your application bundle
-
-https://ui.refinitiv.com/kb/duplicate-styles
-`;
 describe('TestNativeStyleRegistry', function () {
   let testNum = 0;
   const baseName = 'TestNativeStyleRegistry_';
@@ -41,11 +31,14 @@ describe('TestNativeStyleRegistry', function () {
   it('Test define twice same name', function () {
     NativeStyleRegistry.define(testName, mockCssString);
 
-    try {
-      NativeStyleRegistry.define(testName, mockCssString);
-    } catch (error) {
-      expect(error).instanceOf(DuplicateStyleError);
-      expect(error.message).to.equal(duplicateStyleErrorMessage);
+    if (isLocalhost) {
+      expect(() => {
+        NativeStyleRegistry.define(testName, mockCssString);
+      }).to.throw(DuplicateStyleError);
+    } else {
+      expect(() => {
+        NativeStyleRegistry.define(testName, mockCssString);
+      }).not.to.throw(DuplicateStyleError);
     }
   });
 

--- a/packages/core/__test__/utils/elementReady.test.js
+++ b/packages/core/__test__/utils/elementReady.test.js
@@ -56,7 +56,7 @@ describe('TestReady', function () {
     const { errorMessage, errorCount } = getErrors();
 
     expect(errorCount).to.equal(1, 'Error not thrown');
-    expect(errorMessage).to.equal('test', 'duplication error not thrown');
+    expect(errorMessage).to.equal('test', 'test error not thrown');
 
     setErrors();
   });

--- a/packages/core/__test__/utils/elementReady.test.js
+++ b/packages/core/__test__/utils/elementReady.test.js
@@ -1,7 +1,7 @@
-import { expect } from '@refinitiv-ui/test-helpers';
+import { expect, nextFrame } from '@refinitiv-ui/test-helpers';
 
 import { ready } from '../../lib/utils/elementReady.js';
-import { asyncFrames, getErrors, setErrors } from '../helper.js';
+import { getErrors, setErrors } from '../helper.js';
 
 describe('TestReady', function () {
   const baseName = 'TestReady_';
@@ -51,12 +51,12 @@ describe('TestReady', function () {
 
     expect(callbackCallCount).to.equal(1, 'First callback was not called before throw error');
 
-    await asyncFrames();
+    await nextFrame(2);
 
     const { errorMessage, errorCount } = getErrors();
 
-    expect(errorMessage).to.equal('test');
-    expect(errorCount).to.equal(1);
+    expect(errorCount).to.equal(1, 'Error not thrown');
+    expect(errorMessage).to.equal('test', 'duplication error not thrown');
 
     setErrors();
   });

--- a/packages/core/src/registries/CustomStyleRegistry.ts
+++ b/packages/core/src/registries/CustomStyleRegistry.ts
@@ -17,10 +17,10 @@ export abstract class CustomStyleRegistry {
    */
   public static define(name: string, css: string): void {
     if (register.has(name)) {
+      /* istanbul ignore else */
       if (isLocalhost) {
         throw new DuplicateStyleError(name);
       }
-      /* istanbul ignore next */
       return;
     }
 

--- a/packages/core/src/registries/CustomStyleRegistry.ts
+++ b/packages/core/src/registries/CustomStyleRegistry.ts
@@ -1,5 +1,6 @@
 import { DuplicateStyleError } from '../errors/DuplicateStyleError.js';
 import { ready } from '../utils/elementReady.js';
+import { isLocalhost } from '../utils/helpers.js';
 
 const register = new Map<string, string>();
 
@@ -16,8 +17,13 @@ export abstract class CustomStyleRegistry {
    */
   public static define(name: string, css: string): void {
     if (register.has(name)) {
-      throw new DuplicateStyleError(name);
+      if (isLocalhost) {
+        throw new DuplicateStyleError(name);
+      }
+      /* istanbul ignore next */
+      return;
     }
+
     register.set(name, css);
     ready(name);
   }

--- a/packages/core/src/registries/CustomStyleRegistry.ts
+++ b/packages/core/src/registries/CustomStyleRegistry.ts
@@ -21,6 +21,7 @@ export abstract class CustomStyleRegistry {
       if (isLocalhost) {
         throw new DuplicateStyleError(name);
       }
+      /* istanbul ignore next */
       return;
     }
 

--- a/packages/core/src/registries/NativeStyleRegistry.ts
+++ b/packages/core/src/registries/NativeStyleRegistry.ts
@@ -17,10 +17,10 @@ export abstract class NativeStyleRegistry {
    */
   public static define(name: string, css: string): void {
     if (register.has(name)) {
+      /* istanbul ignore else */
       if (isLocalhost) {
         throw new DuplicateStyleError(name);
       }
-      /* istanbul ignore next */
       return;
     }
 

--- a/packages/core/src/registries/NativeStyleRegistry.ts
+++ b/packages/core/src/registries/NativeStyleRegistry.ts
@@ -1,4 +1,5 @@
 import { DuplicateStyleError } from '../errors/DuplicateStyleError.js';
+import { isLocalhost } from '../utils/helpers.js';
 import { ShadyCSS } from '../utils/shadyStyles.js';
 
 const register = new Map<string, string>();
@@ -16,8 +17,13 @@ export abstract class NativeStyleRegistry {
    */
   public static define(name: string, css: string): void {
     if (register.has(name)) {
-      throw new DuplicateStyleError(name);
+      if (isLocalhost) {
+        throw new DuplicateStyleError(name);
+      }
+      /* istanbul ignore next */
+      return;
     }
+
     register.set(name, css);
     // Skip if style has empty content
     // it causes problem in shadyCSS in IE

--- a/packages/core/src/registries/NativeStyleRegistry.ts
+++ b/packages/core/src/registries/NativeStyleRegistry.ts
@@ -21,6 +21,7 @@ export abstract class NativeStyleRegistry {
       if (isLocalhost) {
         throw new DuplicateStyleError(name);
       }
+      /* istanbul ignore next */
       return;
     }
 

--- a/packages/core/src/utils/helpers.ts
+++ b/packages/core/src/utils/helpers.ts
@@ -1,6 +1,8 @@
 import type { BasicElement } from '../elements/BasicElement';
 
 const BasicElementSymbol = Symbol('BasicElement');
+/* istanbul ignore next */
+const isLocalhost = /^(localhost|127\.0\.0\.1)$/.test(location.hostname);
 
 /**
  * Check if a passed node is of basic element.
@@ -12,4 +14,4 @@ const isBasicElement = (element: unknown): element is BasicElement => {
   return element instanceof HTMLElement && BasicElementSymbol in element.constructor;
 };
 
-export { BasicElementSymbol, isBasicElement };
+export { BasicElementSymbol, isBasicElement, isLocalhost };


### PR DESCRIPTION
## Description
To prevent element to throw error when custom element into registry on the production, we need to check environment before throw error to notice the developer.

Fixes # (issue)
DME-14858

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
