### PR TITLE
fix(chart): fix gridlines colors

### DIFF
--- a/packages/elements/src/chart/__test__/chart.test.js
+++ b/packages/elements/src/chart/__test__/chart.test.js
@@ -352,6 +352,24 @@ describe('chart/Chart', function () {
         expect(labelstrokeStyle).to.equal(labels[0].strokeStyle);
       }
     });
+
+    it('Should be able to change grid line color', async function () {
+      const gridLineColor = '#FF0000';
+      el = await fixture(`<ef-chart style="--grid-line-color: '${gridLineColor}'"></ef-chart>`);
+      el.config = config.line;
+      await chartRendered(el);
+      expect(el.chart.options.scales.x.grid.color).to.equal(el.getComputedVariable('--grid-line-color'));
+      expect(el.chart.options.scales.y.grid.color).to.equal(el.getComputedVariable('--grid-line-color'));
+    });
+
+    it('Should be able to change zero grid line color', async function () {
+      const zeroLineColor = '#FF0000';
+      el = await fixture(`<ef-chart style="--grid-line-color: '${zeroLineColor}'"></ef-chart>`);
+      el.config = config.line;
+      await chartRendered(el);
+      expect(el.chart.options.scales.x.border.color).to.equal(el.getComputedVariable('--zero-line-color'));
+      expect(el.chart.options.scales.y.border.color).to.equal(el.getComputedVariable('--zero-line-color'));
+    });
   });
 
   describe('Plugins', function () {

--- a/packages/elements/src/chart/__test__/chart.test.js
+++ b/packages/elements/src/chart/__test__/chart.test.js
@@ -364,11 +364,11 @@ describe('chart/Chart', function () {
 
     it('Should be able to change zero grid line color', async function () {
       const zeroLineColor = '#FF0000';
-      el = await fixture(`<ef-chart style="--grid-line-color: '${zeroLineColor}'"></ef-chart>`);
+      el = await fixture(`<ef-chart style="--zero-line-color: '${zeroLineColor}'"></ef-chart>`);
       el.config = config.line;
       await chartRendered(el);
-      expect(el.chart.options.scales.x.border.color).to.equal(el.getComputedVariable('--zero-line-color'));
-      expect(el.chart.options.scales.y.border.color).to.equal(el.getComputedVariable('--zero-line-color'));
+      expect(el.chart.options.scales.x.border.color).to.equal(zeroLineColor);
+      expect(el.chart.options.scales.y.border.color).to.equal(zeroLineColor);
     });
   });
 

--- a/packages/elements/src/chart/__test__/chart.test.js
+++ b/packages/elements/src/chart/__test__/chart.test.js
@@ -358,8 +358,8 @@ describe('chart/Chart', function () {
       el = await fixture(`<ef-chart style="--grid-line-color: '${gridLineColor}'"></ef-chart>`);
       el.config = config.line;
       await chartRendered(el);
-      expect(el.chart.options.scales.x.grid.color).to.equal(el.getComputedVariable('--grid-line-color'));
-      expect(el.chart.options.scales.y.grid.color).to.equal(el.getComputedVariable('--grid-line-color'));
+      expect(el.chart.options.scales.x.grid.color).to.equal(gridLineColor);
+      expect(el.chart.options.scales.y.grid.color).to.equal(gridLineColor);
     });
 
     it('Should be able to change zero grid line color', async function () {

--- a/packages/elements/src/chart/elements/chart.ts
+++ b/packages/elements/src/chart/elements/chart.ts
@@ -1,5 +1,6 @@
 import { Chart as ChartJS } from 'chart.js';
 import type {
+  CartesianScaleOptions,
   ChartConfiguration,
   ChartDataset,
   ChartOptions,
@@ -290,13 +291,6 @@ export class Chart extends BasicElement {
       | 'initial'
       | 'inherit'
       | undefined;
-    // Set global grid color
-    ChartJS.defaults.scale.grid.color = (line) => {
-      return line.index === 0
-        ? this.getComputedVariable('--zero-line-color', 'transparent')
-        : this.getComputedVariable('--grid-line-color', 'transparent');
-    };
-
     if (ChartJS.defaults.scales.radialLinear) {
       ChartJS.defaults.scales.radialLinear.ticks.showLabelBackdrop = false;
     }
@@ -333,7 +327,28 @@ export class Chart extends BasicElement {
     // set global config again in case the CSS font isn't loaded when updating the chart
     this.setGlobalConfig();
     this.decorateColors(chart);
+    this.decorateGridColors(chart);
   };
+
+  /**
+   * Set grid color in beforeUpdate event from Chartjs
+   * @param chart Chart.js instance
+   * @returns {void}
+   */
+  private decorateGridColors(chart: ChartJS): void {
+    for (const scale in chart.scales) {
+      const axis = chart.options?.scales?.[scale] as CartesianScaleOptions;
+      const userGridColor = this.config?.options?.scales?.[scale]?.grid?.color as Color;
+      // rgba(0,0,0,0.1) is unset grid color
+      if (axis && userGridColor === 'rgba(0,0,0,0.1)') {
+        axis.grid.color = (line) => {
+          return line.index === 0
+            ? this.getComputedVariable('--zero-line-color', 'transparent')
+            : this.getComputedVariable('--grid-line-color', 'transparent');
+        };
+      }
+    }
+  }
 
   /**
    * Inject theme color into each datasets
@@ -512,6 +527,7 @@ export class Chart extends BasicElement {
    * Merges all the different layers of the config.
    * @returns {void}
    */
+  // refactor this func to immutable that return merged config
   protected mergeConfigs(): void {
     if (!this.config) {
       return;

--- a/packages/elements/src/chart/elements/chart.ts
+++ b/packages/elements/src/chart/elements/chart.ts
@@ -341,7 +341,7 @@ export class Chart extends BasicElement {
       const userAxis = this.config?.options?.scales?.[scale] as CartesianScaleOptions | undefined;
       const userGridColor = userAxis?.grid?.color;
       const userZeroGridColor = userAxis?.border?.color;
-      // Change grid color if the color is default which rgba(0,0,0,0.1) is default grid color.
+      // Change grid color if the color is the default value of `rgba(0,0,0,0.1)`
       if (axis && userGridColor === 'rgba(0,0,0,0.1)') {
         axis.grid.color = this.getComputedVariable('--grid-line-color', 'transparent');
       }

--- a/packages/elements/src/chart/elements/chart.ts
+++ b/packages/elements/src/chart/elements/chart.ts
@@ -340,7 +340,7 @@ export class Chart extends BasicElement {
       const axis = chart.options?.scales?.[scale] as CartesianScaleOptions | undefined;
       const userAxis = this.config?.options?.scales?.[scale] as CartesianScaleOptions | undefined;
       const userGridColor = userAxis?.grid?.color;
-      const userZeroGridColor = userAxis?.border?.color;
+      const userBorderColor = userAxis?.border?.color;
       // Change grid color if the color is the default value of `rgba(0,0,0,0.1)`
       if (axis && userGridColor === 'rgba(0,0,0,0.1)') {
         axis.grid.color = this.getComputedVariable('--grid-line-color', 'transparent');

--- a/packages/elements/src/chart/elements/chart.ts
+++ b/packages/elements/src/chart/elements/chart.ts
@@ -336,7 +336,7 @@ export class Chart extends BasicElement {
    * @returns {void}
    */
   private decorateGridColors(chart: ChartJS): void {
-    for (const scale in chart.scales) {
+    for (const scale of Object.keys(chart.scales)) {
       const axis = chart.options?.scales?.[scale] as CartesianScaleOptions | undefined;
       const userGridColor = this.config?.options?.scales?.[scale]?.grid?.color;
       // rgba(0,0,0,0.1) is unset grid color

--- a/packages/elements/src/chart/elements/chart.ts
+++ b/packages/elements/src/chart/elements/chart.ts
@@ -345,7 +345,8 @@ export class Chart extends BasicElement {
       if (axis && userGridColor === 'rgba(0,0,0,0.1)') {
         axis.grid.color = this.getComputedVariable('--grid-line-color', 'transparent');
       }
-      if (axis && userZeroGridColor === 'rgba(0,0,0,0.1)') {
+      // Change border color if the color is the default value of `rgba(0,0,0,0.1)`
+      if (axis && userBorderColor === 'rgba(0,0,0,0.1)') {
         axis.border.color = this.getComputedVariable('--zero-line-color', 'transparent');
       }
     }

--- a/packages/elements/src/chart/elements/chart.ts
+++ b/packages/elements/src/chart/elements/chart.ts
@@ -528,7 +528,6 @@ export class Chart extends BasicElement {
    * Merges all the different layers of the config.
    * @returns {void}
    */
-  // refactor this func to immutable that return merged config
   protected mergeConfigs(): void {
     if (!this.config) {
       return;

--- a/packages/elements/src/chart/elements/chart.ts
+++ b/packages/elements/src/chart/elements/chart.ts
@@ -339,7 +339,7 @@ export class Chart extends BasicElement {
     for (const scale of Object.keys(chart.scales)) {
       const axis = chart.options?.scales?.[scale] as CartesianScaleOptions | undefined;
       const userGridColor = this.config?.options?.scales?.[scale]?.grid?.color;
-      // rgba(0,0,0,0.1) is unset grid color
+      // Change grid color if the color is default which rgba(0,0,0,0.1) is default grid color.
       if (axis && userGridColor === 'rgba(0,0,0,0.1)') {
         axis.grid.color = (line) => {
           return line.index === 0

--- a/packages/elements/src/chart/elements/chart.ts
+++ b/packages/elements/src/chart/elements/chart.ts
@@ -338,7 +338,7 @@ export class Chart extends BasicElement {
   private decorateGridColors(chart: ChartJS): void {
     for (const scale in chart.scales) {
       const axis = chart.options?.scales?.[scale] as CartesianScaleOptions;
-      const userGridColor = this.config?.options?.scales?.[scale]?.grid?.color as Color;
+      const userGridColor = this.config?.options?.scales?.[scale]?.grid?.color;
       // rgba(0,0,0,0.1) is unset grid color
       if (axis && userGridColor === 'rgba(0,0,0,0.1)') {
         axis.grid.color = (line) => {

--- a/packages/elements/src/chart/elements/chart.ts
+++ b/packages/elements/src/chart/elements/chart.ts
@@ -337,7 +337,7 @@ export class Chart extends BasicElement {
    */
   private decorateGridColors(chart: ChartJS): void {
     for (const scale in chart.scales) {
-      const axis = chart.options?.scales?.[scale] as CartesianScaleOptions;
+      const axis = chart.options?.scales?.[scale] as CartesianScaleOptions | undefined;
       const userGridColor = this.config?.options?.scales?.[scale]?.grid?.color;
       // rgba(0,0,0,0.1) is unset grid color
       if (axis && userGridColor === 'rgba(0,0,0,0.1)') {

--- a/packages/elements/src/chart/elements/chart.ts
+++ b/packages/elements/src/chart/elements/chart.ts
@@ -338,14 +338,15 @@ export class Chart extends BasicElement {
   private decorateGridColors(chart: ChartJS): void {
     for (const scale of Object.keys(chart.scales)) {
       const axis = chart.options?.scales?.[scale] as CartesianScaleOptions | undefined;
-      const userGridColor = this.config?.options?.scales?.[scale]?.grid?.color;
+      const userAxis = this.config?.options?.scales?.[scale] as CartesianScaleOptions | undefined;
+      const userGridColor = userAxis?.grid?.color;
+      const userZeroGridColor = userAxis?.border?.color;
       // Change grid color if the color is default which rgba(0,0,0,0.1) is default grid color.
       if (axis && userGridColor === 'rgba(0,0,0,0.1)') {
-        axis.grid.color = (line) => {
-          return line.index === 0
-            ? this.getComputedVariable('--zero-line-color', 'transparent')
-            : this.getComputedVariable('--grid-line-color', 'transparent');
-        };
+        axis.grid.color = this.getComputedVariable('--grid-line-color', 'transparent');
+      }
+      if (axis && userZeroGridColor === 'rgba(0,0,0,0.1)') {
+        axis.border.color = this.getComputedVariable('--zero-line-color', 'transparent');
       }
     }
   }


### PR DESCRIPTION
## Description

In chart, when create chart elements more than one. The gridline of other charts except the first don't show the same style.

Fixes # ([DME-7098](https://jira.refinitiv.com/browse/DME-7098))

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
