### PR TITLE
fix(datetime-picker): fix changing format doesn't sync to input

### DIFF
--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.default.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.default.test.js
@@ -108,6 +108,10 @@ describe('datetime-picker/DatetimePicker', function () {
       );
       expect(el.format).to.be.equal(customFormat, 'Custom format is not passed');
       expect(el.inputEl.value).to.be.equal('21-04-20 14:58:59', 'Custom format is not applied');
+
+      el.format = 'MMM yo HH:mm:ss do';
+      await elementUpdated(el);
+      expect(el.inputEl.value).to.be.equal('2020thApr21 14/58/59', 'Custom format is not applied');
     });
   });
   describe('Placeholder Test', function () {

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.default.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.default.test.js
@@ -101,17 +101,24 @@ describe('datetime-picker/DatetimePicker', function () {
       );
     });
 
-    it('Can change format', async function () {
+    it('Input value should apply to custom format', async function () {
       const customFormat = 'dd-MM-yy HH:mm:ss';
       const el = await fixture(
         `<ef-datetime-picker lang="en-gb" format="${customFormat}" timepicker show-seconds value="2020-04-21T14:58:59"></ef-datetime-picker>`
       );
       expect(el.format).to.be.equal(customFormat, 'Custom format is not passed');
       expect(el.inputEl.value).to.be.equal('21-04-20 14:58:59', 'Custom format is not applied');
-
-      el.format = 'yoMMMdd HH/mm/ss';
+    });
+    it('Input value should update after update format', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker lang="en-gb" timepicker show-seconds value="2020-04-21T14:58:59"></ef-datetime-picker>'
+      );
+      el.format = 'yoMMMdd HH:mm:ss';
       await elementUpdated(el);
-      expect(el.inputEl.value).to.be.equal('2020thApr21 14/58/59', 'Custom format is not applied');
+      expect(el.inputEl.value).to.be.equal(
+        '2020thApr21 14:58:59',
+        "Updated format doesn't sync to input value"
+      );
     });
   });
   describe('Placeholder Test', function () {

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.default.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.default.test.js
@@ -109,7 +109,7 @@ describe('datetime-picker/DatetimePicker', function () {
       expect(el.format).to.be.equal(customFormat, 'Custom format is not passed');
       expect(el.inputEl.value).to.be.equal('21-04-20 14:58:59', 'Custom format is not applied');
 
-      el.format = 'MMM yo HH:mm:ss do';
+      el.format = 'yoMMMdd HH/mm/ss';
       await elementUpdated(el);
       expect(el.inputEl.value).to.be.equal('2020thApr21 14/58/59', 'Custom format is not applied');
     });

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -495,7 +495,11 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
       this.opened = false; /* this cannot be nor stopped nor listened */
     }
 
-    if (changedProperties.has('_values') || changedProperties.has(TranslatePropertyKey)) {
+    if (
+      changedProperties.has('_values') ||
+      changedProperties.has(TranslatePropertyKey) ||
+      changedProperties.has('format')
+    ) {
       this.syncInputValues();
     }
 


### PR DESCRIPTION
## Description

The input should sync when changed the format prop.

Reproduce steps:

1. Open https://ui.refinitiv.com/v6/elements/datetime-picker
2. Go to some live demo and then put html code
3. <ef-datetime-picker format="dd M月 yyyy" value="2024-05-10"></ef-datetime-picker>. The input value should be "10 5月 2024".
4. Then try programmatically change on format prop like "yyyy年MM月dd日"
5. The input still be unchanged. To see the modification, you must do the following actions: open, close, and blur.  

Fixes # ([DME-16727](https://jira.refinitiv.com/browse/DME-16727))

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
