### PR TITLE
test(tree-select): wait another frame before assertion for iOS 15

### DIFF
--- a/packages/elements/src/tree-select/__test__/tree-select.tree-node.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.tree-node.test.js
@@ -40,6 +40,8 @@ describe('tree-select/tree-node', function () {
         ];
         await elementUpdated(el);
 
+        await nextFrame(); // iOS 15 needs another frame to complete rendering
+
         const index = 0;
         const treeElement = getTreeElPart(el);
         const elementIcon = getIconPart(treeElement.children[index]);
@@ -60,6 +62,8 @@ describe('tree-select/tree-node', function () {
           { value: '2', label: 'two' }
         ];
         await elementUpdated(el);
+
+        await nextFrame(); // iOS 15 needs another frame to complete rendering
 
         const index = 0;
         const treeElement = getTreeElPart(el);
@@ -84,6 +88,8 @@ describe('tree-select/tree-node', function () {
         const el = await fixture('<ef-tree-select opened></ef-tree-select>');
         el.data = flatData;
         await elementUpdated(el);
+
+        await nextFrame(); // iOS 15 needs another frame to complete rendering
 
         const index = 3;
         const treeElement = getTreeElPart(el);


### PR DESCRIPTION
## Description

Resolve [failing test of Tree Select on iOS 15](https://github.com/Refinitiv/refinitiv-ui/actions/runs/8978884418/job/24661664695#step:3:1650).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
