### PR TITLE
test(calendar, translate) resolve inconsistent full date pattern of en-GB

### DIFF
--- a/packages/elements/src/calendar/__snapshots__/Defaults.md
+++ b/packages/elements/src/calendar/__snapshots__/Defaults.md
@@ -5031,7 +5031,7 @@
 
 ```html
 <div
-  aria-label="Selected none. Choose date"
+  aria-label="Keine ausgewählt. Wählen Sie date"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -5039,7 +5039,7 @@
 </div>
 <div part="navigation">
   <ef-button
-    aria-label="Previous month"
+    aria-label="Vorheriger Monat"
     empty=""
     icon="left"
     part="btn-prev"
@@ -5049,7 +5049,7 @@
   >
   </ef-button>
   <ef-button
-    aria-description="Click to select year"
+    aria-description="Anklicken, um das Jahr auszuwählen"
     icon="down"
     part="btn-view"
     role="button"
@@ -5059,7 +5059,7 @@
     April 2005
   </ef-button>
   <ef-button
-    aria-label="Next month"
+    aria-label="Nächster Monat"
     empty=""
     icon="right"
     part="btn-next"
@@ -5189,7 +5189,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Freitag, 1. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -5205,7 +5205,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Samstag, 2. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5221,7 +5221,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 3 April 2005"
+        aria-label="Sonntag, 3. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5242,7 +5242,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Montag, 4. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5258,7 +5258,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Dienstag, 5. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5274,7 +5274,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Mittwoch, 6. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5290,7 +5290,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Donnerstag, 7. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5306,7 +5306,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Freitag, 8. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5322,7 +5322,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Samstag, 9. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5338,7 +5338,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 10 April 2005"
+        aria-label="Sonntag, 10. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5359,7 +5359,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Montag, 11. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5375,7 +5375,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Dienstag, 12. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5391,7 +5391,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Mittwoch, 13. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5407,7 +5407,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Donnerstag, 14. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5423,7 +5423,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Freitag, 15. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5439,7 +5439,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Samstag, 16. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5455,7 +5455,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 17 April 2005"
+        aria-label="Sonntag, 17. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5476,7 +5476,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Montag, 18. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5492,7 +5492,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Dienstag, 19. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5508,7 +5508,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Mittwoch, 20. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5524,7 +5524,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Donnerstag, 21. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5540,7 +5540,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Freitag, 22. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5556,7 +5556,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Samstag, 23. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5572,7 +5572,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 24 April 2005"
+        aria-label="Sonntag, 24. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5593,7 +5593,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Montag, 25. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5609,7 +5609,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Dienstag, 26. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5625,7 +5625,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Mittwoch, 27. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5641,7 +5641,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Donnerstag, 28. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5657,7 +5657,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Freitag, 29. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5674,7 +5674,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Samstag, 30. April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"

--- a/packages/elements/src/calendar/__snapshots__/Defaults.md
+++ b/packages/elements/src/calendar/__snapshots__/Defaults.md
@@ -54,6 +54,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -113,16 +123,6 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
@@ -137,10 +137,27 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 28 March 2005"
+        aria-label="Sunday, March 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
+      >
+        <slot name="2005-03-27">
+          27
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      idle=""
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, March 28, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
       >
         <slot name="2005-03-28">
           28
@@ -154,7 +171,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 29 March 2005"
+        aria-label="Tuesday, March 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -171,7 +188,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 30 March 2005"
+        aria-label="Wednesday, March 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -188,7 +205,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 31 March 2005"
+        aria-label="Thursday, March 31, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -204,7 +221,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -220,29 +237,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -257,7 +258,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -273,7 +290,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -289,7 +306,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -305,7 +322,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -321,7 +338,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -337,29 +354,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -374,7 +375,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -390,7 +407,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -406,7 +423,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -422,7 +439,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -438,7 +455,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -454,29 +471,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -491,7 +492,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -507,7 +524,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -523,7 +540,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -539,7 +556,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -555,7 +572,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -571,29 +588,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -608,7 +609,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -624,7 +641,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -640,7 +657,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -656,7 +673,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -672,7 +689,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -688,30 +705,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-30">
           30
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      idle=""
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 1 May 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-05-01">
-          1
         </slot>
       </div>
     </div>
@@ -727,7 +727,24 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 2 May 2005"
+        aria-label="Sunday, May 1, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-05-01">
+          1
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      idle=""
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, May 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -744,7 +761,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 3 May 2005"
+        aria-label="Tuesday, May 3, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -761,7 +778,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 4 May 2005"
+        aria-label="Wednesday, May 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -778,7 +795,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 5 May 2005"
+        aria-label="Thursday, May 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -795,7 +812,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 6 May 2005"
+        aria-label="Friday, May 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -808,35 +825,18 @@
     <div
       aria-selected="false"
       idle=""
+      last-date=""
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 7 May 2005"
+        aria-label="Saturday, May 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-05-07">
           7
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      idle=""
-      last-date=""
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 8 May 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-05-08">
-          8
         </slot>
       </div>
     </div>
@@ -901,6 +901,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -960,21 +970,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -1011,7 +1018,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -1027,29 +1034,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -1064,7 +1055,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1080,7 +1087,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1096,7 +1103,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1112,7 +1119,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1128,7 +1135,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1144,29 +1151,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -1181,7 +1172,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1197,7 +1204,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1213,7 +1220,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1229,7 +1236,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1245,7 +1252,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1261,29 +1268,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -1298,7 +1289,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1314,7 +1321,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1330,7 +1337,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1346,7 +1353,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1362,7 +1369,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1378,29 +1385,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -1415,7 +1406,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1431,7 +1438,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1447,7 +1454,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1463,7 +1470,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1479,7 +1486,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1496,7 +1503,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1504,13 +1511,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -2296,6 +2296,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -2355,21 +2365,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -2385,7 +2392,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 1 February 2005"
+        aria-label="Tuesday, February 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -2401,7 +2408,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 2 February 2005"
+        aria-label="Wednesday, February 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2417,7 +2424,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 3 February 2005"
+        aria-label="Thursday, February 3, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2433,7 +2440,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 4 February 2005"
+        aria-label="Friday, February 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2449,29 +2456,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 5 February 2005"
+        aria-label="Saturday, February 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-02-05">
           5
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 6 February 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-02-06">
-          6
         </slot>
       </div>
     </div>
@@ -2486,7 +2477,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 7 February 2005"
+        aria-label="Sunday, February 6, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-02-06">
+          6
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, February 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2502,7 +2509,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 8 February 2005"
+        aria-label="Tuesday, February 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2518,7 +2525,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 9 February 2005"
+        aria-label="Wednesday, February 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2534,7 +2541,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 10 February 2005"
+        aria-label="Thursday, February 10, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2550,7 +2557,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 11 February 2005"
+        aria-label="Friday, February 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2566,29 +2573,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 12 February 2005"
+        aria-label="Saturday, February 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-02-12">
           12
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 13 February 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-02-13">
-          13
         </slot>
       </div>
     </div>
@@ -2603,7 +2594,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 14 February 2005"
+        aria-label="Sunday, February 13, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-02-13">
+          13
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, February 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2619,7 +2626,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 15 February 2005"
+        aria-label="Tuesday, February 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2635,7 +2642,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 16 February 2005"
+        aria-label="Wednesday, February 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2651,7 +2658,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 17 February 2005"
+        aria-label="Thursday, February 17, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2667,7 +2674,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 18 February 2005"
+        aria-label="Friday, February 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2683,29 +2690,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 19 February 2005"
+        aria-label="Saturday, February 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-02-19">
           19
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 20 February 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-02-20">
-          20
         </slot>
       </div>
     </div>
@@ -2720,7 +2711,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 21 February 2005"
+        aria-label="Sunday, February 20, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-02-20">
+          20
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, February 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2736,7 +2743,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 22 February 2005"
+        aria-label="Tuesday, February 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2752,7 +2759,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 23 February 2005"
+        aria-label="Wednesday, February 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2768,7 +2775,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 24 February 2005"
+        aria-label="Thursday, February 24, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2784,7 +2791,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 25 February 2005"
+        aria-label="Friday, February 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2800,29 +2807,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 26 February 2005"
+        aria-label="Saturday, February 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-02-26">
           26
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 27 February 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-02-27">
-          27
         </slot>
       </div>
     </div>
@@ -2833,12 +2824,28 @@
   >
     <div
       aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Sunday, February 27, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-02-27">
+          27
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
       last-date=""
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 28 February 2005"
+        aria-label="Monday, February 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2846,13 +2853,6 @@
         <slot name="2005-02-28">
           28
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -3673,6 +3673,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -3732,21 +3742,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -3769,7 +3776,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 1 December 2004"
+        aria-label="Wednesday, December 1, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -3785,7 +3792,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 2 December 2004"
+        aria-label="Thursday, December 2, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3801,7 +3808,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 3 December 2004"
+        aria-label="Friday, December 3, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3817,29 +3824,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 4 December 2004"
+        aria-label="Saturday, December 4, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2004-12-04">
           4
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 5 December 2004"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2004-12-05">
-          5
         </slot>
       </div>
     </div>
@@ -3854,7 +3845,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 6 December 2004"
+        aria-label="Sunday, December 5, 2004"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2004-12-05">
+          5
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 6, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3870,7 +3877,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 7 December 2004"
+        aria-label="Tuesday, December 7, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3886,7 +3893,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 8 December 2004"
+        aria-label="Wednesday, December 8, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3902,7 +3909,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 9 December 2004"
+        aria-label="Thursday, December 9, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3918,7 +3925,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 10 December 2004"
+        aria-label="Friday, December 10, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3934,29 +3941,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 11 December 2004"
+        aria-label="Saturday, December 11, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2004-12-11">
           11
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 12 December 2004"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2004-12-12">
-          12
         </slot>
       </div>
     </div>
@@ -3971,7 +3962,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 13 December 2004"
+        aria-label="Sunday, December 12, 2004"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2004-12-12">
+          12
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 13, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3987,7 +3994,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 14 December 2004"
+        aria-label="Tuesday, December 14, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4003,7 +4010,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 15 December 2004"
+        aria-label="Wednesday, December 15, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4019,7 +4026,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 16 December 2004"
+        aria-label="Thursday, December 16, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4035,7 +4042,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 17 December 2004"
+        aria-label="Friday, December 17, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4051,29 +4058,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 18 December 2004"
+        aria-label="Saturday, December 18, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2004-12-18">
           18
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 19 December 2004"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2004-12-19">
-          19
         </slot>
       </div>
     </div>
@@ -4088,7 +4079,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 20 December 2004"
+        aria-label="Sunday, December 19, 2004"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2004-12-19">
+          19
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 20, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4104,7 +4111,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 21 December 2004"
+        aria-label="Tuesday, December 21, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4120,7 +4127,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 22 December 2004"
+        aria-label="Wednesday, December 22, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4136,7 +4143,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 23 December 2004"
+        aria-label="Thursday, December 23, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4152,7 +4159,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 24 December 2004"
+        aria-label="Friday, December 24, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4168,29 +4175,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 25 December 2004"
+        aria-label="Saturday, December 25, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2004-12-25">
           25
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 26 December 2004"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2004-12-26">
-          26
         </slot>
       </div>
     </div>
@@ -4205,7 +4196,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 27 December 2004"
+        aria-label="Sunday, December 26, 2004"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2004-12-26">
+          26
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 27, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4221,7 +4228,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 28 December 2004"
+        aria-label="Tuesday, December 28, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4237,7 +4244,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 29 December 2004"
+        aria-label="Wednesday, December 29, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4253,7 +4260,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 30 December 2004"
+        aria-label="Thursday, December 30, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4270,7 +4277,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 31 December 2004"
+        aria-label="Friday, December 31, 2004"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4278,13 +4285,6 @@
         <slot name="2004-12-31">
           31
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -5756,7 +5756,6 @@
 
 ```html
 <div
-  aria-label="Selected none. Choose date"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -5921,7 +5920,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -5937,7 +5935,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5958,7 +5955,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 3 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5974,7 +5970,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5990,7 +5985,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6006,7 +6000,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6022,7 +6015,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6038,7 +6030,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6054,7 +6045,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6075,7 +6065,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 10 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6091,7 +6080,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6107,7 +6095,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6123,7 +6110,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6139,7 +6125,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6155,7 +6140,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6171,7 +6155,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6192,7 +6175,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 17 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6208,7 +6190,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6224,7 +6205,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6240,7 +6220,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6256,7 +6235,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6272,7 +6250,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6288,7 +6265,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6309,7 +6285,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 24 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6325,7 +6300,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6341,7 +6315,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6357,7 +6330,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6373,7 +6345,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6389,7 +6360,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6406,7 +6376,6 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6622,7 +6591,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -6638,7 +6607,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6654,7 +6623,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 3 April 2005"
+        aria-label="Sunday, April 3, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6670,7 +6639,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6686,7 +6655,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6702,7 +6671,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6723,7 +6692,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6739,7 +6708,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6755,7 +6724,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6771,7 +6740,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 10 April 2005"
+        aria-label="Sunday, April 10, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6787,7 +6756,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6803,7 +6772,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6819,7 +6788,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6840,7 +6809,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6856,7 +6825,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6872,7 +6841,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6888,7 +6857,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 17 April 2005"
+        aria-label="Sunday, April 17, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6904,7 +6873,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6920,7 +6889,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6936,7 +6905,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6957,7 +6926,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6973,7 +6942,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6989,7 +6958,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7005,7 +6974,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 24 April 2005"
+        aria-label="Sunday, April 24, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7021,7 +6990,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7037,7 +7006,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7053,7 +7022,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7074,7 +7043,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7090,7 +7059,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7107,7 +7076,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7262,6 +7231,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -7321,21 +7300,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -7386,7 +7362,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -7396,13 +7372,18 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 3 April 2005"
+        aria-label="Sunday, April 3, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7412,11 +7393,6 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       disabled=""
       part="cell day"
@@ -7493,7 +7469,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7503,13 +7479,18 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 10 April 2005"
+        aria-label="Sunday, April 10, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7519,11 +7500,6 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       disabled=""
       part="cell day"
@@ -7600,7 +7576,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7610,13 +7586,18 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 17 April 2005"
+        aria-label="Sunday, April 17, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7626,11 +7607,6 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       disabled=""
       part="cell day"
@@ -7707,7 +7683,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7717,13 +7693,18 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 24 April 2005"
+        aria-label="Sunday, April 24, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7733,11 +7714,6 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       disabled=""
       part="cell day"
@@ -7815,7 +7791,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7823,13 +7799,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -7949,6 +7918,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -8008,21 +7987,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -8059,7 +8035,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -8083,6 +8059,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       disabled=""
       part="cell day"
@@ -8097,18 +8078,13 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8124,7 +8100,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8140,7 +8116,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8156,7 +8132,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8172,7 +8148,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8196,6 +8172,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       disabled=""
       part="cell day"
@@ -8210,18 +8191,13 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8237,7 +8213,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8253,7 +8229,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8269,7 +8245,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8285,7 +8261,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8309,6 +8285,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       disabled=""
       part="cell day"
@@ -8323,18 +8304,13 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8350,7 +8326,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8366,7 +8342,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8382,7 +8358,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8398,7 +8374,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8422,6 +8398,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       disabled=""
       part="cell day"
@@ -8436,18 +8417,13 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8463,7 +8439,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8479,7 +8455,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8495,7 +8471,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8511,7 +8487,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8534,13 +8510,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -8660,6 +8629,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -8719,21 +8698,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -8791,6 +8767,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       disabled=""
       part="cell day"
@@ -8805,11 +8786,6 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       disabled=""
       part="cell day"
@@ -8831,7 +8807,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -8847,7 +8823,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8863,7 +8839,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8879,7 +8855,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8895,29 +8871,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -8932,7 +8892,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8948,7 +8924,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8964,7 +8940,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8980,7 +8956,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8996,7 +8972,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9012,29 +8988,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -9049,7 +9009,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9065,7 +9041,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9081,7 +9057,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9097,7 +9073,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9113,7 +9089,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9129,29 +9105,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -9166,7 +9126,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9182,7 +9158,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9198,7 +9174,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9214,7 +9190,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9230,7 +9206,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9247,7 +9223,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9255,13 +9231,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -9381,6 +9350,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -9440,21 +9419,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -9491,7 +9467,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -9507,29 +9483,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -9544,7 +9504,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9560,7 +9536,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9576,7 +9552,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9592,7 +9568,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9608,7 +9584,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9624,29 +9600,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -9661,7 +9621,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9677,7 +9653,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9693,7 +9669,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9709,7 +9685,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9725,7 +9701,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9741,29 +9717,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -9778,7 +9738,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9794,7 +9770,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9810,7 +9786,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9826,7 +9802,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9842,7 +9818,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9858,29 +9834,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -9895,7 +9855,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -9974,13 +9950,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -10100,6 +10069,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -10159,21 +10138,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -10210,7 +10186,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -10234,13 +10210,18 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 3 April 2005"
+        aria-label="Sunday, April 3, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10250,11 +10231,6 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       disabled=""
       part="cell day"
@@ -10275,7 +10251,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10305,7 +10281,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10335,7 +10311,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10345,6 +10321,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       disabled=""
       part="cell day"
@@ -10359,18 +10340,13 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10400,7 +10376,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10430,7 +10406,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10454,13 +10430,18 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 17 April 2005"
+        aria-label="Sunday, April 17, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10470,11 +10451,6 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       disabled=""
       part="cell day"
@@ -10495,7 +10471,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10525,7 +10501,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10555,7 +10531,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10565,6 +10541,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       disabled=""
       part="cell day"
@@ -10579,18 +10560,13 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10620,7 +10596,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10650,7 +10626,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -10673,13 +10649,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -10797,6 +10766,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -10856,21 +10835,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -10928,6 +10904,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       disabled=""
       part="cell day"
@@ -10942,11 +10923,6 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       disabled=""
       part="cell day"
@@ -10968,7 +10944,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -10998,7 +10974,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -11036,6 +11012,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       disabled=""
       part="cell day"
@@ -11050,18 +11031,13 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -11091,7 +11067,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -11121,7 +11097,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -11145,6 +11121,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       disabled=""
       part="cell day"
@@ -11159,11 +11140,6 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       disabled=""
       part="cell day"
@@ -11184,7 +11160,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -11214,7 +11190,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -11252,6 +11228,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       disabled=""
       part="cell day"
@@ -11266,18 +11247,13 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -11356,13 +11332,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>

--- a/packages/elements/src/calendar/__snapshots__/KeyboardNavigation.md
+++ b/packages/elements/src/calendar/__snapshots__/KeyboardNavigation.md
@@ -54,6 +54,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -113,21 +123,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -142,7 +149,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 1 March 2005"
+        aria-label="Tuesday, March 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -158,7 +165,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 2 March 2005"
+        aria-label="Wednesday, March 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -174,7 +181,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 3 March 2005"
+        aria-label="Thursday, March 3, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -190,7 +197,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 4 March 2005"
+        aria-label="Friday, March 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -206,29 +213,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 5 March 2005"
+        aria-label="Saturday, March 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-03-05">
           5
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 6 March 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-03-06">
-          6
         </slot>
       </div>
     </div>
@@ -243,7 +234,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 7 March 2005"
+        aria-label="Sunday, March 6, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-03-06">
+          6
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, March 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -259,7 +266,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 8 March 2005"
+        aria-label="Tuesday, March 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -275,7 +282,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 9 March 2005"
+        aria-label="Wednesday, March 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -291,7 +298,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 10 March 2005"
+        aria-label="Thursday, March 10, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -307,7 +314,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 11 March 2005"
+        aria-label="Friday, March 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -323,29 +330,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 12 March 2005"
+        aria-label="Saturday, March 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-03-12">
           12
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 13 March 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-03-13">
-          13
         </slot>
       </div>
     </div>
@@ -360,7 +351,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 14 March 2005"
+        aria-label="Sunday, March 13, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-03-13">
+          13
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, March 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -376,7 +383,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 15 March 2005"
+        aria-label="Tuesday, March 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -392,7 +399,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 16 March 2005"
+        aria-label="Wednesday, March 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -408,7 +415,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 17 March 2005"
+        aria-label="Thursday, March 17, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -424,7 +431,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 18 March 2005"
+        aria-label="Friday, March 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -440,29 +447,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 19 March 2005"
+        aria-label="Saturday, March 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-03-19">
           19
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 20 March 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-03-20">
-          20
         </slot>
       </div>
     </div>
@@ -477,7 +468,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 21 March 2005"
+        aria-label="Sunday, March 20, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-03-20">
+          20
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, March 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -493,7 +500,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 22 March 2005"
+        aria-label="Tuesday, March 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -509,7 +516,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 23 March 2005"
+        aria-label="Wednesday, March 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -525,7 +532,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 24 March 2005"
+        aria-label="Thursday, March 24, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -541,7 +548,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 25 March 2005"
+        aria-label="Friday, March 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -557,29 +564,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 26 March 2005"
+        aria-label="Saturday, March 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-03-26">
           26
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 27 March 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-03-27">
-          27
         </slot>
       </div>
     </div>
@@ -594,7 +585,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 28 March 2005"
+        aria-label="Sunday, March 27, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-03-27">
+          27
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, March 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -610,7 +617,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 29 March 2005"
+        aria-label="Tuesday, March 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -626,7 +633,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 30 March 2005"
+        aria-label="Wednesday, March 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -644,7 +651,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 31 March 2005"
+        aria-label="Thursday, March 31, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -652,13 +659,6 @@
         <slot name="2005-03-31">
           31
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -788,6 +788,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -847,21 +857,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -898,7 +905,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -914,29 +921,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -951,7 +942,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -967,7 +974,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -983,7 +990,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -999,7 +1006,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1015,7 +1022,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1031,29 +1038,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -1068,7 +1059,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1084,7 +1091,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1100,7 +1107,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1116,7 +1123,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1132,7 +1139,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1148,29 +1155,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -1185,7 +1176,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1201,7 +1208,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1217,7 +1224,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1233,7 +1240,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1249,7 +1256,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1265,29 +1272,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -1302,7 +1293,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1318,7 +1325,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1334,7 +1341,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1350,7 +1357,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1366,7 +1373,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1383,7 +1390,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1391,13 +1398,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>

--- a/packages/elements/src/calendar/__snapshots__/Multiple.md
+++ b/packages/elements/src/calendar/__snapshots__/Multiple.md
@@ -6,7 +6,7 @@
 
 ```html
 <div
-  aria-label="Selected 3 dates, Thursday, 21 April 2005 and others"
+  aria-label="Selected 3 dates, Thursday, April 21, 2005 and others"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -53,6 +53,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -113,21 +123,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -163,7 +170,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -179,29 +186,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -216,7 +207,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -232,7 +239,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -248,7 +255,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -264,7 +271,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -280,7 +287,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -296,29 +303,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -333,7 +324,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -349,7 +356,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -365,7 +372,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -381,7 +388,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -397,7 +404,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -413,29 +420,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -450,7 +441,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -466,7 +473,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -482,7 +489,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -500,7 +507,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Thursday, 21 April 2005"
+        aria-label="Selected: Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -516,7 +523,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -532,7 +539,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -542,6 +549,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       aria-selected="true"
       part="cell day"
@@ -549,7 +561,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Sunday, 24 April 2005"
+        aria-label="Selected: Sunday, April 24, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -559,18 +571,13 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -586,7 +593,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -602,7 +609,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -618,7 +625,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -634,7 +641,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -651,7 +658,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -659,13 +666,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -733,7 +733,7 @@
 
 ```html
 <div
-  aria-label="Selected 3 dates, Thursday, 21 April 2005 and others"
+  aria-label="Selected 3 dates, Thursday, April 21, 2005 and others"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -1070,7 +1070,7 @@
 
 ```html
 <div
-  aria-label="Selected 3 dates, Thursday, 21 April 2005 and others"
+  aria-label="Selected 3 dates, Thursday, April 21, 2005 and others"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -1454,6 +1454,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -1513,21 +1523,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -1564,7 +1571,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -1580,29 +1587,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -1617,7 +1608,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1633,7 +1640,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1649,7 +1656,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1665,7 +1672,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1681,7 +1688,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1697,29 +1704,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -1734,7 +1725,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1750,7 +1757,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1766,7 +1773,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1782,7 +1789,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1798,7 +1805,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1814,29 +1821,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -1851,7 +1842,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1867,7 +1874,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1883,7 +1890,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1899,7 +1906,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1915,7 +1922,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1931,29 +1938,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -1968,7 +1959,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1984,7 +1991,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2000,7 +2007,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2016,7 +2023,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2032,7 +2039,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2049,7 +2056,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2057,13 +2064,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>

--- a/packages/elements/src/calendar/__snapshots__/Navigation.md
+++ b/packages/elements/src/calendar/__snapshots__/Navigation.md
@@ -54,6 +54,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -113,21 +123,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -171,29 +178,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 1 February 2020"
+        aria-label="Saturday, February 1, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
         <slot name="2020-02-01">
           1
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 2 February 2020"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2020-02-02">
-          2
         </slot>
       </div>
     </div>
@@ -208,7 +199,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 3 February 2020"
+        aria-label="Sunday, February 2, 2020"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2020-02-02">
+          2
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, February 3, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -224,7 +231,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 4 February 2020"
+        aria-label="Tuesday, February 4, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -240,7 +247,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 5 February 2020"
+        aria-label="Wednesday, February 5, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -256,7 +263,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 6 February 2020"
+        aria-label="Thursday, February 6, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -272,7 +279,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 7 February 2020"
+        aria-label="Friday, February 7, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -288,29 +295,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 8 February 2020"
+        aria-label="Saturday, February 8, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2020-02-08">
           8
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 9 February 2020"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2020-02-09">
-          9
         </slot>
       </div>
     </div>
@@ -325,7 +316,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 10 February 2020"
+        aria-label="Sunday, February 9, 2020"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2020-02-09">
+          9
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, February 10, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -341,7 +348,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 11 February 2020"
+        aria-label="Tuesday, February 11, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -357,7 +364,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 12 February 2020"
+        aria-label="Wednesday, February 12, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -373,7 +380,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 13 February 2020"
+        aria-label="Thursday, February 13, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -389,7 +396,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 14 February 2020"
+        aria-label="Friday, February 14, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -405,29 +412,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 15 February 2020"
+        aria-label="Saturday, February 15, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2020-02-15">
           15
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 16 February 2020"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2020-02-16">
-          16
         </slot>
       </div>
     </div>
@@ -442,7 +433,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 17 February 2020"
+        aria-label="Sunday, February 16, 2020"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2020-02-16">
+          16
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, February 17, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -458,7 +465,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 18 February 2020"
+        aria-label="Tuesday, February 18, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -474,7 +481,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 19 February 2020"
+        aria-label="Wednesday, February 19, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -490,7 +497,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 20 February 2020"
+        aria-label="Thursday, February 20, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -506,7 +513,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 21 February 2020"
+        aria-label="Friday, February 21, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -522,29 +529,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 22 February 2020"
+        aria-label="Saturday, February 22, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2020-02-22">
           22
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 23 February 2020"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2020-02-23">
-          23
         </slot>
       </div>
     </div>
@@ -559,7 +550,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 24 February 2020"
+        aria-label="Sunday, February 23, 2020"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2020-02-23">
+          23
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, February 24, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -575,7 +582,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 25 February 2020"
+        aria-label="Tuesday, February 25, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -591,7 +598,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 26 February 2020"
+        aria-label="Wednesday, February 26, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -607,7 +614,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 27 February 2020"
+        aria-label="Thursday, February 27, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -623,7 +630,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 28 February 2020"
+        aria-label="Friday, February 28, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -640,7 +647,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 29 February 2020"
+        aria-label="Saturday, February 29, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -648,13 +655,6 @@
         <slot name="2020-02-29">
           29
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -770,6 +770,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -829,21 +839,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -866,7 +873,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 1 January 2020"
+        aria-label="Wednesday, January 1, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -882,7 +889,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 2 January 2020"
+        aria-label="Thursday, January 2, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -898,7 +905,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 3 January 2020"
+        aria-label="Friday, January 3, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -914,29 +921,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 4 January 2020"
+        aria-label="Saturday, January 4, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2020-01-04">
           4
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 5 January 2020"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2020-01-05">
-          5
         </slot>
       </div>
     </div>
@@ -951,7 +942,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 6 January 2020"
+        aria-label="Sunday, January 5, 2020"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2020-01-05">
+          5
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 6, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -967,7 +974,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 7 January 2020"
+        aria-label="Tuesday, January 7, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -983,7 +990,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 8 January 2020"
+        aria-label="Wednesday, January 8, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -999,7 +1006,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 9 January 2020"
+        aria-label="Thursday, January 9, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1015,7 +1022,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 10 January 2020"
+        aria-label="Friday, January 10, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1031,29 +1038,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 11 January 2020"
+        aria-label="Saturday, January 11, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2020-01-11">
           11
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 12 January 2020"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2020-01-12">
-          12
         </slot>
       </div>
     </div>
@@ -1068,7 +1059,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 13 January 2020"
+        aria-label="Sunday, January 12, 2020"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2020-01-12">
+          12
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 13, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1084,7 +1091,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 14 January 2020"
+        aria-label="Tuesday, January 14, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1100,7 +1107,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 15 January 2020"
+        aria-label="Wednesday, January 15, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1116,7 +1123,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 16 January 2020"
+        aria-label="Thursday, January 16, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1132,7 +1139,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 17 January 2020"
+        aria-label="Friday, January 17, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1148,29 +1155,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 18 January 2020"
+        aria-label="Saturday, January 18, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2020-01-18">
           18
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 19 January 2020"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2020-01-19">
-          19
         </slot>
       </div>
     </div>
@@ -1185,7 +1176,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 20 January 2020"
+        aria-label="Sunday, January 19, 2020"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2020-01-19">
+          19
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 20, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1201,7 +1208,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 21 January 2020"
+        aria-label="Tuesday, January 21, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1217,7 +1224,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 22 January 2020"
+        aria-label="Wednesday, January 22, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1233,7 +1240,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 23 January 2020"
+        aria-label="Thursday, January 23, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1249,7 +1256,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 24 January 2020"
+        aria-label="Friday, January 24, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1265,29 +1272,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 25 January 2020"
+        aria-label="Saturday, January 25, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2020-01-25">
           25
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 26 January 2020"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2020-01-26">
-          26
         </slot>
       </div>
     </div>
@@ -1302,7 +1293,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 27 January 2020"
+        aria-label="Sunday, January 26, 2020"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2020-01-26">
+          26
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 27, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1318,7 +1325,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 28 January 2020"
+        aria-label="Tuesday, January 28, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1334,7 +1341,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 29 January 2020"
+        aria-label="Wednesday, January 29, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1350,7 +1357,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 30 January 2020"
+        aria-label="Thursday, January 30, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1367,7 +1374,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 31 January 2020"
+        aria-label="Friday, January 31, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1375,13 +1382,6 @@
         <slot name="2020-01-31">
           31
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -1504,6 +1504,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -1563,63 +1573,11 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
     <div
       active=""
       aria-selected="false"
@@ -1628,7 +1586,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 1 December 2019"
+        aria-label="Sunday, December 1, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -1638,18 +1596,13 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 2 December 2019"
+        aria-label="Monday, December 2, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1665,7 +1618,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 3 December 2019"
+        aria-label="Tuesday, December 3, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1681,7 +1634,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 4 December 2019"
+        aria-label="Wednesday, December 4, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1697,7 +1650,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 5 December 2019"
+        aria-label="Thursday, December 5, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1713,7 +1666,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 6 December 2019"
+        aria-label="Friday, December 6, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1729,29 +1682,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 7 December 2019"
+        aria-label="Saturday, December 7, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2019-12-07">
           7
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 8 December 2019"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2019-12-08">
-          8
         </slot>
       </div>
     </div>
@@ -1766,7 +1703,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 9 December 2019"
+        aria-label="Sunday, December 8, 2019"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2019-12-08">
+          8
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 9, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1782,7 +1735,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 10 December 2019"
+        aria-label="Tuesday, December 10, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1798,7 +1751,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 11 December 2019"
+        aria-label="Wednesday, December 11, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1814,7 +1767,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 12 December 2019"
+        aria-label="Thursday, December 12, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1830,7 +1783,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 13 December 2019"
+        aria-label="Friday, December 13, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1846,29 +1799,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 14 December 2019"
+        aria-label="Saturday, December 14, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2019-12-14">
           14
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 15 December 2019"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2019-12-15">
-          15
         </slot>
       </div>
     </div>
@@ -1883,7 +1820,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 16 December 2019"
+        aria-label="Sunday, December 15, 2019"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2019-12-15">
+          15
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 16, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1899,7 +1852,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 17 December 2019"
+        aria-label="Tuesday, December 17, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1915,7 +1868,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 18 December 2019"
+        aria-label="Wednesday, December 18, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1931,7 +1884,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 19 December 2019"
+        aria-label="Thursday, December 19, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1947,7 +1900,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 20 December 2019"
+        aria-label="Friday, December 20, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1963,29 +1916,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 21 December 2019"
+        aria-label="Saturday, December 21, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2019-12-21">
           21
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 22 December 2019"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2019-12-22">
-          22
         </slot>
       </div>
     </div>
@@ -2000,7 +1937,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 23 December 2019"
+        aria-label="Sunday, December 22, 2019"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2019-12-22">
+          22
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 23, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2016,7 +1969,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 24 December 2019"
+        aria-label="Tuesday, December 24, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2032,7 +1985,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 25 December 2019"
+        aria-label="Wednesday, December 25, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2048,7 +2001,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 26 December 2019"
+        aria-label="Thursday, December 26, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2064,7 +2017,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 27 December 2019"
+        aria-label="Friday, December 27, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2080,29 +2033,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 28 December 2019"
+        aria-label="Saturday, December 28, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2019-12-28">
           28
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 29 December 2019"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2019-12-29">
-          29
         </slot>
       </div>
     </div>
@@ -2117,7 +2054,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 30 December 2019"
+        aria-label="Sunday, December 29, 2019"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2019-12-29">
+          29
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 30, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2134,7 +2087,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 31 December 2019"
+        aria-label="Tuesday, December 31, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2142,6 +2095,53 @@
         <slot name="2019-12-31">
           31
         </slot>
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
       </div>
     </div>
     <div
@@ -2240,6 +2240,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -2299,21 +2309,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -2350,7 +2357,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 November 2019"
+        aria-label="Friday, November 1, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -2366,29 +2373,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 November 2019"
+        aria-label="Saturday, November 2, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2019-11-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 November 2019"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2019-11-03">
-          3
         </slot>
       </div>
     </div>
@@ -2403,7 +2394,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 November 2019"
+        aria-label="Sunday, November 3, 2019"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2019-11-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, November 4, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2419,7 +2426,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 November 2019"
+        aria-label="Tuesday, November 5, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2435,7 +2442,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 November 2019"
+        aria-label="Wednesday, November 6, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2451,7 +2458,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 November 2019"
+        aria-label="Thursday, November 7, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2467,7 +2474,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 November 2019"
+        aria-label="Friday, November 8, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2483,29 +2490,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 November 2019"
+        aria-label="Saturday, November 9, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2019-11-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 November 2019"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2019-11-10">
-          10
         </slot>
       </div>
     </div>
@@ -2520,7 +2511,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 November 2019"
+        aria-label="Sunday, November 10, 2019"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2019-11-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, November 11, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2536,7 +2543,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 November 2019"
+        aria-label="Tuesday, November 12, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2552,7 +2559,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 November 2019"
+        aria-label="Wednesday, November 13, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2568,7 +2575,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 November 2019"
+        aria-label="Thursday, November 14, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2584,7 +2591,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 November 2019"
+        aria-label="Friday, November 15, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2600,29 +2607,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 November 2019"
+        aria-label="Saturday, November 16, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2019-11-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 November 2019"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2019-11-17">
-          17
         </slot>
       </div>
     </div>
@@ -2637,7 +2628,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 November 2019"
+        aria-label="Sunday, November 17, 2019"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2019-11-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, November 18, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2653,7 +2660,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 November 2019"
+        aria-label="Tuesday, November 19, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2669,7 +2676,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 November 2019"
+        aria-label="Wednesday, November 20, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2685,7 +2692,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 November 2019"
+        aria-label="Thursday, November 21, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2701,7 +2708,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 November 2019"
+        aria-label="Friday, November 22, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2717,29 +2724,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 November 2019"
+        aria-label="Saturday, November 23, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2019-11-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 November 2019"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2019-11-24">
-          24
         </slot>
       </div>
     </div>
@@ -2754,7 +2745,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 November 2019"
+        aria-label="Sunday, November 24, 2019"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2019-11-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, November 25, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2770,7 +2777,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 November 2019"
+        aria-label="Tuesday, November 26, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2786,7 +2793,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 November 2019"
+        aria-label="Wednesday, November 27, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2802,7 +2809,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 November 2019"
+        aria-label="Thursday, November 28, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2818,7 +2825,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 November 2019"
+        aria-label="Friday, November 29, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2835,7 +2842,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 November 2019"
+        aria-label="Saturday, November 30, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2843,13 +2850,6 @@
         <slot name="2019-11-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -2965,6 +2965,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -3024,63 +3034,11 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
     <div
       active=""
       aria-selected="false"
@@ -3089,7 +3047,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 1 December 2019"
+        aria-label="Sunday, December 1, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -3099,18 +3057,13 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 2 December 2019"
+        aria-label="Monday, December 2, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3126,7 +3079,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 3 December 2019"
+        aria-label="Tuesday, December 3, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3142,7 +3095,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 4 December 2019"
+        aria-label="Wednesday, December 4, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3158,7 +3111,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 5 December 2019"
+        aria-label="Thursday, December 5, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3174,7 +3127,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 6 December 2019"
+        aria-label="Friday, December 6, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3190,29 +3143,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 7 December 2019"
+        aria-label="Saturday, December 7, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2019-12-07">
           7
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 8 December 2019"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2019-12-08">
-          8
         </slot>
       </div>
     </div>
@@ -3227,7 +3164,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 9 December 2019"
+        aria-label="Sunday, December 8, 2019"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2019-12-08">
+          8
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 9, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3243,7 +3196,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 10 December 2019"
+        aria-label="Tuesday, December 10, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3259,7 +3212,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 11 December 2019"
+        aria-label="Wednesday, December 11, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3275,7 +3228,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 12 December 2019"
+        aria-label="Thursday, December 12, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3291,7 +3244,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 13 December 2019"
+        aria-label="Friday, December 13, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3307,29 +3260,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 14 December 2019"
+        aria-label="Saturday, December 14, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2019-12-14">
           14
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 15 December 2019"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2019-12-15">
-          15
         </slot>
       </div>
     </div>
@@ -3344,7 +3281,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 16 December 2019"
+        aria-label="Sunday, December 15, 2019"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2019-12-15">
+          15
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 16, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3360,7 +3313,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 17 December 2019"
+        aria-label="Tuesday, December 17, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3376,7 +3329,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 18 December 2019"
+        aria-label="Wednesday, December 18, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3392,7 +3345,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 19 December 2019"
+        aria-label="Thursday, December 19, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3408,7 +3361,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 20 December 2019"
+        aria-label="Friday, December 20, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3424,29 +3377,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 21 December 2019"
+        aria-label="Saturday, December 21, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2019-12-21">
           21
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 22 December 2019"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2019-12-22">
-          22
         </slot>
       </div>
     </div>
@@ -3461,7 +3398,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 23 December 2019"
+        aria-label="Sunday, December 22, 2019"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2019-12-22">
+          22
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 23, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3477,7 +3430,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 24 December 2019"
+        aria-label="Tuesday, December 24, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3493,7 +3446,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 25 December 2019"
+        aria-label="Wednesday, December 25, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3509,7 +3462,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 26 December 2019"
+        aria-label="Thursday, December 26, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3525,7 +3478,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 27 December 2019"
+        aria-label="Friday, December 27, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3541,29 +3494,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 28 December 2019"
+        aria-label="Saturday, December 28, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2019-12-28">
           28
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 29 December 2019"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2019-12-29">
-          29
         </slot>
       </div>
     </div>
@@ -3578,7 +3515,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 30 December 2019"
+        aria-label="Sunday, December 29, 2019"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2019-12-29">
+          29
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 30, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3595,7 +3548,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 31 December 2019"
+        aria-label="Tuesday, December 31, 2019"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3603,6 +3556,53 @@
         <slot name="2019-12-31">
           31
         </slot>
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
       </div>
     </div>
     <div
@@ -3699,6 +3699,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -3758,21 +3768,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -3795,7 +3802,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 1 January 2020"
+        aria-label="Wednesday, January 1, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -3811,7 +3818,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 2 January 2020"
+        aria-label="Thursday, January 2, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3827,7 +3834,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 3 January 2020"
+        aria-label="Friday, January 3, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3843,29 +3850,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 4 January 2020"
+        aria-label="Saturday, January 4, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2020-01-04">
           4
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 5 January 2020"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2020-01-05">
-          5
         </slot>
       </div>
     </div>
@@ -3880,7 +3871,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 6 January 2020"
+        aria-label="Sunday, January 5, 2020"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2020-01-05">
+          5
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 6, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3896,7 +3903,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 7 January 2020"
+        aria-label="Tuesday, January 7, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3912,7 +3919,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 8 January 2020"
+        aria-label="Wednesday, January 8, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3928,7 +3935,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 9 January 2020"
+        aria-label="Thursday, January 9, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3944,7 +3951,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 10 January 2020"
+        aria-label="Friday, January 10, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3960,29 +3967,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 11 January 2020"
+        aria-label="Saturday, January 11, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2020-01-11">
           11
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 12 January 2020"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2020-01-12">
-          12
         </slot>
       </div>
     </div>
@@ -3997,7 +3988,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 13 January 2020"
+        aria-label="Sunday, January 12, 2020"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2020-01-12">
+          12
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 13, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4013,7 +4020,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 14 January 2020"
+        aria-label="Tuesday, January 14, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4029,7 +4036,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 15 January 2020"
+        aria-label="Wednesday, January 15, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4045,7 +4052,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 16 January 2020"
+        aria-label="Thursday, January 16, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4061,7 +4068,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 17 January 2020"
+        aria-label="Friday, January 17, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4077,29 +4084,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 18 January 2020"
+        aria-label="Saturday, January 18, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2020-01-18">
           18
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 19 January 2020"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2020-01-19">
-          19
         </slot>
       </div>
     </div>
@@ -4114,7 +4105,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 20 January 2020"
+        aria-label="Sunday, January 19, 2020"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2020-01-19">
+          19
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 20, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4130,7 +4137,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 21 January 2020"
+        aria-label="Tuesday, January 21, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4146,7 +4153,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 22 January 2020"
+        aria-label="Wednesday, January 22, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4162,7 +4169,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 23 January 2020"
+        aria-label="Thursday, January 23, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4178,7 +4185,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 24 January 2020"
+        aria-label="Friday, January 24, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4194,29 +4201,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 25 January 2020"
+        aria-label="Saturday, January 25, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2020-01-25">
           25
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 26 January 2020"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2020-01-26">
-          26
         </slot>
       </div>
     </div>
@@ -4231,7 +4222,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 27 January 2020"
+        aria-label="Sunday, January 26, 2020"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2020-01-26">
+          26
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 27, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4247,7 +4254,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 28 January 2020"
+        aria-label="Tuesday, January 28, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4263,7 +4270,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 29 January 2020"
+        aria-label="Wednesday, January 29, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4279,7 +4286,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 30 January 2020"
+        aria-label="Thursday, January 30, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4296,7 +4303,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 31 January 2020"
+        aria-label="Friday, January 31, 2020"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4304,13 +4311,6 @@
         <slot name="2020-01-31">
           31
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -4437,6 +4437,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -4496,21 +4506,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -4540,7 +4547,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 1 February 1"
+        aria-label="Thursday, February 1, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -4556,7 +4563,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 2 February 1"
+        aria-label="Friday, February 2, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4572,29 +4579,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 3 February 1"
+        aria-label="Saturday, February 3, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0001-02-03">
           3
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 4 February 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0001-02-04">
-          4
         </slot>
       </div>
     </div>
@@ -4609,7 +4600,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 5 February 1"
+        aria-label="Sunday, February 4, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0001-02-04">
+          4
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, February 5, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4625,7 +4632,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 6 February 1"
+        aria-label="Tuesday, February 6, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4641,7 +4648,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 7 February 1"
+        aria-label="Wednesday, February 7, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4657,7 +4664,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 8 February 1"
+        aria-label="Thursday, February 8, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4673,7 +4680,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 9 February 1"
+        aria-label="Friday, February 9, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4689,29 +4696,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 10 February 1"
+        aria-label="Saturday, February 10, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0001-02-10">
           10
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 11 February 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0001-02-11">
-          11
         </slot>
       </div>
     </div>
@@ -4726,7 +4717,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 12 February 1"
+        aria-label="Sunday, February 11, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0001-02-11">
+          11
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, February 12, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4742,7 +4749,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 13 February 1"
+        aria-label="Tuesday, February 13, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4758,7 +4765,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 14 February 1"
+        aria-label="Wednesday, February 14, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4774,7 +4781,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 15 February 1"
+        aria-label="Thursday, February 15, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4790,7 +4797,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 16 February 1"
+        aria-label="Friday, February 16, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4806,29 +4813,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 17 February 1"
+        aria-label="Saturday, February 17, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0001-02-17">
           17
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 18 February 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0001-02-18">
-          18
         </slot>
       </div>
     </div>
@@ -4843,7 +4834,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 19 February 1"
+        aria-label="Sunday, February 18, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0001-02-18">
+          18
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, February 19, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4859,7 +4866,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 20 February 1"
+        aria-label="Tuesday, February 20, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4875,7 +4882,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 21 February 1"
+        aria-label="Wednesday, February 21, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4891,7 +4898,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 22 February 1"
+        aria-label="Thursday, February 22, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4907,7 +4914,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 23 February 1"
+        aria-label="Friday, February 23, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4923,29 +4930,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 24 February 1"
+        aria-label="Saturday, February 24, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0001-02-24">
           24
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 25 February 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0001-02-25">
-          25
         </slot>
       </div>
     </div>
@@ -4960,7 +4951,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 26 February 1"
+        aria-label="Sunday, February 25, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0001-02-25">
+          25
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, February 26, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4976,7 +4983,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 27 February 1"
+        aria-label="Tuesday, February 27, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4993,7 +5000,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 28 February 1"
+        aria-label="Wednesday, February 28, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5001,13 +5008,6 @@
         <slot name="0001-02-28">
           28
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -5144,6 +5144,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -5203,21 +5213,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       active=""
       aria-selected="false"
@@ -5226,7 +5233,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 1 January 1"
+        aria-label="Monday, January 1, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -5242,7 +5249,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 2 January 1"
+        aria-label="Tuesday, January 2, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5258,7 +5265,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 3 January 1"
+        aria-label="Wednesday, January 3, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5274,7 +5281,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 4 January 1"
+        aria-label="Thursday, January 4, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5290,7 +5297,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 5 January 1"
+        aria-label="Friday, January 5, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5306,29 +5313,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 6 January 1"
+        aria-label="Saturday, January 6, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0001-01-06">
           6
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 7 January 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0001-01-07">
-          7
         </slot>
       </div>
     </div>
@@ -5343,7 +5334,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 8 January 1"
+        aria-label="Sunday, January 7, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0001-01-07">
+          7
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 8, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5359,7 +5366,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 9 January 1"
+        aria-label="Tuesday, January 9, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5375,7 +5382,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 10 January 1"
+        aria-label="Wednesday, January 10, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5391,7 +5398,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 11 January 1"
+        aria-label="Thursday, January 11, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5407,7 +5414,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 12 January 1"
+        aria-label="Friday, January 12, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5423,29 +5430,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 13 January 1"
+        aria-label="Saturday, January 13, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0001-01-13">
           13
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 14 January 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0001-01-14">
-          14
         </slot>
       </div>
     </div>
@@ -5460,7 +5451,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 15 January 1"
+        aria-label="Sunday, January 14, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0001-01-14">
+          14
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 15, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5476,7 +5483,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 16 January 1"
+        aria-label="Tuesday, January 16, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5492,7 +5499,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 17 January 1"
+        aria-label="Wednesday, January 17, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5508,7 +5515,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 18 January 1"
+        aria-label="Thursday, January 18, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5524,7 +5531,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 19 January 1"
+        aria-label="Friday, January 19, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5540,29 +5547,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 20 January 1"
+        aria-label="Saturday, January 20, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0001-01-20">
           20
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 21 January 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0001-01-21">
-          21
         </slot>
       </div>
     </div>
@@ -5577,7 +5568,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 22 January 1"
+        aria-label="Sunday, January 21, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0001-01-21">
+          21
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 22, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5593,7 +5600,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 23 January 1"
+        aria-label="Tuesday, January 23, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5609,7 +5616,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 24 January 1"
+        aria-label="Wednesday, January 24, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5625,7 +5632,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 25 January 1"
+        aria-label="Thursday, January 25, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5641,7 +5648,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 26 January 1"
+        aria-label="Friday, January 26, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5657,29 +5664,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 27 January 1"
+        aria-label="Saturday, January 27, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0001-01-27">
           27
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 28 January 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0001-01-28">
-          28
         </slot>
       </div>
     </div>
@@ -5694,7 +5685,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 29 January 1"
+        aria-label="Sunday, January 28, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0001-01-28">
+          28
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 29, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5710,7 +5717,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 30 January 1"
+        aria-label="Tuesday, January 30, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5727,7 +5734,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 31 January 1"
+        aria-label="Wednesday, January 31, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5735,13 +5742,6 @@
         <slot name="0001-01-31">
           31
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -5878,6 +5878,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -5937,21 +5947,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -5988,7 +5995,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 December 1"
+        aria-label="Friday, December 1, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -6004,29 +6011,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 December 1"
+        aria-label="Saturday, December 2, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0000-12-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 December 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0000-12-03">
-          3
         </slot>
       </div>
     </div>
@@ -6041,7 +6032,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 December 1"
+        aria-label="Sunday, December 3, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0000-12-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 4, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6057,7 +6064,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 December 1"
+        aria-label="Tuesday, December 5, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6073,7 +6080,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 December 1"
+        aria-label="Wednesday, December 6, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6089,7 +6096,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 December 1"
+        aria-label="Thursday, December 7, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6105,7 +6112,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 December 1"
+        aria-label="Friday, December 8, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6121,29 +6128,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 December 1"
+        aria-label="Saturday, December 9, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0000-12-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 December 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0000-12-10">
-          10
         </slot>
       </div>
     </div>
@@ -6158,7 +6149,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 December 1"
+        aria-label="Sunday, December 10, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0000-12-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 11, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6174,7 +6181,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 December 1"
+        aria-label="Tuesday, December 12, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6190,7 +6197,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 December 1"
+        aria-label="Wednesday, December 13, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6206,7 +6213,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 December 1"
+        aria-label="Thursday, December 14, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6222,7 +6229,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 December 1"
+        aria-label="Friday, December 15, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6238,29 +6245,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 December 1"
+        aria-label="Saturday, December 16, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0000-12-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 December 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0000-12-17">
-          17
         </slot>
       </div>
     </div>
@@ -6275,7 +6266,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 December 1"
+        aria-label="Sunday, December 17, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0000-12-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 18, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6291,7 +6298,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 December 1"
+        aria-label="Tuesday, December 19, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6307,7 +6314,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 December 1"
+        aria-label="Wednesday, December 20, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6323,7 +6330,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 December 1"
+        aria-label="Thursday, December 21, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6339,7 +6346,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 December 1"
+        aria-label="Friday, December 22, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6355,29 +6362,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 December 1"
+        aria-label="Saturday, December 23, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0000-12-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 December 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0000-12-24">
-          24
         </slot>
       </div>
     </div>
@@ -6392,7 +6383,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 December 1"
+        aria-label="Sunday, December 24, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0000-12-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 25, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6408,7 +6415,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 December 1"
+        aria-label="Tuesday, December 26, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6424,7 +6431,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 December 1"
+        aria-label="Wednesday, December 27, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6440,7 +6447,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 December 1"
+        aria-label="Thursday, December 28, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6456,7 +6463,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 December 1"
+        aria-label="Friday, December 29, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6472,7 +6479,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 December 1"
+        aria-label="Saturday, December 30, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6482,6 +6489,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       aria-selected="false"
       last-date=""
@@ -6489,7 +6501,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 31 December 1"
+        aria-label="Sunday, December 31, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6497,18 +6509,6 @@
         <slot name="0000-12-31">
           31
         </slot>
-      </div>
-    </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -6614,6 +6614,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -6673,21 +6683,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       active=""
       aria-selected="false"
@@ -6696,7 +6703,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 1 November 2"
+        aria-label="Monday, November 1, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -6712,7 +6719,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 2 November 2"
+        aria-label="Tuesday, November 2, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6728,7 +6735,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 3 November 2"
+        aria-label="Wednesday, November 3, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6744,7 +6751,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 4 November 2"
+        aria-label="Thursday, November 4, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6760,7 +6767,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 5 November 2"
+        aria-label="Friday, November 5, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6776,29 +6783,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 6 November 2"
+        aria-label="Saturday, November 6, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000001-11-06">
           6
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 7 November 2"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000001-11-07">
-          7
         </slot>
       </div>
     </div>
@@ -6813,7 +6804,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 8 November 2"
+        aria-label="Sunday, November 7, 2"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000001-11-07">
+          7
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, November 8, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6829,7 +6836,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 9 November 2"
+        aria-label="Tuesday, November 9, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6845,7 +6852,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 10 November 2"
+        aria-label="Wednesday, November 10, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6861,7 +6868,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 11 November 2"
+        aria-label="Thursday, November 11, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6877,7 +6884,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 12 November 2"
+        aria-label="Friday, November 12, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6893,29 +6900,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 13 November 2"
+        aria-label="Saturday, November 13, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000001-11-13">
           13
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 14 November 2"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000001-11-14">
-          14
         </slot>
       </div>
     </div>
@@ -6930,7 +6921,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 15 November 2"
+        aria-label="Sunday, November 14, 2"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000001-11-14">
+          14
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, November 15, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6946,7 +6953,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 16 November 2"
+        aria-label="Tuesday, November 16, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6962,7 +6969,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 17 November 2"
+        aria-label="Wednesday, November 17, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6978,7 +6985,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 18 November 2"
+        aria-label="Thursday, November 18, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6994,7 +7001,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 19 November 2"
+        aria-label="Friday, November 19, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7010,29 +7017,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 20 November 2"
+        aria-label="Saturday, November 20, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000001-11-20">
           20
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 21 November 2"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000001-11-21">
-          21
         </slot>
       </div>
     </div>
@@ -7047,7 +7038,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 22 November 2"
+        aria-label="Sunday, November 21, 2"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000001-11-21">
+          21
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, November 22, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7063,7 +7070,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 23 November 2"
+        aria-label="Tuesday, November 23, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7079,7 +7086,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 24 November 2"
+        aria-label="Wednesday, November 24, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7095,7 +7102,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 25 November 2"
+        aria-label="Thursday, November 25, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7111,7 +7118,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 26 November 2"
+        aria-label="Friday, November 26, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7127,29 +7134,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 27 November 2"
+        aria-label="Saturday, November 27, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000001-11-27">
           27
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 28 November 2"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000001-11-28">
-          28
         </slot>
       </div>
     </div>
@@ -7164,7 +7155,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 29 November 2"
+        aria-label="Sunday, November 28, 2"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000001-11-28">
+          28
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, November 29, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7181,7 +7188,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 30 November 2"
+        aria-label="Tuesday, November 30, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7189,13 +7196,6 @@
         <slot name="-000001-11-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -7339,6 +7339,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -7398,21 +7408,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -7435,7 +7442,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 1 December 2"
+        aria-label="Wednesday, December 1, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -7451,7 +7458,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 2 December 2"
+        aria-label="Thursday, December 2, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7467,7 +7474,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 3 December 2"
+        aria-label="Friday, December 3, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7483,29 +7490,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 4 December 2"
+        aria-label="Saturday, December 4, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000001-12-04">
           4
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 5 December 2"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000001-12-05">
-          5
         </slot>
       </div>
     </div>
@@ -7520,7 +7511,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 6 December 2"
+        aria-label="Sunday, December 5, 2"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000001-12-05">
+          5
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 6, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7536,7 +7543,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 7 December 2"
+        aria-label="Tuesday, December 7, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7552,7 +7559,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 8 December 2"
+        aria-label="Wednesday, December 8, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7568,7 +7575,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 9 December 2"
+        aria-label="Thursday, December 9, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7584,7 +7591,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 10 December 2"
+        aria-label="Friday, December 10, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7600,29 +7607,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 11 December 2"
+        aria-label="Saturday, December 11, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000001-12-11">
           11
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 12 December 2"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000001-12-12">
-          12
         </slot>
       </div>
     </div>
@@ -7637,7 +7628,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 13 December 2"
+        aria-label="Sunday, December 12, 2"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000001-12-12">
+          12
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 13, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7653,7 +7660,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 14 December 2"
+        aria-label="Tuesday, December 14, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7669,7 +7676,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 15 December 2"
+        aria-label="Wednesday, December 15, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7685,7 +7692,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 16 December 2"
+        aria-label="Thursday, December 16, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7701,7 +7708,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 17 December 2"
+        aria-label="Friday, December 17, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7717,29 +7724,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 18 December 2"
+        aria-label="Saturday, December 18, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000001-12-18">
           18
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 19 December 2"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000001-12-19">
-          19
         </slot>
       </div>
     </div>
@@ -7754,7 +7745,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 20 December 2"
+        aria-label="Sunday, December 19, 2"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000001-12-19">
+          19
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 20, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7770,7 +7777,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 21 December 2"
+        aria-label="Tuesday, December 21, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7786,7 +7793,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 22 December 2"
+        aria-label="Wednesday, December 22, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7802,7 +7809,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 23 December 2"
+        aria-label="Thursday, December 23, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7818,7 +7825,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 24 December 2"
+        aria-label="Friday, December 24, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7834,29 +7841,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 25 December 2"
+        aria-label="Saturday, December 25, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000001-12-25">
           25
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 26 December 2"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000001-12-26">
-          26
         </slot>
       </div>
     </div>
@@ -7871,7 +7862,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 27 December 2"
+        aria-label="Sunday, December 26, 2"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000001-12-26">
+          26
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, December 27, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7887,7 +7894,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 28 December 2"
+        aria-label="Tuesday, December 28, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7903,7 +7910,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 29 December 2"
+        aria-label="Wednesday, December 29, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7919,7 +7926,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 30 December 2"
+        aria-label="Thursday, December 30, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7936,7 +7943,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 31 December 2"
+        aria-label="Friday, December 31, 2"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7944,13 +7951,6 @@
         <slot name="-000001-12-31">
           31
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -8073,6 +8073,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -8132,21 +8142,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -8190,29 +8197,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 1 January 1"
+        aria-label="Saturday, January 1, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
         <slot name="0000-01-01">
           1
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 2 January 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0000-01-02">
-          2
         </slot>
       </div>
     </div>
@@ -8227,7 +8218,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 3 January 1"
+        aria-label="Sunday, January 2, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0000-01-02">
+          2
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 3, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8243,7 +8250,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 4 January 1"
+        aria-label="Tuesday, January 4, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8259,7 +8266,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 5 January 1"
+        aria-label="Wednesday, January 5, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8275,7 +8282,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 6 January 1"
+        aria-label="Thursday, January 6, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8291,7 +8298,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 7 January 1"
+        aria-label="Friday, January 7, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8307,29 +8314,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 8 January 1"
+        aria-label="Saturday, January 8, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0000-01-08">
           8
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 9 January 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0000-01-09">
-          9
         </slot>
       </div>
     </div>
@@ -8344,7 +8335,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 10 January 1"
+        aria-label="Sunday, January 9, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0000-01-09">
+          9
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 10, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8360,7 +8367,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 11 January 1"
+        aria-label="Tuesday, January 11, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8376,7 +8383,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 12 January 1"
+        aria-label="Wednesday, January 12, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8392,7 +8399,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 13 January 1"
+        aria-label="Thursday, January 13, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8408,7 +8415,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 14 January 1"
+        aria-label="Friday, January 14, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8424,29 +8431,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 15 January 1"
+        aria-label="Saturday, January 15, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0000-01-15">
           15
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 16 January 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0000-01-16">
-          16
         </slot>
       </div>
     </div>
@@ -8461,7 +8452,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 17 January 1"
+        aria-label="Sunday, January 16, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0000-01-16">
+          16
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 17, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8477,7 +8484,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 18 January 1"
+        aria-label="Tuesday, January 18, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8493,7 +8500,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 19 January 1"
+        aria-label="Wednesday, January 19, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8509,7 +8516,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 20 January 1"
+        aria-label="Thursday, January 20, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8525,7 +8532,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 21 January 1"
+        aria-label="Friday, January 21, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8541,29 +8548,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 22 January 1"
+        aria-label="Saturday, January 22, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0000-01-22">
           22
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 23 January 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0000-01-23">
-          23
         </slot>
       </div>
     </div>
@@ -8578,7 +8569,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 24 January 1"
+        aria-label="Sunday, January 23, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0000-01-23">
+          23
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, January 24, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8594,7 +8601,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 25 January 1"
+        aria-label="Tuesday, January 25, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8610,7 +8617,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 26 January 1"
+        aria-label="Wednesday, January 26, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8626,7 +8633,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 27 January 1"
+        aria-label="Thursday, January 27, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8642,7 +8649,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 28 January 1"
+        aria-label="Friday, January 28, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8658,29 +8665,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 29 January 1"
+        aria-label="Saturday, January 29, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="0000-01-29">
           29
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 30 January 1"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="0000-01-30">
-          30
         </slot>
       </div>
     </div>
@@ -8691,12 +8682,28 @@
   >
     <div
       aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Sunday, January 30, 1"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="0000-01-30">
+          30
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
       last-date=""
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 31 January 1"
+        aria-label="Monday, January 31, 1"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -8704,13 +8711,6 @@
         <slot name="0000-01-31">
           31
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -16851,6 +16851,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -16910,21 +16920,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -16961,7 +16968,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -16977,29 +16984,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -17014,7 +17005,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17030,7 +17037,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17046,7 +17053,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17062,7 +17069,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17078,7 +17085,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17094,29 +17101,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -17131,7 +17122,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17147,7 +17154,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17163,7 +17170,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17179,7 +17186,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17195,7 +17202,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17211,29 +17218,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -17248,7 +17239,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17264,7 +17271,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17280,7 +17287,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17296,7 +17303,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17312,7 +17319,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17328,29 +17335,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -17365,7 +17356,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17381,7 +17388,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17397,7 +17404,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17413,7 +17420,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17429,7 +17436,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17446,7 +17453,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -17454,13 +17461,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -17908,6 +17908,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -17967,21 +17977,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -18018,7 +18025,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -18034,29 +18041,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -18071,7 +18062,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18087,7 +18094,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18103,7 +18110,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18119,7 +18126,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18135,7 +18142,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18151,29 +18158,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -18188,7 +18179,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18204,7 +18211,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18220,7 +18227,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18236,7 +18243,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18252,7 +18259,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18268,29 +18275,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -18305,7 +18296,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18321,7 +18328,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18337,7 +18344,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18353,7 +18360,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18369,7 +18376,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18385,29 +18392,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -18422,7 +18413,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18438,7 +18445,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18454,7 +18461,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18470,7 +18477,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18486,7 +18493,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18503,7 +18510,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -18511,13 +18518,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -18969,6 +18969,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -19028,21 +19038,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -19079,7 +19086,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -19095,29 +19102,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -19132,7 +19123,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19148,7 +19155,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19164,7 +19171,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19180,7 +19187,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19196,7 +19203,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19212,29 +19219,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -19249,7 +19240,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19265,7 +19272,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19281,7 +19288,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19297,7 +19304,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19313,7 +19320,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19329,29 +19336,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -19366,7 +19357,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19382,7 +19389,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19398,7 +19405,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19414,7 +19421,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19430,7 +19437,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19446,29 +19453,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -19483,7 +19474,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19499,7 +19506,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19515,7 +19522,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19531,7 +19538,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19547,7 +19554,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19564,7 +19571,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -19572,13 +19579,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -21382,6 +21382,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -21441,21 +21451,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -21492,7 +21499,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -21508,29 +21515,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -21545,7 +21536,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21561,7 +21568,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21577,7 +21584,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21593,7 +21600,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21609,7 +21616,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21625,29 +21632,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -21662,7 +21653,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21678,7 +21685,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21694,7 +21701,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21710,7 +21717,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21726,7 +21733,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21742,29 +21749,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -21779,7 +21770,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21795,7 +21802,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21811,7 +21818,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21827,7 +21834,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21843,7 +21850,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21859,29 +21866,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -21896,7 +21887,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21912,7 +21919,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21928,7 +21935,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21944,7 +21951,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21960,7 +21967,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21977,7 +21984,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -21985,13 +21992,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -22109,6 +22109,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -22168,21 +22178,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -22219,7 +22226,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -22235,29 +22242,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -22272,7 +22263,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22288,7 +22295,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22304,7 +22311,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22320,7 +22327,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22336,7 +22343,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22352,29 +22359,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -22389,7 +22380,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22405,7 +22412,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22421,7 +22428,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22437,7 +22444,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22453,7 +22460,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22469,29 +22476,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -22506,7 +22497,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22522,7 +22529,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22538,7 +22545,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22554,7 +22561,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22570,7 +22577,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22586,29 +22593,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -22623,7 +22614,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22639,7 +22646,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22655,7 +22662,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22671,7 +22678,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22687,7 +22694,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22704,7 +22711,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -22712,13 +22719,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -22838,6 +22838,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -22897,21 +22907,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -22948,7 +22955,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -22964,29 +22971,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -23001,7 +22992,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23017,7 +23024,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23033,7 +23040,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23049,7 +23056,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23065,7 +23072,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23081,29 +23088,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -23118,7 +23109,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23134,7 +23141,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23150,7 +23157,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23166,7 +23173,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23182,7 +23189,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23198,29 +23205,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -23235,7 +23226,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23251,7 +23258,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23267,7 +23274,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23283,7 +23290,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23299,7 +23306,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23315,29 +23322,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -23352,7 +23343,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23368,7 +23375,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23384,7 +23391,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23400,7 +23407,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23416,7 +23423,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23433,7 +23440,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23441,13 +23448,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -23563,6 +23563,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -23622,21 +23632,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -23673,7 +23680,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -23689,29 +23696,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -23726,7 +23717,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23742,7 +23749,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23758,7 +23765,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23774,7 +23781,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23790,7 +23797,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23806,29 +23813,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -23843,7 +23834,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23859,7 +23866,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23875,7 +23882,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23891,7 +23898,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23907,7 +23914,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23923,29 +23930,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -23960,7 +23951,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23976,7 +23983,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -23992,7 +23999,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -24008,7 +24015,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -24024,7 +24031,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -24040,29 +24047,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -24077,7 +24068,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -24093,7 +24100,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -24109,7 +24116,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -24125,7 +24132,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -24141,7 +24148,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -24158,7 +24165,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -24166,13 +24173,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>

--- a/packages/elements/src/calendar/__snapshots__/Range.md
+++ b/packages/elements/src/calendar/__snapshots__/Range.md
@@ -6,7 +6,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Friday, 1 April 2005 to Friday, 1 April 2005"
+  aria-label="Selected range is from Friday, April 1, 2005 to Friday, April 1, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -53,6 +53,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -113,21 +123,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -167,7 +174,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Friday, 1 April 2005"
+        aria-label="Selected: Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -183,29 +190,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -220,7 +211,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -236,7 +243,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -252,7 +259,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -268,7 +275,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -284,7 +291,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -300,29 +307,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -337,7 +328,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -353,7 +360,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -369,7 +376,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -385,7 +392,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -401,7 +408,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -417,29 +424,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -454,7 +445,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -470,7 +477,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -486,7 +493,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -502,7 +509,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -518,7 +525,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -534,29 +541,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -571,7 +562,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -587,7 +594,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -603,7 +610,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -619,7 +626,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -635,7 +642,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -652,7 +659,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -660,13 +667,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -734,7 +734,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Friday, 1 April 2005 to Friday, 1 April 2005"
+  aria-label="Selected range is from Friday, April 1, 2005 to Friday, April 1, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -1073,7 +1073,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Friday, 1 April 2005 to Friday, 1 April 2005"
+  aria-label="Selected range is from Friday, April 1, 2005 to Friday, April 1, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -1410,7 +1410,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Tuesday, 1 March 2005 to Wednesday, 1 April 2009"
+  aria-label="Selected range is from Tuesday, March 1, 2005 to Wednesday, April 1, 2009"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -1457,6 +1457,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -1517,21 +1527,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -1569,7 +1576,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -1586,30 +1593,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      range=""
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -1625,7 +1615,24 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      range=""
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1642,7 +1649,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1659,7 +1666,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1676,7 +1683,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1693,7 +1700,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1710,30 +1717,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      range=""
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -1749,7 +1739,24 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      range=""
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1766,7 +1773,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1783,7 +1790,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1800,7 +1807,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1817,7 +1824,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1834,30 +1841,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      range=""
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -1873,7 +1863,24 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      range=""
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1890,7 +1897,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1907,7 +1914,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1924,7 +1931,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1941,7 +1948,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1958,30 +1965,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      range=""
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -1997,7 +1987,24 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      range=""
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2014,7 +2021,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2031,7 +2038,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2048,7 +2055,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2065,7 +2072,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2083,7 +2090,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2091,13 +2098,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -2165,7 +2165,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Tuesday, 1 March 2005 to Wednesday, 1 April 2009"
+  aria-label="Selected range is from Tuesday, March 1, 2005 to Wednesday, April 1, 2009"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -2514,7 +2514,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Tuesday, 1 March 2005 to Wednesday, 1 April 2009"
+  aria-label="Selected range is from Tuesday, March 1, 2005 to Wednesday, April 1, 2009"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -2855,7 +2855,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Tuesday, 4 April 12 to Friday, 21 April 12"
+  aria-label="Selected range is from Tuesday, April 4, 12 to Friday, April 21, 12"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -2902,6 +2902,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -2962,21 +2972,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -3019,29 +3026,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 1 April 12"
+        aria-label="Saturday, April 1, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-01">
           1
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 2 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-02">
-          2
         </slot>
       </div>
     </div>
@@ -3056,7 +3047,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 3 April 12"
+        aria-label="Sunday, April 2, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-02">
+          2
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 3, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3075,7 +3082,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Tuesday, 4 April 12"
+        aria-label="Selected: Tuesday, April 4, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -3092,7 +3099,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 5 April 12"
+        aria-label="Wednesday, April 5, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3109,7 +3116,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 6 April 12"
+        aria-label="Thursday, April 6, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3126,7 +3133,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 7 April 12"
+        aria-label="Friday, April 7, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3143,30 +3150,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 8 April 12"
+        aria-label="Saturday, April 8, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-08">
           8
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      range=""
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 9 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-09">
-          9
         </slot>
       </div>
     </div>
@@ -3182,7 +3172,24 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 10 April 12"
+        aria-label="Sunday, April 9, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-09">
+          9
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      range=""
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 10, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3199,7 +3206,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 11 April 12"
+        aria-label="Tuesday, April 11, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3216,7 +3223,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 12 April 12"
+        aria-label="Wednesday, April 12, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3233,7 +3240,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 13 April 12"
+        aria-label="Thursday, April 13, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3250,7 +3257,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 14 April 12"
+        aria-label="Friday, April 14, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3267,30 +3274,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 15 April 12"
+        aria-label="Saturday, April 15, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-15">
           15
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      range=""
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 16 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-16">
-          16
         </slot>
       </div>
     </div>
@@ -3306,7 +3296,24 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 17 April 12"
+        aria-label="Sunday, April 16, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-16">
+          16
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      range=""
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 17, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3323,7 +3330,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 18 April 12"
+        aria-label="Tuesday, April 18, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3340,7 +3347,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 19 April 12"
+        aria-label="Wednesday, April 19, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3357,7 +3364,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 20 April 12"
+        aria-label="Thursday, April 20, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3375,7 +3382,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Friday, 21 April 12"
+        aria-label="Selected: Friday, April 21, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3391,29 +3398,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 22 April 12"
+        aria-label="Saturday, April 22, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-22">
           22
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 23 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-23">
-          23
         </slot>
       </div>
     </div>
@@ -3428,7 +3419,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 24 April 12"
+        aria-label="Sunday, April 23, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-23">
+          23
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 24, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3444,7 +3451,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 25 April 12"
+        aria-label="Tuesday, April 25, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3460,7 +3467,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 26 April 12"
+        aria-label="Wednesday, April 26, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3476,7 +3483,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 27 April 12"
+        aria-label="Thursday, April 27, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3492,7 +3499,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 28 April 12"
+        aria-label="Friday, April 28, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3508,7 +3515,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 29 April 12"
+        aria-label="Saturday, April 29, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3518,6 +3525,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       aria-selected="false"
       last-date=""
@@ -3525,7 +3537,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 30 April 12"
+        aria-label="Sunday, April 30, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3533,18 +3545,6 @@
         <slot name="-000011-04-30">
           30
         </slot>
-      </div>
-    </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -3600,7 +3600,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Tuesday, 4 April 12 to Friday, 21 April 12"
+  aria-label="Selected range is from Tuesday, April 4, 12 to Friday, April 21, 12"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -3939,7 +3939,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Tuesday, 4 April 12 to Friday, 21 April 12"
+  aria-label="Selected range is from Tuesday, April 4, 12 to Friday, April 21, 12"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -4278,7 +4278,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Wednesday, 6 April 2005"
+  aria-label="Selected range is from Wednesday, April 6, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -4325,6 +4325,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -4385,21 +4395,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -4435,7 +4442,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4451,29 +4458,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -4488,7 +4479,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4504,7 +4511,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4522,7 +4529,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Wednesday, 6 April 2005"
+        aria-label="Selected: Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -4538,7 +4545,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4554,7 +4561,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4570,29 +4577,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -4607,7 +4598,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4623,7 +4630,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4639,7 +4646,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4655,7 +4662,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4671,7 +4678,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4687,29 +4694,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -4724,7 +4715,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4740,7 +4747,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4756,7 +4763,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4772,7 +4779,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4788,7 +4795,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4804,29 +4811,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -4841,7 +4832,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4857,7 +4864,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4873,7 +4880,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4889,7 +4896,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4905,7 +4912,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4922,7 +4929,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4930,13 +4937,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -5004,7 +5004,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Wednesday, 6 April 2005 to Sunday, 10 April 2005"
+  aria-label="Selected range is from Wednesday, April 6, 2005 to Sunday, April 10, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -5051,6 +5051,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -5111,21 +5121,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -5161,7 +5168,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5177,29 +5184,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -5214,7 +5205,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5230,7 +5237,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5248,7 +5255,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Wednesday, 6 April 2005"
+        aria-label="Selected: Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5265,7 +5272,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5282,7 +5289,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5299,7 +5306,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5309,6 +5316,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       active=""
       aria-selected="true"
@@ -5318,7 +5330,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Sunday, 10 April 2005"
+        aria-label="Selected: Sunday, April 10, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -5328,18 +5340,13 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5355,7 +5362,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5371,7 +5378,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5387,7 +5394,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5403,7 +5410,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5419,29 +5426,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -5456,7 +5447,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5472,7 +5479,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5488,7 +5495,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5504,7 +5511,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5520,7 +5527,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5536,29 +5543,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -5573,7 +5564,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5589,7 +5596,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5605,7 +5612,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5621,7 +5628,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5637,7 +5644,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5654,7 +5661,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5662,13 +5669,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -5736,7 +5736,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Wednesday, 13 April 2005"
+  aria-label="Selected range is from Wednesday, April 13, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -5783,6 +5783,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -5843,21 +5853,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -5893,7 +5900,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5909,29 +5916,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -5946,7 +5937,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5962,7 +5969,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5978,7 +5985,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5994,7 +6001,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6010,7 +6017,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6026,29 +6033,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -6063,7 +6054,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6079,7 +6086,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6097,7 +6104,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Wednesday, 13 April 2005"
+        aria-label="Selected: Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -6113,7 +6120,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6129,7 +6136,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6145,29 +6152,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -6182,7 +6173,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6198,7 +6205,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6214,7 +6221,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6230,7 +6237,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6246,7 +6253,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6262,29 +6269,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -6299,7 +6290,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6315,7 +6322,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6331,7 +6338,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6347,7 +6354,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6363,7 +6370,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6380,7 +6387,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6388,13 +6395,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -6462,7 +6462,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Tuesday, 12 April 2005"
+  aria-label="Selected range is from Tuesday, April 12, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -6509,6 +6509,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -6569,21 +6579,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -6619,7 +6626,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6635,29 +6642,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -6672,7 +6663,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6688,7 +6695,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6704,7 +6711,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6720,7 +6727,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6736,7 +6743,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6752,29 +6759,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -6789,7 +6780,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6807,7 +6814,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Tuesday, 12 April 2005"
+        aria-label="Selected: Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -6823,7 +6830,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6839,7 +6846,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6855,7 +6862,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6871,29 +6878,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -6908,7 +6899,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6924,7 +6931,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6940,7 +6947,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6956,7 +6963,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6972,7 +6979,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6988,29 +6995,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -7025,7 +7016,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7041,7 +7048,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7057,7 +7064,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7073,7 +7080,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7089,7 +7096,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7106,7 +7113,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7114,13 +7121,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -7188,7 +7188,7 @@
 
 ```html
 <div
-  aria-label="Selected range is from Tuesday, 12 April 2005"
+  aria-label="Selected range is from Tuesday, April 12, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -7236,6 +7236,16 @@
     role="row"
   >
     <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
+    <div
       abbr="Monday"
       part="cell day-name"
       role="columnheader"
@@ -7295,63 +7305,11 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
-      </div>
-    </div>
     <div
       active=""
       aria-selected="false"
@@ -7360,7 +7318,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 1 May 2005"
+        aria-label="Sunday, May 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -7370,18 +7328,13 @@
         </slot>
       </div>
     </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
     <div
       aria-selected="false"
       part="cell day"
       role="gridcell"
     >
       <div
-        aria-label="Monday, 2 May 2005"
+        aria-label="Monday, May 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7397,7 +7350,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 3 May 2005"
+        aria-label="Tuesday, May 3, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7413,7 +7366,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 4 May 2005"
+        aria-label="Wednesday, May 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7429,7 +7382,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 5 May 2005"
+        aria-label="Thursday, May 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7445,7 +7398,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 6 May 2005"
+        aria-label="Friday, May 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7461,29 +7414,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 7 May 2005"
+        aria-label="Saturday, May 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-05-07">
           7
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 8 May 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-05-08">
-          8
         </slot>
       </div>
     </div>
@@ -7498,7 +7435,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 9 May 2005"
+        aria-label="Sunday, May 8, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-05-08">
+          8
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, May 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7514,7 +7467,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 10 May 2005"
+        aria-label="Tuesday, May 10, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7530,7 +7483,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 11 May 2005"
+        aria-label="Wednesday, May 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7546,7 +7499,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 12 May 2005"
+        aria-label="Thursday, May 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7562,7 +7515,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 13 May 2005"
+        aria-label="Friday, May 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7578,29 +7531,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 14 May 2005"
+        aria-label="Saturday, May 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-05-14">
           14
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 15 May 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-05-15">
-          15
         </slot>
       </div>
     </div>
@@ -7615,7 +7552,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 16 May 2005"
+        aria-label="Sunday, May 15, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-05-15">
+          15
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, May 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7631,7 +7584,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 17 May 2005"
+        aria-label="Tuesday, May 17, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7647,7 +7600,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 18 May 2005"
+        aria-label="Wednesday, May 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7663,7 +7616,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 19 May 2005"
+        aria-label="Thursday, May 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7679,7 +7632,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 20 May 2005"
+        aria-label="Friday, May 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7695,29 +7648,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 21 May 2005"
+        aria-label="Saturday, May 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-05-21">
           21
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 22 May 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-05-22">
-          22
         </slot>
       </div>
     </div>
@@ -7732,7 +7669,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 23 May 2005"
+        aria-label="Sunday, May 22, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-05-22">
+          22
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, May 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7748,7 +7701,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 24 May 2005"
+        aria-label="Tuesday, May 24, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7764,7 +7717,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 25 May 2005"
+        aria-label="Wednesday, May 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7780,7 +7733,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 26 May 2005"
+        aria-label="Thursday, May 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7796,7 +7749,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 27 May 2005"
+        aria-label="Friday, May 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7812,29 +7765,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 28 May 2005"
+        aria-label="Saturday, May 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-05-28">
           28
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 29 May 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-05-29">
-          29
         </slot>
       </div>
     </div>
@@ -7849,7 +7786,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 30 May 2005"
+        aria-label="Sunday, May 29, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-05-29">
+          29
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, May 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7866,7 +7819,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 31 May 2005"
+        aria-label="Tuesday, May 31, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -7874,6 +7827,53 @@
         <slot name="2005-05-31">
           31
         </slot>
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
       </div>
     </div>
     <div

--- a/packages/elements/src/calendar/__snapshots__/Value.md
+++ b/packages/elements/src/calendar/__snapshots__/Value.md
@@ -6,7 +6,7 @@
 
 ```html
 <div
-  aria-label="Selected date is Thursday, 21 April 2005"
+  aria-label="Selected date is Thursday, April 21, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -53,6 +53,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -113,21 +123,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -163,7 +170,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -179,29 +186,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -216,7 +207,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -232,7 +239,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -248,7 +255,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -264,7 +271,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -280,7 +287,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -296,29 +303,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -333,7 +324,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -349,7 +356,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -365,7 +372,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -381,7 +388,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -397,7 +404,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -413,29 +420,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -450,7 +441,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -466,7 +473,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -482,7 +489,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -500,7 +507,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Thursday, 21 April 2005"
+        aria-label="Selected: Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -516,7 +523,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -532,29 +539,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -569,7 +560,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -585,7 +592,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -601,7 +608,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -617,7 +624,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -633,7 +640,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -650,7 +657,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -658,13 +665,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -732,7 +732,7 @@
 
 ```html
 <div
-  aria-label="Selected date is Thursday, 21 April 2005"
+  aria-label="Selected date is Thursday, April 21, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -1069,7 +1069,7 @@
 
 ```html
 <div
-  aria-label="Selected date is Thursday, 21 April 2005"
+  aria-label="Selected date is Thursday, April 21, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -1404,7 +1404,7 @@
 
 ```html
 <div
-  aria-label="Selected date is Thursday, 21 April 2005"
+  aria-label="Selected date is Thursday, April 21, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -1451,6 +1451,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -1511,21 +1521,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -1561,7 +1568,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1577,29 +1584,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -1614,7 +1605,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1630,7 +1637,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1646,7 +1653,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1662,7 +1669,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1678,7 +1685,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1694,29 +1701,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -1731,7 +1722,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1747,7 +1754,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1763,7 +1770,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1779,7 +1786,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1795,7 +1802,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1811,29 +1818,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -1848,7 +1839,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1864,7 +1871,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1880,7 +1887,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1898,7 +1905,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Thursday, 21 April 2005"
+        aria-label="Selected: Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -1914,7 +1921,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1930,29 +1937,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -1967,7 +1958,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1983,7 +1990,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -1999,7 +2006,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2015,7 +2022,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2031,7 +2038,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2048,7 +2055,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2056,13 +2063,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -2132,7 +2132,7 @@
 
 ```html
 <div
-  aria-label="Selected date is Friday, 21 April 12"
+  aria-label="Selected date is Friday, April 21, 12"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -2179,6 +2179,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -2239,21 +2249,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -2296,29 +2303,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 1 April 12"
+        aria-label="Saturday, April 1, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-01">
           1
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 2 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-02">
-          2
         </slot>
       </div>
     </div>
@@ -2333,7 +2324,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 3 April 12"
+        aria-label="Sunday, April 2, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-02">
+          2
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 3, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2349,7 +2356,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 4 April 12"
+        aria-label="Tuesday, April 4, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2365,7 +2372,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 5 April 12"
+        aria-label="Wednesday, April 5, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2381,7 +2388,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 6 April 12"
+        aria-label="Thursday, April 6, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2397,7 +2404,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 7 April 12"
+        aria-label="Friday, April 7, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2413,29 +2420,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 8 April 12"
+        aria-label="Saturday, April 8, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-08">
           8
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 9 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-09">
-          9
         </slot>
       </div>
     </div>
@@ -2450,7 +2441,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 10 April 12"
+        aria-label="Sunday, April 9, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-09">
+          9
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 10, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2466,7 +2473,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 11 April 12"
+        aria-label="Tuesday, April 11, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2482,7 +2489,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 12 April 12"
+        aria-label="Wednesday, April 12, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2498,7 +2505,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 13 April 12"
+        aria-label="Thursday, April 13, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2514,7 +2521,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 14 April 12"
+        aria-label="Friday, April 14, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2530,29 +2537,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 15 April 12"
+        aria-label="Saturday, April 15, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-15">
           15
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 16 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-16">
-          16
         </slot>
       </div>
     </div>
@@ -2567,7 +2558,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 17 April 12"
+        aria-label="Sunday, April 16, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-16">
+          16
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 17, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2583,7 +2590,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 18 April 12"
+        aria-label="Tuesday, April 18, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2599,7 +2606,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 19 April 12"
+        aria-label="Wednesday, April 19, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2615,7 +2622,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 20 April 12"
+        aria-label="Thursday, April 20, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2633,7 +2640,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Friday, 21 April 12"
+        aria-label="Selected: Friday, April 21, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -2649,29 +2656,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 22 April 12"
+        aria-label="Saturday, April 22, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-22">
           22
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 23 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-23">
-          23
         </slot>
       </div>
     </div>
@@ -2686,7 +2677,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 24 April 12"
+        aria-label="Sunday, April 23, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-23">
+          23
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 24, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2702,7 +2709,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 25 April 12"
+        aria-label="Tuesday, April 25, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2718,7 +2725,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 26 April 12"
+        aria-label="Wednesday, April 26, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2734,7 +2741,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 27 April 12"
+        aria-label="Thursday, April 27, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2750,7 +2757,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 28 April 12"
+        aria-label="Friday, April 28, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2766,7 +2773,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 29 April 12"
+        aria-label="Saturday, April 29, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2776,6 +2783,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       aria-selected="false"
       last-date=""
@@ -2783,7 +2795,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 30 April 12"
+        aria-label="Sunday, April 30, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -2791,18 +2803,6 @@
         <slot name="-000011-04-30">
           30
         </slot>
-      </div>
-    </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -2858,7 +2858,7 @@
 
 ```html
 <div
-  aria-label="Selected date is Friday, 21 April 12"
+  aria-label="Selected date is Friday, April 21, 12"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -3195,7 +3195,7 @@
 
 ```html
 <div
-  aria-label="Selected date is Friday, 21 April 12"
+  aria-label="Selected date is Friday, April 21, 12"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -3532,7 +3532,7 @@
 
 ```html
 <div
-  aria-label="Selected date is Friday, 1 April 2005"
+  aria-label="Selected date is Friday, April 1, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -3579,6 +3579,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -3639,21 +3649,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -3691,7 +3698,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Friday, 1 April 2005"
+        aria-label="Selected: Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -3707,29 +3714,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -3744,7 +3735,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3760,7 +3767,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3776,7 +3783,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3792,7 +3799,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3808,7 +3815,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3824,29 +3831,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -3861,7 +3852,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3877,7 +3884,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3893,7 +3900,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3909,7 +3916,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3925,7 +3932,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3941,29 +3948,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -3978,7 +3969,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -3994,7 +4001,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4010,7 +4017,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4026,7 +4033,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4042,7 +4049,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4058,29 +4065,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -4095,7 +4086,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4111,7 +4118,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4127,7 +4134,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4143,7 +4150,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4159,7 +4166,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4176,7 +4183,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 30 April 2005"
+        aria-label="Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4184,13 +4191,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -4258,7 +4258,7 @@
 
 ```html
 <div
-  aria-label="Selected date is Saturday, 30 April 2005"
+  aria-label="Selected date is Saturday, April 30, 2005"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -4305,6 +4305,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -4365,21 +4375,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -4415,7 +4422,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 1 April 2005"
+        aria-label="Friday, April 1, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4431,29 +4438,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 2 April 2005"
+        aria-label="Saturday, April 2, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-02">
           2
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 3 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-03">
-          3
         </slot>
       </div>
     </div>
@@ -4468,7 +4459,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 4 April 2005"
+        aria-label="Sunday, April 3, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-03">
+          3
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 4, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4484,7 +4491,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 5 April 2005"
+        aria-label="Tuesday, April 5, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4500,7 +4507,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 6 April 2005"
+        aria-label="Wednesday, April 6, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4516,7 +4523,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 7 April 2005"
+        aria-label="Thursday, April 7, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4532,7 +4539,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 8 April 2005"
+        aria-label="Friday, April 8, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4548,29 +4555,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 9 April 2005"
+        aria-label="Saturday, April 9, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-09">
           9
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 10 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-10">
-          10
         </slot>
       </div>
     </div>
@@ -4585,7 +4576,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 11 April 2005"
+        aria-label="Sunday, April 10, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-10">
+          10
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 11, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4601,7 +4608,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 12 April 2005"
+        aria-label="Tuesday, April 12, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4617,7 +4624,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 13 April 2005"
+        aria-label="Wednesday, April 13, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4633,7 +4640,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 14 April 2005"
+        aria-label="Thursday, April 14, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4649,7 +4656,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 15 April 2005"
+        aria-label="Friday, April 15, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4665,29 +4672,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 16 April 2005"
+        aria-label="Saturday, April 16, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-16">
           16
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 17 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-17">
-          17
         </slot>
       </div>
     </div>
@@ -4702,7 +4693,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 18 April 2005"
+        aria-label="Sunday, April 17, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-17">
+          17
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 18, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4718,7 +4725,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 19 April 2005"
+        aria-label="Tuesday, April 19, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4734,7 +4741,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 20 April 2005"
+        aria-label="Wednesday, April 20, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4750,7 +4757,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 21 April 2005"
+        aria-label="Thursday, April 21, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4766,7 +4773,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 22 April 2005"
+        aria-label="Friday, April 22, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4782,29 +4789,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 23 April 2005"
+        aria-label="Saturday, April 23, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="2005-04-23">
           23
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 24 April 2005"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="2005-04-24">
-          24
         </slot>
       </div>
     </div>
@@ -4819,7 +4810,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 25 April 2005"
+        aria-label="Sunday, April 24, 2005"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="2005-04-24">
+          24
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 25, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4835,7 +4842,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 26 April 2005"
+        aria-label="Tuesday, April 26, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4851,7 +4858,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 27 April 2005"
+        aria-label="Wednesday, April 27, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4867,7 +4874,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 28 April 2005"
+        aria-label="Thursday, April 28, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4883,7 +4890,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 29 April 2005"
+        aria-label="Friday, April 29, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -4902,7 +4909,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Saturday, 30 April 2005"
+        aria-label="Selected: Saturday, April 30, 2005"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -4910,13 +4917,6 @@
         <slot name="2005-04-30">
           30
         </slot>
-      </div>
-    </div>
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
   </div>
@@ -4986,7 +4986,7 @@
 
 ```html
 <div
-  aria-label="Selected date is Saturday, 1 April 12"
+  aria-label="Selected date is Saturday, April 1, 12"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -5033,6 +5033,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -5093,21 +5103,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -5152,29 +5159,13 @@
       selected=""
     >
       <div
-        aria-label="Selected: Saturday, 1 April 12"
+        aria-label="Selected: Saturday, April 1, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
       >
         <slot name="-000011-04-01">
           1
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 2 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-02">
-          2
         </slot>
       </div>
     </div>
@@ -5189,7 +5180,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 3 April 12"
+        aria-label="Sunday, April 2, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-02">
+          2
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 3, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5205,7 +5212,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 4 April 12"
+        aria-label="Tuesday, April 4, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5221,7 +5228,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 5 April 12"
+        aria-label="Wednesday, April 5, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5237,7 +5244,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 6 April 12"
+        aria-label="Thursday, April 6, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5253,7 +5260,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 7 April 12"
+        aria-label="Friday, April 7, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5269,29 +5276,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 8 April 12"
+        aria-label="Saturday, April 8, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-08">
           8
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 9 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-09">
-          9
         </slot>
       </div>
     </div>
@@ -5306,7 +5297,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 10 April 12"
+        aria-label="Sunday, April 9, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-09">
+          9
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 10, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5322,7 +5329,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 11 April 12"
+        aria-label="Tuesday, April 11, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5338,7 +5345,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 12 April 12"
+        aria-label="Wednesday, April 12, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5354,7 +5361,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 13 April 12"
+        aria-label="Thursday, April 13, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5370,7 +5377,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 14 April 12"
+        aria-label="Friday, April 14, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5386,29 +5393,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 15 April 12"
+        aria-label="Saturday, April 15, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-15">
           15
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 16 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-16">
-          16
         </slot>
       </div>
     </div>
@@ -5423,7 +5414,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 17 April 12"
+        aria-label="Sunday, April 16, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-16">
+          16
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 17, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5439,7 +5446,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 18 April 12"
+        aria-label="Tuesday, April 18, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5455,7 +5462,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 19 April 12"
+        aria-label="Wednesday, April 19, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5471,7 +5478,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 20 April 12"
+        aria-label="Thursday, April 20, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5487,7 +5494,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 21 April 12"
+        aria-label="Friday, April 21, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5503,29 +5510,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 22 April 12"
+        aria-label="Saturday, April 22, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-22">
           22
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 23 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-23">
-          23
         </slot>
       </div>
     </div>
@@ -5540,7 +5531,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 24 April 12"
+        aria-label="Sunday, April 23, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-23">
+          23
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 24, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5556,7 +5563,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 25 April 12"
+        aria-label="Tuesday, April 25, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5572,7 +5579,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 26 April 12"
+        aria-label="Wednesday, April 26, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5588,7 +5595,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 27 April 12"
+        aria-label="Thursday, April 27, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5604,7 +5611,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 28 April 12"
+        aria-label="Friday, April 28, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5620,7 +5627,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 29 April 12"
+        aria-label="Saturday, April 29, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5630,6 +5637,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       aria-selected="false"
       last-date=""
@@ -5637,7 +5649,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Sunday, 30 April 12"
+        aria-label="Sunday, April 30, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5645,18 +5657,6 @@
         <slot name="-000011-04-30">
           30
         </slot>
-      </div>
-    </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div
@@ -5712,7 +5712,7 @@
 
 ```html
 <div
-  aria-label="Selected date is Sunday, 30 April 12"
+  aria-label="Selected date is Sunday, April 30, 12"
   aria-live="polite"
   part="aria-selection"
   role="status"
@@ -5759,6 +5759,16 @@
     part="row day-name-row"
     role="row"
   >
+    <div
+      abbr="Sunday"
+      part="cell day-name"
+      role="columnheader"
+      scope="col"
+    >
+      <div part="cell-content">
+        S
+      </div>
+    </div>
     <div
       abbr="Monday"
       part="cell day-name"
@@ -5819,21 +5829,18 @@
         S
       </div>
     </div>
-    <div
-      abbr="Sunday"
-      part="cell day-name"
-      role="columnheader"
-      scope="col"
-    >
-      <div part="cell-content">
-        S
-      </div>
-    </div>
   </div>
   <div
     part="row"
     role="row"
   >
+    <div
+      part="cell day"
+      role="gridcell"
+    >
+      <div part="cell-content">
+      </div>
+    </div>
     <div
       part="cell day"
       role="gridcell"
@@ -5876,29 +5883,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 1 April 12"
+        aria-label="Saturday, April 1, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-01">
           1
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 2 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-02">
-          2
         </slot>
       </div>
     </div>
@@ -5913,7 +5904,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 3 April 12"
+        aria-label="Sunday, April 2, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-02">
+          2
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 3, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5929,7 +5936,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 4 April 12"
+        aria-label="Tuesday, April 4, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5945,7 +5952,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 5 April 12"
+        aria-label="Wednesday, April 5, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5961,7 +5968,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 6 April 12"
+        aria-label="Thursday, April 6, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5977,7 +5984,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 7 April 12"
+        aria-label="Friday, April 7, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -5993,29 +6000,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 8 April 12"
+        aria-label="Saturday, April 8, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-08">
           8
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 9 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-09">
-          9
         </slot>
       </div>
     </div>
@@ -6030,7 +6021,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 10 April 12"
+        aria-label="Sunday, April 9, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-09">
+          9
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 10, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6046,7 +6053,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 11 April 12"
+        aria-label="Tuesday, April 11, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6062,7 +6069,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 12 April 12"
+        aria-label="Wednesday, April 12, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6078,7 +6085,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 13 April 12"
+        aria-label="Thursday, April 13, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6094,7 +6101,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 14 April 12"
+        aria-label="Friday, April 14, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6110,29 +6117,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 15 April 12"
+        aria-label="Saturday, April 15, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-15">
           15
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 16 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-16">
-          16
         </slot>
       </div>
     </div>
@@ -6147,7 +6138,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 17 April 12"
+        aria-label="Sunday, April 16, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-16">
+          16
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 17, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6163,7 +6170,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 18 April 12"
+        aria-label="Tuesday, April 18, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6179,7 +6186,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 19 April 12"
+        aria-label="Wednesday, April 19, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6195,7 +6202,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 20 April 12"
+        aria-label="Thursday, April 20, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6211,7 +6218,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 21 April 12"
+        aria-label="Friday, April 21, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6227,29 +6234,13 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 22 April 12"
+        aria-label="Saturday, April 22, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
       >
         <slot name="-000011-04-22">
           22
-        </slot>
-      </div>
-    </div>
-    <div
-      aria-selected="false"
-      part="cell day"
-      role="gridcell"
-    >
-      <div
-        aria-label="Sunday, 23 April 12"
-        part="cell-content selection selectable"
-        role="button"
-        tabindex="-1"
-      >
-        <slot name="-000011-04-23">
-          23
         </slot>
       </div>
     </div>
@@ -6264,7 +6255,23 @@
       role="gridcell"
     >
       <div
-        aria-label="Monday, 24 April 12"
+        aria-label="Sunday, April 23, 12"
+        part="cell-content selection selectable"
+        role="button"
+        tabindex="-1"
+      >
+        <slot name="-000011-04-23">
+          23
+        </slot>
+      </div>
+    </div>
+    <div
+      aria-selected="false"
+      part="cell day"
+      role="gridcell"
+    >
+      <div
+        aria-label="Monday, April 24, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6280,7 +6287,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Tuesday, 25 April 12"
+        aria-label="Tuesday, April 25, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6296,7 +6303,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Wednesday, 26 April 12"
+        aria-label="Wednesday, April 26, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6312,7 +6319,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Thursday, 27 April 12"
+        aria-label="Thursday, April 27, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6328,7 +6335,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Friday, 28 April 12"
+        aria-label="Friday, April 28, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6344,7 +6351,7 @@
       role="gridcell"
     >
       <div
-        aria-label="Saturday, 29 April 12"
+        aria-label="Saturday, April 29, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="-1"
@@ -6354,6 +6361,11 @@
         </slot>
       </div>
     </div>
+  </div>
+  <div
+    part="row"
+    role="row"
+  >
     <div
       active=""
       aria-selected="true"
@@ -6363,7 +6375,7 @@
       selected=""
     >
       <div
-        aria-label="Selected: Sunday, 30 April 12"
+        aria-label="Selected: Sunday, April 30, 12"
         part="cell-content selection selectable"
         role="button"
         tabindex="0"
@@ -6371,18 +6383,6 @@
         <slot name="-000011-04-30">
           30
         </slot>
-      </div>
-    </div>
-  </div>
-  <div
-    part="row"
-    role="row"
-  >
-    <div
-      part="cell day"
-      role="gridcell"
-    >
-      <div part="cell-content">
       </div>
     </div>
     <div

--- a/packages/elements/src/calendar/__test__/calendar.defaults.test.js
+++ b/packages/elements/src/calendar/__test__/calendar.defaults.test.js
@@ -89,7 +89,7 @@ describe('calendar/Defaults', function () {
     it('Set dynamic locales', async function () {
       const el = await fixture('<ef-calendar view="2005-04" lang="de"></ef-calendar>');
       expect(el.lang, 'lang is not propagated').to.equal('de');
-      expect(el, 'Russian locale is incorrect').shadowDom.to.equalSnapshot();
+      expect(el, 'German locale is incorrect').shadowDom.to.equalSnapshot();
 
       el.lang = 'th';
       await nextFrame();

--- a/packages/elements/src/calendar/__test__/calendar.defaults.test.js
+++ b/packages/elements/src/calendar/__test__/calendar.defaults.test.js
@@ -42,7 +42,7 @@ describe('calendar/Defaults', function () {
       expect(el.filter, 'filter should not be set').to.equal(null);
     });
     it("Today's date should have additional attribute set", async function () {
-      const el = await fixture('<ef-calendar lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar lang="en-US"></ef-calendar>');
       const now = new Date();
       const todayCells = el.shadowRoot.querySelectorAll('div[today]');
       expect(todayCells.length, 'Incorrect view or only one cell should be set to today').to.equal(1);
@@ -51,12 +51,12 @@ describe('calendar/Defaults', function () {
       );
     });
     it('fill-cells should fill empty cells', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" fill-cells lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" fill-cells lang="en-US"></ef-calendar>');
       expect(el.fillCells, 'fill-cells is not propagated').to.equal(true);
       expect(el).shadowDom.to.equalSnapshot();
     });
     it('DOM structure is correct for 2005-04', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       expect(el.view, 'View property is not propagated').to.equal('2005-04');
       expect(el.renderView, 'Render view should be DAY').to.equal(CalendarRenderView.DAY);
       expect(el).shadowDom.to.equalSnapshot();
@@ -68,7 +68,7 @@ describe('calendar/Defaults', function () {
       expect(el).shadowDom.to.equalSnapshot();
     });
     it('DOM structure is correct for 2005-02', async function () {
-      const el = await fixture('<ef-calendar view="2005-02" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-02" lang="en-US"></ef-calendar>');
       expect(el).shadowDom.to.equalSnapshot();
       await setMonthView(el);
       expect(el).shadowDom.to.equalSnapshot();
@@ -76,7 +76,7 @@ describe('calendar/Defaults', function () {
       expect(el).shadowDom.to.equalSnapshot();
     });
     it('DOM structure is correct for 2004-12', async function () {
-      const el = await fixture('<ef-calendar view="2004-12" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2004-12" lang="en-US"></ef-calendar>');
       expect(el).shadowDom.to.equalSnapshot();
       await setMonthView(el);
       expect(el).shadowDom.to.equalSnapshot();
@@ -90,16 +90,25 @@ describe('calendar/Defaults', function () {
       const el = await fixture('<ef-calendar view="2005-04" lang="de"></ef-calendar>');
       expect(el.lang, 'lang is not propagated').to.equal('de');
       expect(el, 'Russian locale is incorrect').shadowDom.to.equalSnapshot();
+
       el.lang = 'th';
       await nextFrame();
-      expect(el, 'Thai locale is incorrect').shadowDom.to.equalSnapshot();
+      /**
+       * Locales without phrasebook translation, such as 'th', follow en-GB for full date pattern.
+       * https://icu4c-demos.unicode.org/icu-bin/locexp?_=en_GB
+       * Since only Safari 17.4+ & Chrome 125+ format it correctly,
+       * Skip aria-label of div elements using the pattern.
+       */
+      expect(el, 'Thai locale is incorrect').shadowDom.to.equalSnapshot({
+        ignoreAttributes: [{ tags: ['div'], attributes: ['aria-label'] }]
+      });
     });
   });
 
   describe('First Day Of Week', function () {
     it('First day of week should change', async function () {
       const el = await fixture(
-        '<ef-calendar view="2005-04" lang="en-GB" first-day-of-week="4"></ef-calendar>'
+        '<ef-calendar view="2005-04" lang="en-US" first-day-of-week="4"></ef-calendar>'
       );
       expect(el.firstDayOfWeek, 'first-day-of-week is not propagated').to.equal(4);
       expect(el).shadowDom.to.equalSnapshot();
@@ -113,7 +122,7 @@ describe('calendar/Defaults', function () {
 
   describe('Weekends Only Option', function () {
     it('Should support weekends only option', async function () {
-      const el = await fixture('<ef-calendar weekends-only view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar weekends-only view="2005-04" lang="en-US"></ef-calendar>');
       expect(el.weekendsOnly, 'weekends-only is not propagated').to.equal(true);
       expect(el).shadowDom.to.equalSnapshot();
     });
@@ -121,7 +130,7 @@ describe('calendar/Defaults', function () {
 
   describe('Weekdays Only Option', function () {
     it('Should support weekdays only option', async function () {
-      const el = await fixture('<ef-calendar weekdays-only view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar weekdays-only view="2005-04" lang="en-US"></ef-calendar>');
       expect(el.weekdaysOnly, 'weekdays-only is not propagated').to.equal(true);
       expect(el).shadowDom.to.equalSnapshot();
     });
@@ -129,7 +138,7 @@ describe('calendar/Defaults', function () {
 
   describe('Min Value', function () {
     it('Should support min value', async function () {
-      const el = await fixture('<ef-calendar min="2005-04-05" view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar min="2005-04-05" view="2005-04" lang="en-US"></ef-calendar>');
       expect(el.min, 'min is not propagated').to.equal('2005-04-05');
       expect(el).shadowDom.to.equalSnapshot();
     });
@@ -137,7 +146,7 @@ describe('calendar/Defaults', function () {
 
   describe('Max Value', function () {
     it('Should support max value', async function () {
-      const el = await fixture('<ef-calendar max="2005-04-25" view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar max="2005-04-25" view="2005-04" lang="en-US"></ef-calendar>');
       expect(el.max, 'max is not propagated').to.equal('2005-04-25');
       expect(el).shadowDom.to.equalSnapshot();
     });
@@ -145,7 +154,7 @@ describe('calendar/Defaults', function () {
 
   describe('Custom Filter', function () {
     it('Should support custom filter (Odds Only)', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       el.filter = function (value) {
         const date = parse(value);
         return date.getDate() % 2;
@@ -155,7 +164,7 @@ describe('calendar/Defaults', function () {
     });
     it('Should support custom filter combined with default filters', async function () {
       const el = await fixture(
-        '<ef-calendar view="2005-04" min="2005-04-03" max="2005-04-25" weekdays-only lang="en-GB"></ef-calendar>'
+        '<ef-calendar view="2005-04" min="2005-04-03" max="2005-04-25" weekdays-only lang="en-US"></ef-calendar>'
       );
       el.filter = function (value) {
         const date = parse(value);

--- a/packages/elements/src/calendar/__test__/calendar.defaults.test.js
+++ b/packages/elements/src/calendar/__test__/calendar.defaults.test.js
@@ -3,6 +3,7 @@ import '@refinitiv-ui/elements/calendar';
 import { CalendarRenderView } from '@refinitiv-ui/elements/calendar';
 
 import '@refinitiv-ui/elemental-theme/light/ef-calendar.js';
+import '@refinitiv-ui/phrasebook/locale/de/calendar.js';
 import {
   elementUpdated,
   expect,

--- a/packages/elements/src/calendar/__test__/calendar.keyboard.test.js
+++ b/packages/elements/src/calendar/__test__/calendar.keyboard.test.js
@@ -11,25 +11,25 @@ const cellIndex = (calendarEl) => String(calendarEl.activeCellIndex); // access 
 describe('calendar/KeyboardNavigation', function () {
   describe('Day View', function () {
     it('Can navigate over a single month using arrows keys', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       const renderRoot = el.renderRoot;
       await right(renderRoot);
-      expect(cellIndex(el)).to.equal('4,0', 'Right: 01/04/2005 should be selected');
+      expect(cellIndex(el)).to.equal('5,0', 'Right: 01/04/2005 should be selected');
       await right(renderRoot);
-      expect(cellIndex(el)).to.equal('5,0', 'Right: 02/04/2005 should be selected');
+      expect(cellIndex(el)).to.equal('6,0', 'Right: 02/04/2005 should be selected');
       await down(renderRoot);
-      expect(cellIndex(el)).to.equal('5,1', 'Down: 09/04/2005 should be selected');
+      expect(cellIndex(el)).to.equal('6,1', 'Down: 09/04/2005 should be selected');
       await left(renderRoot);
-      expect(cellIndex(el)).to.equal('4,1', 'Left: 08/04/2005 should be selected');
+      expect(cellIndex(el)).to.equal('5,1', 'Left: 08/04/2005 should be selected');
       await up(renderRoot);
-      expect(cellIndex(el)).to.equal('4,0', 'Up: 01/04/2005 should be selected');
+      expect(cellIndex(el)).to.equal('5,0', 'Up: 01/04/2005 should be selected');
       await end(renderRoot);
-      expect(cellIndex(el)).to.equal('5,4', 'End: 30/04/2005 should be selected');
+      expect(cellIndex(el)).to.equal('6,4', 'End: 30/04/2005 should be selected');
       await home(renderRoot);
-      expect(cellIndex(el)).to.equal('4,0', 'Home: 01/04/2005 should be selected');
+      expect(cellIndex(el)).to.equal('5,0', 'Home: 01/04/2005 should be selected');
     });
     it('Can switch months using arrow keys', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       const renderRoot = el.renderRoot;
       await right(renderRoot);
       await left(renderRoot);
@@ -38,21 +38,21 @@ describe('calendar/KeyboardNavigation', function () {
       expect(el).shadowDom.to.equalSnapshot();
     });
     it('Cannot navigate over disabled dates', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB" weekends-only></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US" weekends-only></ef-calendar>');
       const renderRoot = el.renderRoot;
       await right(renderRoot);
-      expect(cellIndex(el)).to.equal('5,0', 'Right: 02/04/2005 should be selected');
+      expect(cellIndex(el)).to.equal('6,0', 'Right: 02/04/2005 should be selected');
       await right(renderRoot);
       await right(renderRoot);
-      expect(cellIndex(el)).to.equal('5,1', 'Right: 09/04/2005 should be selected');
+      expect(cellIndex(el)).to.equal('6,1', 'Right: 09/04/2005 should be selected');
       await left(renderRoot);
-      expect(cellIndex(el)).to.equal('6,0', 'Left: 03/04/2005 should be selected');
+      expect(cellIndex(el)).to.equal('0,1', 'Left: 03/04/2005 should be selected');
     });
   });
 
   describe('Month View', function () {
     it('Can navigate over a single year using arrows keys', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       await setMonthView(el);
       const renderRoot = el.renderRoot;
       await right(renderRoot);
@@ -71,7 +71,7 @@ describe('calendar/KeyboardNavigation', function () {
       expect(cellIndex(el)).to.equal('0,0', 'Home: 11/2004 should be selected');
     });
     it('Can switch years using arrow keys', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       await setMonthView(el);
       const renderRoot = el.renderRoot;
       await right(renderRoot);
@@ -84,7 +84,7 @@ describe('calendar/KeyboardNavigation', function () {
 
   describe('Year View', function () {
     it('Can navigate over a single decade using arrows keys', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       await setYearView(el);
       const renderRoot = el.renderRoot;
       await right(renderRoot);
@@ -103,7 +103,7 @@ describe('calendar/KeyboardNavigation', function () {
       expect(cellIndex(el)).to.equal('0,0', 'Home: 2000 should be selected');
     });
     it('Can switch decades using arrow keys', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       await setYearView(el);
       const renderRoot = el.renderRoot;
       await right(renderRoot);

--- a/packages/elements/src/calendar/__test__/calendar.multiple.test.js
+++ b/packages/elements/src/calendar/__test__/calendar.multiple.test.js
@@ -18,7 +18,7 @@ describe('calendar/Multiple', function () {
   describe('Multiple Test', function () {
     it('Multiple: selected values should be highlighted', async function () {
       const el = await fixture(
-        '<ef-calendar view="2005-04" multiple values="2005-04-21,2005-04-24,2009-01-25" lang="en-GB"></ef-calendar>'
+        '<ef-calendar view="2005-04" multiple values="2005-04-21,2005-04-24,2009-01-25" lang="en-US"></ef-calendar>'
       );
       expect(el.value, 'Value should pick first from values').to.equal('2005-04-21');
       expect(el.values.join(','), 'values is not reflected').to.equal('2005-04-21,2005-04-24,2009-01-25');
@@ -29,7 +29,7 @@ describe('calendar/Multiple', function () {
       expect(el).shadowDom.to.equalSnapshot();
     });
     it('Multiple: should be possible to select values by passing property', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" multiple lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" multiple lang="en-US"></ef-calendar>');
       el.values = ['2005-04-21', '2005-04-24'];
       expect(el).shadowDom.to.equalSnapshot();
     });
@@ -37,7 +37,7 @@ describe('calendar/Multiple', function () {
 
   describe('Navigation Multiple Value', function () {
     it('It should be possible to select multiple values on click', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" multiple lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" multiple lang="en-US"></ef-calendar>');
       const values = listenValueChangeEvent(el);
 
       const cells = getDateCells(el);

--- a/packages/elements/src/calendar/__test__/calendar.navigation.test.js
+++ b/packages/elements/src/calendar/__test__/calendar.navigation.test.js
@@ -25,7 +25,7 @@ const listenViewChangeEvent = (el) => {
 describe('calendar/Navigation', function () {
   describe('Navigation Day', function () {
     it('Day: previous button switches month to previous', async function () {
-      const el = await fixture('<ef-calendar view="2020-02" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2020-02" lang="en-US"></ef-calendar>');
       const viewValues = listenViewChangeEvent(el);
       expect(el, 'Day view: 2020-02').shadowDom.to.equalSnapshot();
       await clickPrev(el);
@@ -35,7 +35,7 @@ describe('calendar/Navigation', function () {
       expect(viewValues.join(','), 'view-changed event details are wrong').to.equal('2020-01,2019-12');
     });
     it('Day: next button switches month to next', async function () {
-      const el = await fixture('<ef-calendar view="2019-11" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2019-11" lang="en-US"></ef-calendar>');
       const viewValues = listenViewChangeEvent(el);
       expect(el, 'Day view: 2019-11').shadowDom.to.equalSnapshot();
       await clickNext(el);
@@ -48,7 +48,7 @@ describe('calendar/Navigation', function () {
 
   describe('AD/BC Navigation Day', function () {
     it('AD/BC Day: previous button switches month to previous', async function () {
-      const el = await fixture('<ef-calendar view="0001-02" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="0001-02" lang="en-US"></ef-calendar>');
       const viewValues = listenViewChangeEvent(el);
       expect(el, 'Day view: Feb, 1AD').shadowDom.to.equalSnapshot();
       await clickPrev(el);
@@ -58,7 +58,7 @@ describe('calendar/Navigation', function () {
       expect(viewValues.join(','), 'view-changed event details are wrong').to.equal('0001-01,0000-12');
     });
     it('AD/BC Day: next button switches month to next', async function () {
-      const el = await fixture('<ef-calendar view="-000001-11" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="-000001-11" lang="en-US"></ef-calendar>');
       const viewValues = listenViewChangeEvent(el);
       expect(el, 'Day view: Nov, 2BC').shadowDom.to.equalSnapshot();
       await clickNext(el);
@@ -71,7 +71,7 @@ describe('calendar/Navigation', function () {
 
   describe('Navigation Month', function () {
     it('Month: previous button switches year to previous', async function () {
-      const el = await fixture('<ef-calendar view="2019-02" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2019-02" lang="en-US"></ef-calendar>');
       await setMonthView(el);
       const viewValues = listenViewChangeEvent(el);
       expect(el, 'Month view: 2019').shadowDom.to.equalSnapshot();
@@ -82,7 +82,7 @@ describe('calendar/Navigation', function () {
       expect(viewValues.join(','), 'view-changed event details are wrong').to.equal('2018-02,2017-02');
     });
     it('Month: next button switches year to next', async function () {
-      const el = await fixture('<ef-calendar view="2017-11" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2017-11" lang="en-US"></ef-calendar>');
       await setMonthView(el);
       const viewValues = listenViewChangeEvent(el);
       expect(el, 'Month view: 2017').shadowDom.to.equalSnapshot();
@@ -96,7 +96,7 @@ describe('calendar/Navigation', function () {
 
   describe('AD/BC Navigation Month', function () {
     it('AD/BC Month: previous button switches year to previous', async function () {
-      const el = await fixture('<ef-calendar view="0001-02" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="0001-02" lang="en-US"></ef-calendar>');
       await setMonthView(el);
       const viewValues = listenViewChangeEvent(el);
       expect(el, 'Month view: 1AD').shadowDom.to.equalSnapshot();
@@ -107,7 +107,7 @@ describe('calendar/Navigation', function () {
       expect(viewValues.join(','), 'view-changed event details are wrong').to.equal('0000-02,-000001-02');
     });
     it('AD/BC Month: next button switches year to next', async function () {
-      const el = await fixture('<ef-calendar view="-000001-11" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="-000001-11" lang="en-US"></ef-calendar>');
       await setMonthView(el);
       const viewValues = listenViewChangeEvent(el);
       expect(el, 'Month view: 2BC').shadowDom.to.equalSnapshot();
@@ -121,7 +121,7 @@ describe('calendar/Navigation', function () {
 
   describe('Navigation Year', function () {
     it('Year: previous button switches decade to previous', async function () {
-      const el = await fixture('<ef-calendar view="1974-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="1974-04" lang="en-US"></ef-calendar>');
       await setYearView(el);
       const viewValues = listenViewChangeEvent(el);
       expect(el, 'Year view: 1968-1983').shadowDom.to.equalSnapshot();
@@ -132,7 +132,7 @@ describe('calendar/Navigation', function () {
       expect(viewValues.join(','), 'view-changed event details are wrong').to.equal('1958-04,1942-04');
     });
     it('Year: next button switches decade to next', async function () {
-      const el = await fixture('<ef-calendar view="1900-01" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="1900-01" lang="en-US"></ef-calendar>');
       await setYearView(el);
       const viewValues = listenViewChangeEvent(el);
       expect(el, 'Year view: 1888-1903').shadowDom.to.equalSnapshot();
@@ -146,7 +146,7 @@ describe('calendar/Navigation', function () {
 
   describe('AD/BC Navigation Year', function () {
     it('AD/BC Year: previous button switches decade to previous', async function () {
-      const el = await fixture('<ef-calendar view="0017-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="0017-04" lang="en-US"></ef-calendar>');
       await setYearView(el);
       const viewValues = listenViewChangeEvent(el);
       expect(el, 'Year view: 16AD - 31AD').shadowDom.to.equalSnapshot();
@@ -157,7 +157,7 @@ describe('calendar/Navigation', function () {
       expect(viewValues.join(','), 'view-changed event details are wrong').to.equal('0001-04,-000015-04');
     });
     it('AD/BC Year: next button switches decade to next', async function () {
-      const el = await fixture('<ef-calendar view="-000015-01" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="-000015-01" lang="en-US"></ef-calendar>');
       await setYearView(el);
       const viewValues = listenViewChangeEvent(el);
       expect(el, 'Year view: 17BC - 2BC').shadowDom.to.equalSnapshot();
@@ -171,7 +171,7 @@ describe('calendar/Navigation', function () {
 
   describe('View Change', function () {
     it('View button should change views', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       expect(el, 'Day view: 2005-04').shadowDom.to.equalSnapshot();
       await clickView(el);
       expect(el, 'Year view: 2000-2015').shadowDom.to.equalSnapshot();
@@ -186,7 +186,7 @@ describe('calendar/Navigation', function () {
 
   describe('View Change Tap', function () {
     it('View should change on tap', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       await setYearView(el);
       expect(el, 'Year view: 2000-2015').shadowDom.to.equalSnapshot();
       const cell2001 = getDateCells(el)[1];
@@ -199,7 +199,7 @@ describe('calendar/Navigation', function () {
     });
 
     it('Clicking on previous year month should switch years', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       await setMonthView(el);
       const cellNov2004 = getDateCells(el)[0];
       cellNov2004.click();
@@ -207,7 +207,7 @@ describe('calendar/Navigation', function () {
     });
 
     it('Clicking on next year month should switch years', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       await setMonthView(el);
       const cellFeb2005 = getDateCells(el)[15];
       cellFeb2005.click();
@@ -217,13 +217,13 @@ describe('calendar/Navigation', function () {
 
   describe('Vew Change Keyboard', function () {
     it('Pressing escape key on month view should return to day view', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       await setMonthView(el);
       await keyboardEvent(el.shadowRoot.querySelector('[part=table]'), 'Escape');
       expect(el, 'Day view: 2005-04').shadowDom.to.equalSnapshot();
     });
     it('Pressing escape key on year view should return to day view', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       await setYearView(el);
       await keyboardEvent(el.shadowRoot.querySelector('[part=table]'), 'Escape');
       expect(el, 'Day view: 2005-04').shadowDom.to.equalSnapshot();
@@ -232,7 +232,7 @@ describe('calendar/Navigation', function () {
 
   describe('View Change Event', function () {
     it('Prevent default should stop view-change event', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       el.addEventListener('view-changed', (event) => {
         event.preventDefault();
       });
@@ -246,7 +246,7 @@ describe('calendar/Navigation', function () {
   describe('Disabled Navigation', function () {
     it('It should not be possible to navigate over disabled calendar', async function () {
       this.skip(); /* a bug with ef-button, which is clickable when parent disabled */
-      const el = await fixture('<ef-calendar disabled view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar disabled view="2005-04" lang="en-US"></ef-calendar>');
       await clickPrev(el);
       expect(el.view, 'When disabled, clicking on previous should not change views').to.equal('2005-04');
       await clickNext(el);

--- a/packages/elements/src/calendar/__test__/calendar.range.test.js
+++ b/packages/elements/src/calendar/__test__/calendar.range.test.js
@@ -18,7 +18,7 @@ describe('calendar/Range', function () {
   describe('Range', function () {
     it('Range: selected values should be highlighted', async function () {
       const el = await fixture(
-        '<ef-calendar range view="2005-04" values="2005-04-01,2005-04-01" lang="en-GB"></ef-calendar>'
+        '<ef-calendar range view="2005-04" values="2005-04-01,2005-04-01" lang="en-US"></ef-calendar>'
       );
       expect(el).shadowDom.to.equalSnapshot();
       await setMonthView(el);
@@ -28,7 +28,7 @@ describe('calendar/Range', function () {
     });
     it('Range: selected values should be highlighted across months and years', async function () {
       const el = await fixture(
-        '<ef-calendar range view="2005-04" values="2005-03-01,2009-04-01" lang="en-GB"></ef-calendar>'
+        '<ef-calendar range view="2005-04" values="2005-03-01,2009-04-01" lang="en-US"></ef-calendar>'
       );
       expect(el).shadowDom.to.equalSnapshot();
       await setMonthView(el);
@@ -38,7 +38,7 @@ describe('calendar/Range', function () {
     });
     it('AD/BC Range: selected values should be highlighted', async function () {
       const el = await fixture(
-        '<ef-calendar range view="-000011-04" values="-000011-04-04,-000011-04-21" lang="en-GB"></ef-calendar>'
+        '<ef-calendar range view="-000011-04" values="-000011-04-04,-000011-04-21" lang="en-US"></ef-calendar>'
       );
       expect(el).shadowDom.to.equalSnapshot();
       await setMonthView(el);
@@ -50,7 +50,7 @@ describe('calendar/Range', function () {
 
   describe('Navigation Range Value', function () {
     it('It should be possible to select range values on click', async function () {
-      const el = await fixture('<ef-calendar range view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar range view="2005-04" lang="en-US"></ef-calendar>');
       const values = listenValueChangeEvent(el);
 
       let cells = getDateCells(el);
@@ -90,7 +90,7 @@ describe('calendar/Range', function () {
       expect(el).shadowDom.to.equalSnapshot();
     });
     it('It should not be possible to deselect all range values', async function () {
-      const el = await fixture('<ef-calendar range view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar range view="2005-04" lang="en-US"></ef-calendar>');
       let cells = getDateCells(el);
 
       cells[5].click(); // April 06
@@ -110,7 +110,7 @@ describe('calendar/Range', function () {
       expect(el.values.join(','), 'from should be populated').to.equal('2005-04-06');
     });
     it('It should be possible to select the same value for From and To', async function () {
-      const el = await fixture('<ef-calendar range view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar range view="2005-04" lang="en-US"></ef-calendar>');
       let cells = getDateCells(el);
 
       cells[5].click(); // April 06

--- a/packages/elements/src/calendar/__test__/calendar.value.test.js
+++ b/packages/elements/src/calendar/__test__/calendar.value.test.js
@@ -17,7 +17,7 @@ const listenValueChangeEvent = (el) => {
 describe('calendar/Value', function () {
   describe('Value Is Selected', function () {
     it('Selected value should be highlighted when set as attribute', async function () {
-      const el = await fixture('<ef-calendar value="2005-04-21" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar value="2005-04-21" lang="en-US"></ef-calendar>');
       expect(el).shadowDom.to.equalSnapshot();
       await setMonthView(el);
       expect(el).shadowDom.to.equalSnapshot();
@@ -27,7 +27,7 @@ describe('calendar/Value', function () {
       expect(el.values.join(','), 'values is not reflected to value').to.equal('2005-04-21');
     });
     it('Selected value should be highlighted when set as property', async function () {
-      const el = await fixture('<ef-calendar lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar lang="en-US"></ef-calendar>');
       const values = listenValueChangeEvent(el);
       el.value = '2005-04-21';
       await elementUpdated(el);
@@ -36,14 +36,14 @@ describe('calendar/Value', function () {
       expect(el.values.join(','), 'values is not reflected to value').to.equal('2005-04-21');
     });
     it('It should be possible to clear the value', async function () {
-      const el = await fixture('<ef-calendar value="2005-04-21" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar value="2005-04-21" lang="en-US"></ef-calendar>');
       el.value = '';
       await elementUpdated(el);
       expect(el.value, 'value is not clear').to.equal('');
       expect(el.shadowRoot.querySelector('[selected]'), 'selected flag is not removed').to.equal(null);
     });
     it('AD/BC selected value should be highlighted', async function () {
-      const el = await fixture('<ef-calendar value="-000011-04-21" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar value="-000011-04-21" lang="en-US"></ef-calendar>');
       expect(el).shadowDom.to.equalSnapshot();
       await setMonthView(el);
       expect(el).shadowDom.to.equalSnapshot();
@@ -56,7 +56,7 @@ describe('calendar/Value', function () {
 
   describe('Navigation Value', function () {
     it('It should be possible to select value on click', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       const values = listenValueChangeEvent(el);
       const cells = getDateCells(el);
       cells[0].click(); // April 01
@@ -72,7 +72,7 @@ describe('calendar/Value', function () {
     });
 
     it('It should not be possible to deselect value on click', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       const cells = getDateCells(el);
       cells[0].click(); // April 01
       await elementUpdated(el);
@@ -85,7 +85,7 @@ describe('calendar/Value', function () {
     });
 
     it('AD/BC It should be possible to select value on click', async function () {
-      const el = await fixture('<ef-calendar view="-000011-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="-000011-04" lang="en-US"></ef-calendar>');
       const values = listenValueChangeEvent(el);
       const cells = getDateCells(el);
       cells[0].click(); // April 01
@@ -102,7 +102,7 @@ describe('calendar/Value', function () {
 
     it('It should be possible to select custom cell content on click', async function () {
       const el = await fixture(`
-        <ef-calendar view="2005-04" lang="en-GB">
+        <ef-calendar view="2005-04" lang="en-US">
           <div slot="2005-04-01" style="width: 100%; height: 100%;">
             <ef-icon icon="cross"></ef-icon>
           </div>
@@ -117,7 +117,7 @@ describe('calendar/Value', function () {
 
     it('It should not be possible to deselect custom cell content on click', async function () {
       const el = await fixture(`
-        <ef-calendar view="2005-04" lang="en-GB">
+        <ef-calendar view="2005-04" lang="en-US">
           <div slot="2005-04-01" style="width: 100%; height: 100%;">
             <ef-icon icon="cross"></ef-icon>
           </div>
@@ -133,7 +133,7 @@ describe('calendar/Value', function () {
     });
 
     it('It should be possible to select value on Spacebar', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       const cells = getDateCells(el);
       await keyboardEvent(cells[0], 'Spacebar');
       await keyboardEvent(cells[0], 'Spacebar', 'keyup'); // April 01
@@ -141,7 +141,7 @@ describe('calendar/Value', function () {
     });
 
     it('It should not be possible to deselect value on Spacebar', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       const cells = getDateCells(el);
       await keyboardEvent(cells[0], 'Spacebar');
       await keyboardEvent(cells[0], 'Spacebar', 'keyup'); // April 01
@@ -152,7 +152,7 @@ describe('calendar/Value', function () {
     });
 
     it("It should be possible to select value on ' ' ", async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       const cells = getDateCells(el);
       await keyboardEvent(cells[0], ' ');
       await keyboardEvent(cells[0], ' ', 'keyup'); // April 01
@@ -160,14 +160,14 @@ describe('calendar/Value', function () {
     });
 
     it('It should be possible to select value on Enter', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US"></ef-calendar>');
       const cells = getDateCells(el);
       await keyboardEvent(cells[0], 'Enter'); // April 01
       expect(el.value, 'value is not set').to.equal('2005-04-01');
     });
 
     it('Clicking on disabled or empty cell should do nothing', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB" weekends-only></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US" weekends-only></ef-calendar>');
       const values = listenValueChangeEvent(el);
       const cells = el.shadowRoot.querySelectorAll('[part="cell day"]');
       cells[0].click(); // Empty cell
@@ -180,7 +180,7 @@ describe('calendar/Value', function () {
     });
 
     it('Setting invalid date should do nothing', async function () {
-      const el = await fixture('<ef-calendar view="2005-04" lang="en-GB" weekends-only></ef-calendar>');
+      const el = await fixture('<ef-calendar view="2005-04" lang="en-US" weekends-only></ef-calendar>');
       el.value = 'invalid-value';
       expect(el.value, 'value should not be set to invalid').to.equal('');
     });
@@ -188,7 +188,7 @@ describe('calendar/Value', function () {
 
   describe('Disabled/Readonly test', function () {
     it('Disabled: it should not be possible to select value on click', async function () {
-      const el = await fixture('<ef-calendar disabled lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar disabled lang="en-US"></ef-calendar>');
       const values = listenValueChangeEvent(el);
       const cells = getDateCells(el);
       cells[0].click(); // April 01
@@ -198,7 +198,7 @@ describe('calendar/Value', function () {
       expect(values.join(','), 'value-changed is fired').to.equal('');
     });
     it('Readonly: it should not be possible to select value on click', async function () {
-      const el = await fixture('<ef-calendar readonly lang="en-GB"></ef-calendar>');
+      const el = await fixture('<ef-calendar readonly lang="en-US"></ef-calendar>');
       const values = listenValueChangeEvent(el);
       const cells = getDateCells(el);
       cells[0].click(); // April 01

--- a/packages/translate/__demo__/index.html
+++ b/packages/translate/__demo__/index.html
@@ -39,10 +39,10 @@
     <test-translate lang="ru"></test-translate>
 
     <header>Default Language with parameters (Wed Mar 03 1999 14:15:19 GMT+0000 (GMT))</header>
-    <test-translate date="920470519000" lang="en-GB"></test-translate>
+    <test-translate date="920470519000"></test-translate>
 
     <header>Fallback Language: en-ZA -> en</header>
-    <test-translate lang="en"></test-translate>
+    <test-translate lang="en-ZA"></test-translate>
 
     <header>Fallback Language: it -> en</header>
     <test-translate lang="it"></test-translate>

--- a/packages/translate/__test__/elf-translate-element.test.js
+++ b/packages/translate/__test__/elf-translate-element.test.js
@@ -139,8 +139,17 @@ describe('Elf Translate Element Lang Test', function () {
     const elUS = await fixture('<test-translate lang="en-US"></test-translate>');
     const elRU = await fixture('<test-translate lang="ru"></test-translate>');
 
-    expect(replaceWhitespace(elGB.dateEl.innerText)).to.equal(
-      'Date: The date is: Tuesday, 21 July 2020, 23:59:50',
+    /**
+     * There is no comma between day and date in full date pattern of en-GB locale.
+     * https://icu4c-demos.unicode.org/icu-bin/locexp?_=en_GB
+     * Since only Safari 17.4+ & Chrome 125+ format it correctly,
+     * both format are accepted until all browsers in our support scope format it correctly.
+     */
+    expect(elGB.dateEl.innerText).to.be.oneOf(
+      [
+        'Date: The date is: Tuesday, 21 July 2020, 23:59:50',
+        'Date: The date is: Tuesday 21 July 2020, 23:59:50'
+      ],
       'en-GB: date'
     );
     expect(replaceWhitespace(elUS.dateEl.innerText)).to.equal(


### PR DESCRIPTION
## Description

a v6 counterpart of https://github.com/Refinitiv/refinitiv-ui/pull/1160. resolving inconsistent full date pattern of en-GB.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
