### PR TITLE
feat(time-picker): add build-in validation for partial input value

### DIFF
--- a/documents/src/pages/elements/time-picker.md
+++ b/documents/src/pages/elements/time-picker.md
@@ -113,6 +113,56 @@ utcTimePicker.hours = date.getUTCHours();
 utcTimePicker.minutes = date.getUTCMinutes();
 ```
 
+## Input validation
+`ef-time-picker` has validation logic similar to a [native input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time). When a user types a partial value into the control, error style will be shown to notify the user.
+
+You can call `reportValidity()` to trigger the validation anytime, and it will set error style if input is partial. In case that the input is initially or programmatically set to an invalid value, you must call `reportValidity()` to show the error style. Make sure that the element has been defined before calling the method.
+
+Whenever input is invalid, the `error` attribute will be added to the element. You can use the error property to check whether input is currently in the error state or not.
+
+### Custom validation
+To customize validation, you require to set `custom-validation` attribute to disable build-in input validation. Moreover, you have responsible to manage error state of element base on your validation criteria.
+
+::
+```javascript
+::import-elements::
+const errorNotice = document.getElementById('error-notice');
+const el = document.querySelector('ef-time-picker');
+
+el.addEventListener('value-changed', (event) => {
+  const targetEl = event.target;
+  if ((targetEl.hours < 8) || (targetEl.hours >= 17 && targetEl.minutes > 0)) {
+    errorNotice.textContent = 'Not in the working hour';
+    targetEl.error = true;
+  } else {
+    errorNotice.textContent = '';
+    targetEl.error = false;
+  }
+});
+
+el.addEventListener('blur', (event) => {
+  const targetEl = event.target;
+  if (!targetEl.hours || !targetEl.minutes) {
+    errorNotice.textContent = 'Please choose time';
+    targetEl.error = true;
+  }
+});
+```
+```css
+#error-notice {
+  color: red;
+}
+```
+```html
+<div>
+  <p>Please choose a time to receive service (Service hours 8:00-17:00)</p>
+  <ef-time-picker></ef-time-picker>
+  <p id="error-notice"></p>
+</div>
+```
+::
+
+
 ## Combining time and date
 
 Typically, the time value must be combined with a date object in order to use an API. To do this, use methods on the native `Date` object.

--- a/documents/src/pages/elements/time-picker.md
+++ b/documents/src/pages/elements/time-picker.md
@@ -128,11 +128,7 @@ const errorStatus = document.querySelector('p');
 const el = document.querySelector('ef-time-picker');
 
 el.addEventListener('error-changed', (event) => {
-  let msg = '';
-  if (event.detail.value) {
-    msg = 'error due to partial input'
-  }
-  errorStatus.textContent = msg;
+  errorStatus.textContent = event.detail.value ? 'error due to partial input' : '';
 });
 
 ```

--- a/documents/src/pages/elements/time-picker.md
+++ b/documents/src/pages/elements/time-picker.md
@@ -118,7 +118,32 @@ utcTimePicker.minutes = date.getUTCMinutes();
 
 You can call `reportValidity()` to trigger the validation anytime, and it will set error style if input is partial. In case that the input is initially or programmatically set to an invalid value, you must call `reportValidity()` to show the error style. Make sure that the element has been defined before calling the method.
 
-Whenever input is invalid, the `error` attribute will be added to the element. You can use the error property to check whether input is currently in the error state or not.
+Whenever input is invalid, the `error` attribute will be added to the element. You can use the `error` property to check whether input is currently in the error state or not.
+If the error state is changed (not programmatically), an `error-changed` event will be dispatched along with the current error state.
+
+::
+```javascript
+::import-elements::
+const errorStatus = document.querySelector('span');
+const el = document.querySelector('ef-time-picker');
+
+el.addEventListener('error-changed', (event) => {
+  errorStatus.textContent = event.detail.value;
+});
+
+```
+```css
+span {
+  color: red;
+}
+```
+```html
+<div>
+  <ef-time-picker></ef-time-picker>
+  <p>Error: <span></span></p>
+</div>
+```
+::
 
 ### Custom validation
 To customize validation, you require to set `custom-validation` attribute to disable build-in input validation. Moreover, you have responsible to manage error state of element base on your validation criteria.

--- a/documents/src/pages/elements/time-picker.md
+++ b/documents/src/pages/elements/time-picker.md
@@ -146,7 +146,9 @@ span {
 ::
 
 ### Custom validation
-To customize validation, you require to set `custom-validation` attribute to disable build-in input validation. Moreover, you have responsible to manage error state of element base on your validation criteria.
+For advance use cases, default validation and error state of the field can be overridden. 
+To do this, make sure that `custom-validation` is set,
+then validate with your customised validation logic and update error property accordingly.
 
 ::
 ```javascript
@@ -181,7 +183,7 @@ el.addEventListener('blur', (event) => {
 ```html
 <div>
   <p>Please choose a time to receive service (Service hours 8:00-17:00)</p>
-  <ef-time-picker></ef-time-picker>
+  <ef-time-picker custom-validation></ef-time-picker>
   <p id="error-notice"></p>
 </div>
 ```

--- a/documents/src/pages/elements/time-picker.md
+++ b/documents/src/pages/elements/time-picker.md
@@ -124,23 +124,27 @@ If the error state is changed (not programmatically), an `error-changed` event w
 ::
 ```javascript
 ::import-elements::
-const errorStatus = document.querySelector('span');
+const errorStatus = document.querySelector('p');
 const el = document.querySelector('ef-time-picker');
 
 el.addEventListener('error-changed', (event) => {
-  errorStatus.textContent = event.detail.value;
+  let msg = '';
+  if (event.detail.value) {
+    msg = 'error due to partial input'
+  }
+  errorStatus.textContent = msg;
 });
 
 ```
 ```css
-span {
+p {
   color: red;
 }
 ```
 ```html
 <div>
   <ef-time-picker></ef-time-picker>
-  <p>Error: <span></span></p>
+  <p></p>
 </div>
 ```
 ::

--- a/documents/src/pages/elements/time-picker.md
+++ b/documents/src/pages/elements/time-picker.md
@@ -148,7 +148,7 @@ p {
 ### Custom validation
 For advance use cases, default validation and error state of the field can be overridden. 
 To do this, make sure that `custom-validation` is set,
-then validate with your customised validation logic and update error property accordingly.
+then validate with your customised validation logic and update `error` property accordingly.
 
 ::
 ```javascript

--- a/packages/elemental-theme/src/custom-elements/ef-time-picker.less
+++ b/packages/elemental-theme/src/custom-elements/ef-time-picker.less
@@ -55,19 +55,6 @@
       opacity: 1;
     }
   }
-
-  &[error]:not([focused]) {
-    border-color: @scheme-color-error;
-  }
-
-  &[error]:hover:not([readonly]):not([focused]) {
-    border-color: @scheme-color-error;
-  }
-
-  &[error][disabled],
-  &[error][readonly]:not([focused]) {
-    border-color: fade(@scheme-color-error, 50%);
-  }
 }
 
 :host:hover {
@@ -76,6 +63,17 @@
 
 :host[focused] {
   &:extend(:host[focused]); // Extend ef-number-field[focused]
+}
+
+:host[error] {
+  &:extend(:host[error]); // Extend ef-number-field[error]
+  [part='input'],
+  [part='toggle'] {
+    &:focus::after,
+    &[focused]::after {
+      border-bottom: 4px solid @scheme-color-error;
+    }
+  }
 }
 
 :host[disabled] {

--- a/packages/elemental-theme/src/custom-elements/ef-time-picker.less
+++ b/packages/elemental-theme/src/custom-elements/ef-time-picker.less
@@ -55,6 +55,19 @@
       opacity: 1;
     }
   }
+
+  &[error]:not([focused]) {
+    border-color: @scheme-color-error;
+  }
+
+  &[error]:hover:not([readonly]):not([focused]) {
+    border-color: @scheme-color-error;
+  }
+
+  &[error][disabled],
+  &[error][readonly]:not([focused]) {
+    border-color: fade(@scheme-color-error, 50%);
+  }
 }
 
 :host:hover {

--- a/packages/elemental-theme/src/custom-elements/ef-time-picker.less
+++ b/packages/elemental-theme/src/custom-elements/ef-time-picker.less
@@ -71,7 +71,7 @@
   [part='toggle'] {
     &:focus::after,
     &[focused]::after {
-      border-bottom: 4px solid @scheme-color-error;
+      border-bottom-color: @scheme-color-error;
     }
   }
 }

--- a/packages/elements/src/datetime-picker/__test__/__snapshots__/datetime-picker.snapshot.test.snap.js
+++ b/packages/elements/src/datetime-picker/__test__/__snapshots__/datetime-picker.snapshot.test.snap.js
@@ -263,6 +263,7 @@ snapshots["datetime-picker/DOMStructure DOM Structure DOM structure is correct w
       </div>
       <div part="timepicker-wrapper">
         <ef-time-picker
+          custom-validation=""
           id="timepicker"
           part="time-picker"
           role="group"
@@ -331,6 +332,7 @@ snapshots["datetime-picker/DOMStructure DOM Structure DOM structure is correct w
       </div>
       <div part="timepicker-wrapper">
         <ef-time-picker
+          custom-validation=""
           id="timepicker"
           part="time-picker"
           role="group"
@@ -411,6 +413,7 @@ snapshots["datetime-picker/DOMStructure DOM Structure DOM structure is correct w
       </div>
       <div part="timepicker-wrapper">
         <ef-time-picker
+          custom-validation=""
           id="timepicker-from"
           part="time-picker"
           role="group"
@@ -420,6 +423,7 @@ snapshots["datetime-picker/DOMStructure DOM Structure DOM structure is correct w
         <div part="input-separator">
         </div>
         <ef-time-picker
+          custom-validation=""
           id="timepicker-to"
           part="time-picker"
           role="group"

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -376,6 +376,42 @@ describe('datetime-picker/Value', function () {
         'error state should return to false when both inputs value are valid'
       );
     });
+    it('It should fall back timepicker value to valid when popup is opened', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker timepicker value="2024-05-10T11:00" lang="en-gb" opened></ef-datetime-picker>'
+      );
+
+      el.opened = true;
+      await elementUpdated(el);
+
+      el.timepickerEl.hours = null;
+      el.opened = false;
+      await elementUpdated(el);
+
+      el.opened = true;
+      await elementUpdated(el);
+
+      expect(el.timepickerEl.value).to.equal('11:00');
+    });
+    it('It should fall back timepicker values to valid when popup is opened in range mode', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker range timepicker values="2024-05-10T11:00,2024-05-11T15:00" lang="en-gb" opened></ef-datetime-picker>'
+      );
+
+      el.opened = true;
+      await elementUpdated(el);
+
+      el.timepickerFromEl.hours = null;
+      el.timepickerToEl.minutes = null;
+      el.opened = false;
+      await elementUpdated(el);
+
+      el.opened = true;
+      await elementUpdated(el);
+
+      expect(el.timepickerFromEl.value).to.equal('11:00');
+      expect(el.timepickerToEl.value).to.equal('15:00');
+    });
     // TODO: add input validation test cases when the value update is originated from typing input
   });
 });

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -376,42 +376,6 @@ describe('datetime-picker/Value', function () {
         'error state should return to false when both inputs value are valid'
       );
     });
-    it('It should fall back timepicker value to valid when popup is opened', async function () {
-      const el = await fixture(
-        '<ef-datetime-picker timepicker value="2024-05-10T11:00" lang="en-gb" opened></ef-datetime-picker>'
-      );
-
-      el.opened = true;
-      await elementUpdated(el);
-
-      el.timepickerEl.hours = null;
-      el.opened = false;
-      await elementUpdated(el);
-
-      el.opened = true;
-      await elementUpdated(el);
-
-      expect(el.timepickerEl.value).to.equal('11:00');
-    });
-    it('It should fall back timepicker values to valid when popup is opened in range mode', async function () {
-      const el = await fixture(
-        '<ef-datetime-picker range timepicker values="2024-05-10T11:00,2024-05-11T15:00" lang="en-gb" opened></ef-datetime-picker>'
-      );
-
-      el.opened = true;
-      await elementUpdated(el);
-
-      el.timepickerFromEl.hours = null;
-      el.timepickerToEl.minutes = null;
-      el.opened = false;
-      await elementUpdated(el);
-
-      el.opened = true;
-      await elementUpdated(el);
-
-      expect(el.timepickerFromEl.value).to.equal('11:00');
-      expect(el.timepickerToEl.value).to.equal('15:00');
-    });
     // TODO: add input validation test cases when the value update is originated from typing input
   });
 });

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -376,6 +376,36 @@ describe('datetime-picker/Value', function () {
         'error state should return to false when both inputs value are valid'
       );
     });
+    it('It should fall back timepicker value to valid when popup is opened', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker timepicker value="2024-05-10T11:00" lang="en-gb" opened></ef-datetime-picker>'
+      );
+
+      el.timepickerEl.hours = null;
+      el.opened = false;
+      await elementUpdated(el);
+
+      el.opened = true;
+      await elementUpdated(el);
+
+      expect(el.timepickerEl.value).to.equal('11:00');
+    });
+    it('It should fall back timepicker values to valid when popup is opened in range mode', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker range timepicker values="2024-05-10T11:00,2024-05-11T15:00" lang="en-gb" opened></ef-datetime-picker>'
+      );
+
+      el.timepickerFromEl.hours = null;
+      el.timepickerToEl.minutes = null;
+      el.opened = false;
+      await elementUpdated(el);
+
+      el.opened = true;
+      await elementUpdated(el);
+
+      expect(el.timepickerFromEl.value).to.equal('11:00');
+      expect(el.timepickerToEl.value).to.equal('15:00');
+    });
     // TODO: add input validation test cases when the value update is originated from typing input
   });
 });

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -487,6 +487,7 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
   protected override update(changedProperties: PropertyValues): void {
     if (changedProperties.has('opened') && this.opened) {
       this.lazyRendered = true;
+      this.validateTimePickerInput();
     }
     // make sure to close popup for disabled
     if (this.opened && !this.canOpenPopup) {
@@ -534,6 +535,35 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
     ]);
 
     void super.performUpdate();
+  }
+  /**
+   * if the time-picker input(s) is invalid
+   * it will revert time-picker value to previous valid value that store in datetime-picker
+   * @param opened True if opened
+   * @returns {void}
+   */
+  private validateTimePickerInput(): void {
+    if (!this.timepicker && !this.opened) {
+      return;
+    }
+
+    const validateAndFallback = (element: TimePicker | null | undefined, value: string) => {
+      if (!element) {
+        return;
+      }
+
+      const validity = element.checkValidity();
+      if (!validity || (validity && !element.value && value)) {
+        element.value = value;
+      }
+    };
+
+    if (this.range) {
+      validateAndFallback(this.timepickerFromEl, this.timepickerValues[0]);
+      validateAndFallback(this.timepickerToEl, this.timepickerValues[1]);
+    } else {
+      validateAndFallback(this.timepickerEl, this.timepickerValues[0]);
+    }
   }
 
   /**

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -551,8 +551,7 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
         return;
       }
 
-      const validity = element.checkValidity();
-      if (!validity || (!element.value && value)) {
+      if (!element.checkValidity() || (!element.value && value)) {
         element.value = value;
       }
     };

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -487,6 +487,7 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
   protected override update(changedProperties: PropertyValues): void {
     if (changedProperties.has('opened') && this.opened) {
       this.lazyRendered = true;
+      this.validateTimePickerInput(this.opened);
     }
     // make sure to close popup for disabled
     if (this.opened && !this.canOpenPopup) {
@@ -530,6 +531,34 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
     ]);
 
     void super.performUpdate();
+  }
+
+  /**
+   * if the time-picker input(s) is invalid
+   * it will revert time-picker value to previous valid value that store in datetime-picker
+   * @param opened True if opened
+   * @returns {void}
+   */
+  private validateTimePickerInput(opened: boolean): void {
+    if (this.timepicker && opened) {
+      const validateAndFallback = (element: TimePicker | null | undefined, value: string) => {
+        if (element) {
+          if (!element.checkValidity() || (element.checkValidity() && !element.value && value)) {
+            element.value = value;
+            setTimeout(() => {
+              element?.reportValidity();
+            });
+          }
+        }
+      };
+
+      if (this.range) {
+        validateAndFallback(this.timepickerFromEl, this.timepickerValues[0]);
+        validateAndFallback(this.timepickerToEl, this.timepickerValues[1]);
+      } else {
+        validateAndFallback(this.timepickerEl, this.timepickerValues[0]);
+      }
+    }
   }
 
   /**

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -487,7 +487,7 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
   protected override update(changedProperties: PropertyValues): void {
     if (changedProperties.has('opened') && this.opened) {
       this.lazyRendered = true;
-      this.validateTimePickerInput();
+      this.syncTimePickerInput();
     }
     // make sure to close popup for disabled
     if (this.opened && !this.canOpenPopup) {
@@ -538,12 +538,11 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
   }
   /**
    * if the time-picker input(s) is invalid
-   * it will revert time-picker value to previous valid value that store in datetime-picker
-   * @param opened True if opened
+   * it will sync time-picker value to previous valid value that store in datetime-picker
    * @returns {void}
    */
-  private validateTimePickerInput(): void {
-    if (!this.timepicker && !this.opened) {
+  private syncTimePickerInput(): void {
+    if (!this.timepicker || !this.opened) {
       return;
     }
 
@@ -553,7 +552,7 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
       }
 
       const validity = element.checkValidity();
-      if (!validity || (validity && !element.value && value)) {
+      if (!validity || (!element.value && value)) {
         element.value = value;
       }
     };

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -487,7 +487,6 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
   protected override update(changedProperties: PropertyValues): void {
     if (changedProperties.has('opened') && this.opened) {
       this.lazyRendered = true;
-      this.validateTimePickerInput(this.opened);
     }
     // make sure to close popup for disabled
     if (this.opened && !this.canOpenPopup) {
@@ -535,34 +534,6 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
     ]);
 
     void super.performUpdate();
-  }
-
-  /**
-   * if the time-picker input(s) is invalid
-   * it will revert time-picker value to previous valid value that store in datetime-picker
-   * @param opened True if opened
-   * @returns {void}
-   */
-  private validateTimePickerInput(opened: boolean): void {
-    if (this.timepicker && opened) {
-      const validateAndFallback = (element: TimePicker | null | undefined, value: string) => {
-        if (element) {
-          if (!element.checkValidity() || (element.checkValidity() && !element.value && value)) {
-            element.value = value;
-            setTimeout(() => {
-              element?.reportValidity();
-            });
-          }
-        }
-      };
-
-      if (this.range) {
-        validateAndFallback(this.timepickerFromEl, this.timepickerValues[0]);
-        validateAndFallback(this.timepickerToEl, this.timepickerValues[1]);
-      } else {
-        validateAndFallback(this.timepickerEl, this.timepickerValues[0]);
-      }
-    }
   }
 
   /**
@@ -1243,6 +1214,7 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
     return html`<ef-time-picker
       id="${id}"
       part="time-picker"
+      custom-validation
       .showSeconds=${this.showSeconds}
       .amPm=${this.amPm}
       .value=${value}

--- a/packages/elements/src/time-picker/__demo__/index.html
+++ b/packages/elements/src/time-picker/__demo__/index.html
@@ -61,7 +61,7 @@
     <demo-block header="Value" layout="normal" tags="value">
       <ef-time-picker value="13:30:25" am-pm></ef-time-picker>
     </demo-block>
-    <demo-block header="Specifig segment value" layout="normal" tags="hours, miutes, seconds">
+    <demo-block header="Specific segment value" layout="normal" tags="hours, miutes, seconds">
       <ef-time-picker hours="20" minutes="50" seconds="30" show-seconds></ef-time-picker>
     </demo-block>
     <demo-block header="Readonly" layout="normal" tags="readonly">
@@ -70,22 +70,63 @@
     <demo-block header="Disabled" layout="normal" tags="disabled">
       <ef-time-picker value="13:30:25" disabled></ef-time-picker>
     </demo-block>
+    <demo-block header="Custom validation" layout="normal" tags="custom-validation">
+      <p>Please choose a time to receive service (Service hours 8:00-17:00)</p>
+      <ef-time-picker id="custom-validation" custom-validation></ef-time-picker>
+      <p id="error-notice"></p>
+      <script>
+        const errorNotice = document.getElementById('error-notice');
+        const el = document.getElementById('custom-validation');
+
+        el.addEventListener('value-changed', (event) => {
+          const targetEl = event.target;
+          if (targetEl.hours < 8 || (targetEl.hours >= 17 && targetEl.minutes > 0)) {
+            errorNotice.textContent = 'Not in the working hour';
+            targetEl.error = true;
+          } else {
+            errorNotice.textContent = '';
+            targetEl.error = false;
+          }
+        });
+
+        el.addEventListener('blur', (event) => {
+          const targetEl = event.target;
+          if (!targetEl.hours || !targetEl.minutes) {
+            errorNotice.textContent = 'Please choose time';
+            targetEl.error = true;
+          }
+        });
+      </script>
+    </demo-block>
     <demo-block id="event" header="Event" layout="normal" tags="event">
+      <p>Value-changed event and error-change event</p>
       <ef-time-picker value="15:30:25"></ef-time-picker>
       <ef-time-picker value="15:30:25" am-pm></ef-time-picker>
       <div>
         <span>value-changed: </span>
         <input id="log" readonly />
       </div>
+      <div>
+        <span>error-changed: </span>
+        <input id="error-log" readonly />
+      </div>
       <script>
         (function () {
           const log = document.getElementById('log');
+          const errorlog = document.getElementById('error-log');
           const onValueChanged = (event) => {
             log.value = JSON.stringify(event.detail);
           };
           document
             .querySelectorAll('#event ef-time-picker')
             .forEach((element) => element.addEventListener('value-changed', onValueChanged));
+
+          const onErrorChanged = (event) => {
+            errorlog.value = JSON.stringify(event.detail);
+          };
+          document
+            .querySelectorAll('#event ef-time-picker')
+            .forEach((element) => element.addEventListener('error-changed', onErrorChanged));
         })();
       </script>
     </demo-block>

--- a/packages/elements/src/time-picker/__demo__/index.html
+++ b/packages/elements/src/time-picker/__demo__/index.html
@@ -112,21 +112,18 @@
       </div>
       <script>
         (function () {
-          const log = document.getElementById('log');
-          const errorlog = document.getElementById('error-log');
+          const valueLog = document.getElementById('log');
+          const errorLog = document.getElementById('error-log');
           const onValueChanged = (event) => {
-            log.value = JSON.stringify(event.detail);
+            valueLog.value = JSON.stringify(event.detail);
           };
-          document
-            .querySelectorAll('#event ef-time-picker')
-            .forEach((element) => element.addEventListener('value-changed', onValueChanged));
-
           const onErrorChanged = (event) => {
-            errorlog.value = JSON.stringify(event.detail);
+            errorLog.value = JSON.stringify(event.detail);
           };
-          document
-            .querySelectorAll('#event ef-time-picker')
-            .forEach((element) => element.addEventListener('error-changed', onErrorChanged));
+          document.querySelectorAll('#event ef-time-picker').forEach((element) => {
+            element.addEventListener('value-changed', onValueChanged);
+            element.addEventListener('error-changed', onErrorChanged);
+          });
         })();
       </script>
     </demo-block>

--- a/packages/elements/src/time-picker/__test__/time-picker.test.js
+++ b/packages/elements/src/time-picker/__test__/time-picker.test.js
@@ -217,21 +217,21 @@ describe('time-picker/TimePicker', function () {
     });
     it('should set error state to false when reportValidity is called without value', async function () {
       const el = await fixture('<ef-time-picker error show-seconds></ef-time-picker>');
-      el.reportValidity();
+      const validity = el.reportValidity();
       expect(el.error).to.be.equal(false);
-      expect(el.checkValidity()).to.be.equal(true);
+      expect(validity).to.be.equal(true);
     });
     it('should set error state to true when reportValidity is called with partial value', async function () {
       const el = await fixture('<ef-time-picker hours="12" show-seconds></ef-time-picker>');
-      el.reportValidity();
+      const validity = el.reportValidity();
       expect(el.error).to.be.equal(true);
-      expect(el.checkValidity()).to.be.equal(false);
+      expect(validity).to.be.equal(false);
     });
     it('should set error state to false when reportValidity is called with valid values', async function () {
       const el = await fixture('<ef-time-picker value="12:11:10" error show-seconds></ef-time-picker>');
-      el.reportValidity();
+      const validity = el.reportValidity();
       expect(el.error).to.be.equal(false);
-      expect(el.checkValidity()).to.be.equal(true);
+      expect(validity).to.be.equal(true);
     });
     it('should add error state when value is partial by a mock user interaction', async function () {
       const el = await fixture(timePickerDefaults);

--- a/packages/elements/src/time-picker/__test__/time-picker.test.js
+++ b/packages/elements/src/time-picker/__test__/time-picker.test.js
@@ -441,13 +441,6 @@ describe('time-picker/TimePicker', function () {
 
     it('Should able to toggle mode between 12hr and 24hr by API toggle method', async function () {
       const el = await fixture(timePickerAMPM);
-      await elementUpdated(el);
-      let togglePart = el.renderRoot.querySelector('[part=toggle]');
-      expect(togglePart).to.exist;
-
-      expect(el.hours).to.equal(13);
-      expect(el.formattedHours).to.equal('01', 'should be 01');
-      expect(el.value).to.equal('13:30', 'should be 13:30');
 
       el.toggle();
       await elementUpdated(el);

--- a/packages/elements/src/time-picker/__test__/time-picker.test.js
+++ b/packages/elements/src/time-picker/__test__/time-picker.test.js
@@ -215,6 +215,58 @@ describe('time-picker/TimePicker', function () {
       expect(el.minutes).to.equal(null);
       expect(el.seconds).to.equal(45);
     });
+    it('should set error state to false when reportValidity is called without value', async function () {
+      const el = await fixture('<ef-time-picker error show-seconds></ef-time-picker>');
+      el.reportValidity();
+      expect(el.error).to.be.equal(false);
+    });
+    it('should set error state to true when reportValidity is called with partial value', async function () {
+      const el = await fixture('<ef-time-picker show-seconds></ef-time-picker>');
+      el.hours = '12';
+      await elementUpdated(el);
+
+      el.reportValidity();
+      expect(el.error).to.be.equal(true);
+    });
+    it('should set error state to false when reportValidity is called with valid values', async function () {
+      const el = await fixture('<ef-time-picker error show-seconds></ef-time-picker>');
+      el.hours = '12';
+      await elementUpdated(el);
+
+      el.minutes = '11';
+      await elementUpdated(el);
+
+      el.seconds = '10';
+      await elementUpdated(el);
+
+      el.reportValidity();
+      expect(el.error).to.be.equal(false);
+    });
+
+    it('checkValidity should return true when it is called without value', async function () {
+      const el = await fixture('<ef-time-picker show-seconds></ef-time-picker>');
+      expect(el.checkValidity()).to.be.equal(true);
+    });
+    it('checkValidity should return false when it is called with partial value', async function () {
+      const el = await fixture('<ef-time-picker show-seconds></ef-time-picker>');
+      el.hours = '12';
+      await elementUpdated(el);
+
+      expect(el.checkValidity()).to.be.equal(false);
+    });
+    it('checkValidity should return true when it is called with valid values', async function () {
+      const el = await fixture('<ef-time-picker show-seconds></ef-time-picker>');
+      el.hours = '12';
+      await elementUpdated(el);
+
+      el.minutes = '11';
+      await elementUpdated(el);
+
+      el.seconds = '10';
+      await elementUpdated(el);
+
+      expect(el.checkValidity()).to.be.equal(true);
+    });
   });
 
   describe('Modes', function () {

--- a/packages/elements/src/time-picker/__test__/time-picker.test.js
+++ b/packages/elements/src/time-picker/__test__/time-picker.test.js
@@ -303,6 +303,32 @@ describe('time-picker/TimePicker', function () {
       await oneEvent(el.secondsInput, 'input');
       expect(el.error).to.be.equal(true);
     });
+
+    it('Should add error state if tap on toggle when there is no value', async function () {
+      const el = await fixture(timePickerAMPM);
+      el.value = '';
+      await elementUpdated(el);
+      const toggleEl = el.renderRoot.querySelector('#toggle');
+      toggleEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+      expect(el.error).to.equal(true);
+    });
+
+    it('Should remove error state if tap on toggle while there is only hour segment to fill in', async function () {
+      const el = await fixture('<ef-time-picker am-pm></ef-time-picker>');
+
+      el.minutesInput.value = '00';
+      setTimeout(() => {
+        el.minutesInput.dispatchEvent(new Event('input'));
+      });
+      await oneEvent(el.minutesInput, 'input');
+      expect(el.error).to.be.equal(true);
+
+      const toggleEl = el.renderRoot.querySelector('#toggle');
+      toggleEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+      expect(el.error).to.equal(false);
+    });
   });
 
   describe('Modes', function () {
@@ -411,6 +437,29 @@ describe('time-picker/TimePicker', function () {
       expect(el.hours).to.equal(10);
       expect(el.formattedHours).to.equal('10', 'should be 10');
       expect(el.value).to.equal('10:20', 'should be 10:20');
+    });
+
+    it('Should able to toggle mode between 12hr and 24hr by API toggle method', async function () {
+      const el = await fixture(timePickerAMPM);
+      await elementUpdated(el);
+      let togglePart = el.renderRoot.querySelector('[part=toggle]');
+      expect(togglePart).to.exist;
+
+      expect(el.hours).to.equal(13);
+      expect(el.formattedHours).to.equal('01', 'should be 01');
+      expect(el.value).to.equal('13:30', 'should be 13:30');
+
+      el.toggle();
+      await elementUpdated(el);
+      expect(el.hours).to.equal(1);
+      expect(el.formattedHours).to.equal('01', 'should be 01');
+      expect(el.value).to.equal('01:30', 'should be 01:30');
+
+      el.toggle();
+      await elementUpdated(el);
+      expect(el.hours).to.equal(13);
+      expect(el.formattedHours).to.equal('01', 'should be 01');
+      expect(el.value).to.equal('13:30', 'should be 13:30');
     });
 
     it('Should able to toggle am/pm', async function () {

--- a/packages/elements/src/time-picker/__test__/time-picker.test.js
+++ b/packages/elements/src/time-picker/__test__/time-picker.test.js
@@ -219,44 +219,18 @@ describe('time-picker/TimePicker', function () {
       const el = await fixture('<ef-time-picker error show-seconds></ef-time-picker>');
       el.reportValidity();
       expect(el.error).to.be.equal(false);
-    });
-    it('should set error state to true when reportValidity is called with partial value', async function () {
-      const el = await fixture('<ef-time-picker show-seconds></ef-time-picker>');
-      el.hours = '12';
-      await elementUpdated(el);
-
-      el.reportValidity();
-      expect(el.error).to.be.equal(true);
-    });
-    it('should set error state to false when reportValidity is called with valid values', async function () {
-      const el = await fixture('<ef-time-picker error show-seconds></ef-time-picker>');
-      el.hours = '12';
-      el.minutes = '11';
-      el.seconds = '10';
-      await elementUpdated(el);
-
-      el.reportValidity();
-      expect(el.error).to.be.equal(false);
-    });
-
-    it('checkValidity should return true when it is called without value', async function () {
-      const el = await fixture('<ef-time-picker show-seconds></ef-time-picker>');
       expect(el.checkValidity()).to.be.equal(true);
     });
-    it('checkValidity should return false when it is called with partial value', async function () {
-      const el = await fixture('<ef-time-picker show-seconds></ef-time-picker>');
-      el.hours = '12';
-      await elementUpdated(el);
-
+    it('should set error state to true when reportValidity is called with partial value', async function () {
+      const el = await fixture('<ef-time-picker hours="12" show-seconds></ef-time-picker>');
+      el.reportValidity();
+      expect(el.error).to.be.equal(true);
       expect(el.checkValidity()).to.be.equal(false);
     });
-    it('checkValidity should return true when it is called with valid values', async function () {
-      const el = await fixture('<ef-time-picker show-seconds></ef-time-picker>');
-      el.hours = '12';
-      el.minutes = '11';
-      el.seconds = '10';
-      await elementUpdated(el);
-
+    it('should set error state to false when reportValidity is called with valid values', async function () {
+      const el = await fixture('<ef-time-picker value="12:11:10" error show-seconds></ef-time-picker>');
+      el.reportValidity();
+      expect(el.error).to.be.equal(false);
       expect(el.checkValidity()).to.be.equal(true);
     });
     it('should add error state when value is partial by a mock user interaction', async function () {
@@ -266,40 +240,39 @@ describe('time-picker/TimePicker', function () {
       await oneEvent(el.hoursInput, 'input');
       expect(el.error).to.be.equal(true);
     });
-    it('should add error state when value is partial with show seconds by a mock user interaction', async function () {
-      const el = await fixture(timePickerDefaults);
-      el.showSeconds = true;
-      el.hoursInput.value = '12';
-      setTimeout(() => el.hoursInput.dispatchEvent(new Event('input')));
-      await oneEvent(el.hoursInput, 'input');
-
-      el.minutesInput.value = '00';
-      setTimeout(() => el.minutesInput.dispatchEvent(new Event('input')));
-      await oneEvent(el.minutesInput, 'input');
-
-      expect(el.error).to.be.equal(true);
-    });
     it('should remove error state when value is not partial by a mock user interaction', async function () {
       const el = await fixture(timePickerDefaults);
       el.hoursInput.value = '12';
       setTimeout(() => el.hoursInput.dispatchEvent(new Event('input')));
       await oneEvent(el.hoursInput, 'input');
+      expect(el.error).to.be.equal(true);
 
       el.minutesInput.value = '00';
       setTimeout(() => el.minutesInput.dispatchEvent(new Event('input')));
       await oneEvent(el.minutesInput, 'input');
       expect(el.error).to.be.equal(false);
     });
-    it('should remove error state when value is not partial with show seconds by a mock user interaction', async function () {
-      const el = await fixture(timePickerDefaults);
-      el.showSeconds = true;
+    it('should add error state when value is partial with show seconds by a mock user interaction', async function () {
+      const el = await fixture('<ef-time-picker show-seconds></ef-time-picker>');
       el.hoursInput.value = '12';
-      setTimeout(() => el.hoursInput.dispatchEvent(new Event('input')));
-      await oneEvent(el.hoursInput, 'input');
-
       el.minutesInput.value = '00';
-      setTimeout(() => el.minutesInput.dispatchEvent(new Event('input')));
-      await oneEvent(el.minutesInput, 'input');
+      setTimeout(() => {
+        el.hoursInput.dispatchEvent(new Event('input'));
+        el.minutesInput.dispatchEvent(new Event('input'));
+      });
+      await Promise.all([oneEvent(el.minutesInput, 'input'), oneEvent(el.hoursInput, 'input')]);
+      expect(el.error).to.be.equal(true);
+    });
+    it('should remove error state when value is not partial with show seconds by a mock user interaction', async function () {
+      const el = await fixture('<ef-time-picker show-seconds></ef-time-picker>');
+      el.hoursInput.value = '12';
+      el.minutesInput.value = '00';
+      setTimeout(() => {
+        el.hoursInput.dispatchEvent(new Event('input'));
+        el.minutesInput.dispatchEvent(new Event('input'));
+      });
+      await Promise.all([oneEvent(el.minutesInput, 'input'), oneEvent(el.hoursInput, 'input')]);
+      expect(el.error).to.be.equal(true);
 
       el.secondsInput.value = '00';
       setTimeout(() => el.secondsInput.dispatchEvent(new Event('input')));
@@ -307,13 +280,7 @@ describe('time-picker/TimePicker', function () {
       expect(el.error).to.be.equal(false);
     });
     it('should not add error state when remove all segments by a mock user interaction', async function () {
-      const el = await fixture(timePickerDefaults);
-      el.showSeconds = true;
-      el.hours = 12;
-      el.minutes = 0;
-      el.seconds = 0;
-      await elementUpdated(el);
-
+      const el = await fixture('<ef-time-picker value="12:00:00" show-seconds></ef-time-picker>');
       el.hoursInput.value = '';
       setTimeout(() => el.hoursInput.dispatchEvent(new Event('input')));
       await oneEvent(el.hoursInput, 'input');
@@ -330,23 +297,7 @@ describe('time-picker/TimePicker', function () {
       expect(el.error).to.be.equal(false);
     });
     it('should add error state when type invalid value by a mock user interaction', async function () {
-      const el = await fixture(timePickerDefaults);
-      el.showSeconds = true;
-      await elementUpdated(el);
-
-      el.hoursInput.value = '12';
-      setTimeout(() => el.hoursInput.dispatchEvent(new Event('input')));
-      await oneEvent(el.hoursInput, 'input');
-
-      el.minutesInput.value = '10';
-      setTimeout(() => el.minutesInput.dispatchEvent(new Event('input')));
-      await oneEvent(el.minutesInput, 'input');
-
-      el.secondsInput.value = '8';
-      setTimeout(() => el.secondsInput.dispatchEvent(new Event('input')));
-      await oneEvent(el.secondsInput, 'input');
-      expect(el.error).to.be.equal(false);
-
+      const el = await fixture('<ef-time-picker value="12:10:08" show-seconds></ef-time-picker>');
       el.secondsInput.value = '88';
       setTimeout(() => el.secondsInput.dispatchEvent(new Event('input')));
       await oneEvent(el.secondsInput, 'input');

--- a/packages/elements/src/time-picker/__test__/time-picker.test.js
+++ b/packages/elements/src/time-picker/__test__/time-picker.test.js
@@ -231,11 +231,7 @@ describe('time-picker/TimePicker', function () {
     it('should set error state to false when reportValidity is called with valid values', async function () {
       const el = await fixture('<ef-time-picker error show-seconds></ef-time-picker>');
       el.hours = '12';
-      await elementUpdated(el);
-
       el.minutes = '11';
-      await elementUpdated(el);
-
       el.seconds = '10';
       await elementUpdated(el);
 
@@ -257,11 +253,7 @@ describe('time-picker/TimePicker', function () {
     it('checkValidity should return true when it is called with valid values', async function () {
       const el = await fixture('<ef-time-picker show-seconds></ef-time-picker>');
       el.hours = '12';
-      await elementUpdated(el);
-
       el.minutes = '11';
-      await elementUpdated(el);
-
       el.seconds = '10';
       await elementUpdated(el);
 

--- a/packages/elements/src/time-picker/__test__/time-picker.test.js
+++ b/packages/elements/src/time-picker/__test__/time-picker.test.js
@@ -259,6 +259,99 @@ describe('time-picker/TimePicker', function () {
 
       expect(el.checkValidity()).to.be.equal(true);
     });
+    it('should add error state when value is partial by a mock user interaction', async function () {
+      const el = await fixture(timePickerDefaults);
+      el.hoursInput.value = '12';
+      setTimeout(() => el.hoursInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.hoursInput, 'input');
+      expect(el.error).to.be.equal(true);
+    });
+    it('should add error state when value is partial with show seconds by a mock user interaction', async function () {
+      const el = await fixture(timePickerDefaults);
+      el.showSeconds = true;
+      el.hoursInput.value = '12';
+      setTimeout(() => el.hoursInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.hoursInput, 'input');
+
+      el.minutesInput.value = '00';
+      setTimeout(() => el.minutesInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.minutesInput, 'input');
+
+      expect(el.error).to.be.equal(true);
+    });
+    it('should remove error state when value is not partial by a mock user interaction', async function () {
+      const el = await fixture(timePickerDefaults);
+      el.hoursInput.value = '12';
+      setTimeout(() => el.hoursInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.hoursInput, 'input');
+
+      el.minutesInput.value = '00';
+      setTimeout(() => el.minutesInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.minutesInput, 'input');
+      expect(el.error).to.be.equal(false);
+    });
+    it('should remove error state when value is not partial with show seconds by a mock user interaction', async function () {
+      const el = await fixture(timePickerDefaults);
+      el.showSeconds = true;
+      el.hoursInput.value = '12';
+      setTimeout(() => el.hoursInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.hoursInput, 'input');
+
+      el.minutesInput.value = '00';
+      setTimeout(() => el.minutesInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.minutesInput, 'input');
+
+      el.secondsInput.value = '00';
+      setTimeout(() => el.secondsInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.secondsInput, 'input');
+      expect(el.error).to.be.equal(false);
+    });
+    it('should not add error state when remove all segments by a mock user interaction', async function () {
+      const el = await fixture(timePickerDefaults);
+      el.showSeconds = true;
+      el.hours = 12;
+      el.minutes = 0;
+      el.seconds = 0;
+      await elementUpdated(el);
+
+      el.hoursInput.value = '';
+      setTimeout(() => el.hoursInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.hoursInput, 'input');
+      expect(el.error).to.be.equal(true);
+
+      el.minutesInput.value = '';
+      setTimeout(() => el.minutesInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.minutesInput, 'input');
+      expect(el.error).to.be.equal(true);
+
+      el.secondsInput.value = '';
+      setTimeout(() => el.secondsInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.secondsInput, 'input');
+      expect(el.error).to.be.equal(false);
+    });
+    it('should add error state when type invalid value by a mock user interaction', async function () {
+      const el = await fixture(timePickerDefaults);
+      el.showSeconds = true;
+      await elementUpdated(el);
+
+      el.hoursInput.value = '12';
+      setTimeout(() => el.hoursInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.hoursInput, 'input');
+
+      el.minutesInput.value = '10';
+      setTimeout(() => el.minutesInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.minutesInput, 'input');
+
+      el.secondsInput.value = '8';
+      setTimeout(() => el.secondsInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.secondsInput, 'input');
+      expect(el.error).to.be.equal(false);
+
+      el.secondsInput.value = '88';
+      setTimeout(() => el.secondsInput.dispatchEvent(new Event('input')));
+      await oneEvent(el.secondsInput, 'input');
+      expect(el.error).to.be.equal(true);
+    });
   });
 
   describe('Modes', function () {

--- a/packages/elements/src/time-picker/index.ts
+++ b/packages/elements/src/time-picker/index.ts
@@ -899,7 +899,7 @@ export class TimePicker extends FormFieldElement {
 
   /**
    * Handle tap toggle between AP and PM state
-   * @param  userInteraction indicates whether the toggle is trigged by user interaction or not
+   * @param  userInteraction indicates whether the toggle is triggered by user interaction or not
    * @returns {void}
    */
   private async onToggle(userInteraction = true): Promise<void> {

--- a/packages/elements/src/time-picker/index.ts
+++ b/packages/elements/src/time-picker/index.ts
@@ -647,7 +647,7 @@ export class TimePicker extends FormFieldElement {
     const validMinute = checkValues(minutes, MAX_MINUTES);
     const validSecond = checkValues(seconds, MAX_SECONDS);
     // Check second only when it's enabled
-    return validHour && validMinute && (!this.showSeconds || validSecond);
+    return validHour && validMinute && (!this.isShowSeconds || validSecond);
   }
 
   /**

--- a/packages/elements/src/time-picker/index.ts
+++ b/packages/elements/src/time-picker/index.ts
@@ -899,7 +899,7 @@ export class TimePicker extends FormFieldElement {
 
   /**
    * Handle tap toggle between AP and PM state
-   * @param  userInteraction to determine whether action is done by user input
+   * @param  userInteraction to determine whether action is done by user input or api call
    * @returns {void}
    */
   private async onToggle(userInteraction = true): Promise<void> {

--- a/packages/elements/src/time-picker/index.ts
+++ b/packages/elements/src/time-picker/index.ts
@@ -749,7 +749,7 @@ export class TimePicker extends FormFieldElement {
    */
   private handleEnterKey(event: KeyboardEvent): void {
     if (event.target === this.toggleEl) {
-      void this.onTapToggle();
+      void this.onToggle();
       event.preventDefault();
     }
   }
@@ -781,7 +781,7 @@ export class TimePicker extends FormFieldElement {
    */
   private toggleOrModify(amount: number, target: HTMLElement): void {
     if (target === this.toggleEl) {
-      void this.onTapToggle();
+      void this.onToggle();
     } else if (target === this.hoursInput) {
       this.changeValueBy(amount, Segment.HOURS);
     } else if (target === this.minutesInput) {
@@ -894,20 +894,24 @@ export class TimePicker extends FormFieldElement {
    * @returns {void}
    */
   public toggle(): void {
-    if (this.amPm) {
-      this.hours =
-        this.hours === null ? new Date().getHours() : (this.hours + HOURS_IN_DAY / 2) % HOURS_IN_DAY;
-    }
+    void this.onToggle(false);
   }
 
   /**
    * Handle tap toggle between AP and PM state
+   * @param  userInteraction to determine whether action is done by user input
    * @returns {void}
    */
-  private async onTapToggle(): Promise<void> {
+  private async onToggle(userInteraction = true): Promise<void> {
     if (this.amPm) {
       const hours =
         this.hours === null ? new Date().getHours() : (this.hours + HOURS_IN_DAY / 2) % HOURS_IN_DAY;
+
+      if (!userInteraction) {
+        this.hours = hours;
+        return;
+      }
+
       this.setSegmentAndNotify(Segment.HOURS, hours);
 
       await this.updateComplete;
@@ -1038,7 +1042,7 @@ export class TimePicker extends FormFieldElement {
             aria-activedescendant="${hasHours ? (this.isAM() ? 'toggle-am' : 'toggle-pm') : nothing}"
             id="toggle"
             part="toggle"
-            @tap=${this.onTapToggle}
+            @tap=${this.onToggle}
             tabindex="0"
           >
             <div

--- a/packages/elements/src/time-picker/index.ts
+++ b/packages/elements/src/time-picker/index.ts
@@ -899,7 +899,7 @@ export class TimePicker extends FormFieldElement {
 
   /**
    * Handle tap toggle between AP and PM state
-   * @param  userInteraction to determine whether action is done by user input or api call
+   * @param  userInteraction indicates whether the toggle is trigged by user interaction or not
    * @returns {void}
    */
   private async onToggle(userInteraction = true): Promise<void> {
@@ -908,14 +908,14 @@ export class TimePicker extends FormFieldElement {
         this.hours === null ? new Date().getHours() : (this.hours + HOURS_IN_DAY / 2) % HOURS_IN_DAY;
 
       if (!userInteraction) {
-        this.hours = hours;
+        this.hours = hours; // set segment without notifying value change
         return;
       }
 
       this.setSegmentAndNotify(Segment.HOURS, hours);
 
       await this.updateComplete;
-      // The segment needs to be validated when the segment input has been changed
+      // The segment needs to be validated when its value has been changed
       if (!this.customValidation) {
         this.reportValidity();
       }

--- a/packages/elements/src/time-picker/index.ts
+++ b/packages/elements/src/time-picker/index.ts
@@ -635,22 +635,17 @@ export class TimePicker extends FormFieldElement {
       return true;
     }
 
-    const isValidUnit = (value: number | null, maxUnit: number) => {
-      if (value === null) {
-        return false;
-      }
-      return value >= MIN_UNIT && value <= maxUnit;
-    };
-    const checkValues = (newValue: string | undefined, maxUnit: number) => {
+    const checkValues = (newValue: string | undefined, oldValue: number | null, maxUnit: number) => {
       if (!newValue) {
         return false;
       }
-      return isValidUnit(Number(newValue), maxUnit);
+      const _newValue = Number(newValue);
+      return TimePicker.validUnit(_newValue, MIN_UNIT, maxUnit, oldValue) === _newValue;
     };
 
-    const validHour = checkValues(hours, MAX_HOURS);
-    const validMinute = checkValues(minutes, MAX_MINUTES);
-    const validSecond = checkValues(seconds, MAX_SECONDS);
+    const validHour = checkValues(hours, this.hours, MAX_HOURS);
+    const validMinute = checkValues(minutes, this.minutes, MAX_MINUTES);
+    const validSecond = checkValues(seconds, this.seconds, MAX_SECONDS);
     const hasHourAndMinute = validHour && validMinute;
     // Check if secondSeconds is provided
     const hasSecond = !this.showSeconds || validSecond;
@@ -679,13 +674,11 @@ export class TimePicker extends FormFieldElement {
    * @returns {void}
    */
   private onInputValidation(): void {
-    /* c8 ignore start */
     if (this.customValidation) {
       return;
     }
 
     this.reportValidity();
-    /* c8 ignore stop */
   }
 
   /**

--- a/packages/elements/src/time-picker/index.ts
+++ b/packages/elements/src/time-picker/index.ts
@@ -624,9 +624,9 @@ export class TimePicker extends FormFieldElement {
 
   /**
    * Returns `true` if all input segments contain valid data or empty. Otherwise, returns false.
-   * @returns true if inputs are not partial
+   * @returns true if input is valid
    */
-  private partialValidation(): boolean {
+  public override checkValidity(): boolean {
     const hours = this.hoursInput?.value;
     const minutes = this.minutesInput?.value;
     const seconds = this.secondsInput?.value;
@@ -635,27 +635,19 @@ export class TimePicker extends FormFieldElement {
       return true;
     }
 
-    const checkValues = (newValue: string | undefined, oldValue: number | null, maxUnit: number) => {
-      if (!newValue) {
+    const checkValues = (value: string | undefined, maxUnit: number) => {
+      if (!value) {
         return false;
       }
-      const _newValue = Number(newValue);
-      return TimePicker.validUnit(_newValue, MIN_UNIT, maxUnit, oldValue) === _newValue;
+      const _value = Number(value);
+      return TimePicker.validUnit(_value, MIN_UNIT, maxUnit, null) === _value;
     };
 
-    const validHour = checkValues(hours, this.hours, MAX_HOURS);
-    const validMinute = checkValues(minutes, this.minutes, MAX_MINUTES);
-    const validSecond = checkValues(seconds, this.seconds, MAX_SECONDS);
+    const validHour = checkValues(hours, MAX_HOURS);
+    const validMinute = checkValues(minutes, MAX_MINUTES);
+    const validSecond = checkValues(seconds, MAX_SECONDS);
     // Check second only when it's enabled
     return validHour && validMinute && (!this.showSeconds || validSecond);
-  }
-
-  /**
-   * Returns `true` if all input segments contain valid data or empty. Otherwise, returns false.
-   * @returns true if input is valid
-   */
-  public override checkValidity(): boolean {
-    return this.partialValidation();
   }
 
   /**

--- a/packages/elements/src/time-picker/index.ts
+++ b/packages/elements/src/time-picker/index.ts
@@ -749,7 +749,7 @@ export class TimePicker extends FormFieldElement {
    */
   private handleEnterKey(event: KeyboardEvent): void {
     if (event.target === this.toggleEl) {
-      this.toggle();
+      void this.onTapToggle();
       event.preventDefault();
     }
   }
@@ -781,7 +781,7 @@ export class TimePicker extends FormFieldElement {
    */
   private toggleOrModify(amount: number, target: HTMLElement): void {
     if (target === this.toggleEl) {
-      this.toggle();
+      void this.onTapToggle();
     } else if (target === this.hoursInput) {
       this.changeValueBy(amount, Segment.HOURS);
     } else if (target === this.minutesInput) {
@@ -895,9 +895,26 @@ export class TimePicker extends FormFieldElement {
    */
   public toggle(): void {
     if (this.amPm) {
+      this.hours =
+        this.hours === null ? new Date().getHours() : (this.hours + HOURS_IN_DAY / 2) % HOURS_IN_DAY;
+    }
+  }
+
+  /**
+   * Handle tap toggle between AP and PM state
+   * @returns {void}
+   */
+  private async onTapToggle(): Promise<void> {
+    if (this.amPm) {
       const hours =
         this.hours === null ? new Date().getHours() : (this.hours + HOURS_IN_DAY / 2) % HOURS_IN_DAY;
       this.setSegmentAndNotify(Segment.HOURS, hours);
+
+      await this.updateComplete;
+      // The segment needs to be validated when the segment input has been changed
+      if (!this.customValidation) {
+        this.reportValidity();
+      }
     }
   }
 
@@ -1021,7 +1038,7 @@ export class TimePicker extends FormFieldElement {
             aria-activedescendant="${hasHours ? (this.isAM() ? 'toggle-am' : 'toggle-pm') : nothing}"
             id="toggle"
             part="toggle"
-            @tap=${this.toggle}
+            @tap=${this.onTapToggle}
             tabindex="0"
           >
             <div

--- a/packages/elements/src/time-picker/index.ts
+++ b/packages/elements/src/time-picker/index.ts
@@ -646,11 +646,8 @@ export class TimePicker extends FormFieldElement {
     const validHour = checkValues(hours, this.hours, MAX_HOURS);
     const validMinute = checkValues(minutes, this.minutes, MAX_MINUTES);
     const validSecond = checkValues(seconds, this.seconds, MAX_SECONDS);
-    const hasHourAndMinute = validHour && validMinute;
-    // Check if secondSeconds is provided
-    const hasSecond = !this.showSeconds || validSecond;
-
-    return hasHourAndMinute && hasSecond;
+    // Check second only when it's enabled
+    return validHour && validMinute && (!this.showSeconds || validSecond);
   }
 
   /**

--- a/packages/elements/src/time-picker/index.ts
+++ b/packages/elements/src/time-picker/index.ts
@@ -626,12 +626,35 @@ export class TimePicker extends FormFieldElement {
     const hours = this.hoursInput?.value;
     const minutes = this.minutesInput?.value;
     const seconds = this.secondsInput?.value;
-
+    // If no values are provided in all segment, there is no error
     if (!hours && !minutes && !seconds) {
       return true;
     }
 
-    return !!(hours && minutes) && !!(!this.showSeconds || seconds);
+    const isInvalidValues = (newValue: number | null, oldValue: number | null, maxUnit: number): boolean => {
+      return oldValue === null && TimePicker.validUnit(newValue, MIN_UNIT, maxUnit, oldValue) === null;
+    };
+    const validateValue = (value: string | undefined, oldValue: number | null, maxUnit: number) => {
+      if (value) {
+        const numValue = Number(value);
+        if (isInvalidValues(numValue, oldValue, maxUnit)) {
+          return false;
+        }
+
+        return String(TimePicker.validUnit(numValue, MIN_UNIT, maxUnit, oldValue));
+      }
+
+      return false;
+    };
+
+    const validHour = validateValue(hours, this.hours, MAX_HOURS);
+    const validMinute = validateValue(minutes, this.minutes, MAX_MINUTES);
+    const validSecond = validateValue(seconds, this.seconds, MAX_SECONDS);
+    const hasHourAndMinute = !!(validHour && validMinute);
+    // Check if secondSeconds is provided
+    const hasSecond = !!(!this.showSeconds || validSecond);
+
+    return hasHourAndMinute && hasSecond;
   }
 
   /**
@@ -656,37 +679,7 @@ export class TimePicker extends FormFieldElement {
       return;
     }
 
-    const isInvalidValues = (newValue: number | null, oldValue: number | null, maxUnit: number): boolean => {
-      return oldValue === null && TimePicker.validUnit(newValue, MIN_UNIT, maxUnit, oldValue) === null;
-    };
-    const validateValue = (value: string | undefined, oldValue: number | null, maxUnit: number) => {
-      if (value) {
-        const numValue = Number(value);
-        if (isInvalidValues(numValue, oldValue, maxUnit)) {
-          return false;
-        }
-
-        return String(TimePicker.validUnit(numValue, MIN_UNIT, maxUnit, oldValue));
-      }
-
-      return false;
-    };
-
-    const validHour = validateValue(this.hoursInput?.value, this.hours, MAX_HOURS);
-    const validMinute = validateValue(this.minutesInput?.value, this.minutes, MAX_MINUTES);
-    const validSecond = validateValue(this.secondsInput?.value, this.seconds, MAX_SECONDS);
-    const hasHourAndMinute = !!(validHour && validMinute);
-    // Check if second input value is provided
-    const hasSecond = !!(!this.showSeconds || validSecond);
-
-    // Set error based on the validation
-    this.error = !(hasHourAndMinute && hasSecond);
-    // If no values are provided in all segment, there is no error
-    if (!validHour && !validMinute && !validSecond) {
-      this.error = false;
-    }
-
-    this.notifyPropertyChange('error', this.error);
+    this.reportValidity();
     /* c8 ignore stop */
   }
 

--- a/packages/halo-theme/src/custom-elements/ef-time-picker.less
+++ b/packages/halo-theme/src/custom-elements/ef-time-picker.less
@@ -18,12 +18,25 @@
     }
   }
 
-  &[error][disabled],
-  &[error][readonly]:not([focused]) {
-    border-color: fade(@control-hover-error-color, 50%);
-  }
-
   &[readonly]:not([focused]) {
     border-color: @input-disabled-border-color;
+  }
+
+  &:hover:not([readonly]):not([focused]) {
+    border-color: @input-hover-border-color;
+  }
+
+  &[error] {
+    &:not([focused]) {
+      border-color: @control-error-color;
+    }
+
+    &[readonly]:not([focused]) {
+      border-color: fade(@control-hover-error-color, 50%);
+    }
+
+    &:hover:not([readonly]):not([focused]) {
+      border-color: @control-hover-error-color;
+    }
   }
 }

--- a/packages/halo-theme/src/custom-elements/ef-time-picker.less
+++ b/packages/halo-theme/src/custom-elements/ef-time-picker.less
@@ -17,4 +17,17 @@
       display: none;
     }
   }
+
+  &[error]:not([focused]) {
+    border-color: @control-error-color;
+  }
+
+  &[error]:hover:not([readonly]):not([focused]) {
+    border-color: @control-hover-error-color;
+  }
+
+  &[error][disabled],
+  &[error][readonly]:not([focused]) {
+    border-color: fade(@control-hover-error-color, 50%);
+  }
 }

--- a/packages/halo-theme/src/custom-elements/ef-time-picker.less
+++ b/packages/halo-theme/src/custom-elements/ef-time-picker.less
@@ -18,16 +18,12 @@
     }
   }
 
-  &[error]:not([focused]) {
-    border-color: @control-error-color;
-  }
-
-  &[error]:hover:not([readonly]):not([focused]) {
-    border-color: @control-hover-error-color;
-  }
-
   &[error][disabled],
   &[error][readonly]:not([focused]) {
     border-color: fade(@control-hover-error-color, 50%);
+  }
+
+  &[readonly]:not([focused]) {
+    border-color: @input-disabled-border-color;
   }
 }

--- a/packages/solar-theme/src/custom-elements/ef-time-picker.less
+++ b/packages/solar-theme/src/custom-elements/ef-time-picker.less
@@ -26,4 +26,25 @@
       background: @input-focused-border-color;
     }
   }
+
+  &[focused] {
+    &[readonly]:not([error]) {
+      border-color: @input-focused-border-color;
+      border-style: @input-focused-border-style;
+    }
+
+    &[error] {
+      &:not([readonly]) {
+        border-color: @input-focused-border-color;
+        border-style: @input-focused-border-style;
+      }
+      [part='input'],
+      [part='toggle'] {
+        &:focus::after,
+        &[focused]::after {
+          border-bottom: none;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Description
Previously, time-picker was not provided any input feedback to Apps when the input is in the partial state. Therefore, we decided to extend `FormFieldElement` instead of `ControlElement` and provide build-in validation to validate partial value in time-picker. Moreover, we also introduce `custom-validation` API to disable build-in validation. it allows Apps to manage error state and validation base on their criteria.

Things that include in this PR

- Time-picker change to FormFieldElement
- Add build-in validation to validate partial value 
- Introduce `custom-validation` API to disable build-in validation and allow user to make their own validation
- Add `error-changed` event for time-picker
- Add stye for `readonly` and `error` state
- Fix incorrect behavior of `toggle` method that fire `value-changed` event when call `toggle` via API
- Add document of input validation of time-picker 
- Add demo of input validation of time-picker 
- Fix datetime-picker issue that it doesn't sync time value back to time-picker input when reopen popup and time-picker input is invalid
- Add unit test to cover those fix and feature in time-picker and datetime-picker

Fixes # (issue)
https://jira.refinitiv.com/browse/DME-11575

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
