### PR TITLE
feat(tree): enable custom filter of query

### DIFF
--- a/documents/src/pages/elements/combo-box.md
+++ b/documents/src/pages/elements/combo-box.md
@@ -246,9 +246,9 @@ const createCustomFilter = (comboBox) => {
     }
     return queryRegExp;
   };
-  return (item, composer) => {
-    const label = composer.getItemPropertyValue(item, 'label');
-    const value = composer.getItemPropertyValue(item, 'value');
+  return (item) => {
+    const value = item.value;
+    const label = item.label;
     const regex = getRegularExpressionOfQuery();
     const result =  regex.test(value) || regex.test(label);
     return result;
@@ -293,9 +293,9 @@ const createCustomFilter = (comboBox) => {
   };
 
   // return scoped custom filter
-  return (item, composer) => {
-    const label = composer.getItemPropertyValue(item, 'label');
-    const value = composer.getItemPropertyValue(item, 'value');
+  return (item) => {
+    const value = item.value;
+    const label = item.label;
     const regex = getRegularExpressionOfQuery();
     const result = regex.test(value) || regex.test(label);
     return result;
@@ -306,7 +306,6 @@ comboBox.filter = createCustomFilter(comboBox);
 ```
 
 ```typescript
-import type { ItemData } from '@refinitiv-ui/elements/item';
 import type { ComboBox, ComboBoxFilter } from '@refinitiv-ui/elements/combo-box';
 
 const comboBox = document.querySelector('ef-combo-box');
@@ -331,10 +330,9 @@ const createCustomFilter = (comboBox: ComboBox): ComboBoxFilter => {
   };
 
   // return scoped custom filter
-  return (item, context) => {
-    const composer = context as CollectionComposer<ItemData>;
-    const label = composer.getItemPropertyValue(item, 'label') as string;
-    const value = composer.getItemPropertyValue(item, 'value') as string;
+  return (item) => {
+    const value = item.value as string;
+    const label = item.label as string;
     const regex = getRegularExpressionOfQuery();
     const result = regex.test(value) || regex.test(label);
     return result;

--- a/documents/src/pages/elements/combo-box.md
+++ b/documents/src/pages/elements/combo-box.md
@@ -233,7 +233,7 @@ comboBox.data = [
   { label: 'Brazil', value: 'br' },
   { label: 'Argentina', value: 'ar' }
 ];
-const customFilter = (comboBox) => {
+const createCustomFilter = (comboBox) => {
   let query = '';
   let queryRegExp;
   const getRegularExpressionOfQuery = () => {
@@ -255,7 +255,7 @@ const customFilter = (comboBox) => {
   };
 };
 
-comboBox.filter = customFilter(comboBox);
+comboBox.filter = createCustomFilter(comboBox);
 ```
 ```css
 .wrapper {
@@ -274,7 +274,7 @@ comboBox.filter = customFilter(comboBox);
 const comboBox = document.querySelector('ef-combo-box');
 
 // Make a scoped re-usable filter for performance
-const customFilter = (comboBox) => {
+const createCustomFilter = (comboBox) => {
   let query = ''; // reference query string for validating queryRegExp cache state
   let queryRegExp; // cache RegExp
 
@@ -302,7 +302,7 @@ const customFilter = (comboBox) => {
   };
 };
 
-comboBox.filter = customFilter(comboBox);
+comboBox.filter = createCustomFilter(comboBox);
 ```
 
 ```typescript
@@ -312,7 +312,7 @@ import type { ComboBox, ComboBoxFilter } from '@refinitiv-ui/elements/combo-box'
 const comboBox = document.querySelector('ef-combo-box');
 
 // Make a scoped re-usable filter for performance
-const customFilter = (comboBox: ComboBox): ComboBoxFilter => {
+const createCustomFilter = (comboBox: ComboBox): ComboBoxFilter => {
   let query = ''; // reference query string for validating queryRegExp cache state
   let queryRegExp: RegExp; // cache RegExp
 
@@ -342,11 +342,11 @@ const customFilter = (comboBox: ComboBox): ComboBoxFilter => {
 };
 
 if (comboBox) {
-  comboBox.filter = customFilter(comboBox);
+  comboBox.filter = createCustomFilter(comboBox);
 }
 ```
 
-@> Regardless of filter configuration Combo Box always treats `type: 'header'` items as group headers, which persist as long as at least one item within the group is visible.
+@> Regardless of filter configuration, Combo Box always treats `type: 'header'` items as group headers, which persist as long as at least one item within the group is visible.
 
 ## Asynchronous filtering
 

--- a/documents/src/pages/elements/combo-box.md
+++ b/documents/src/pages/elements/combo-box.md
@@ -239,14 +239,16 @@ const customFilter = (comboBox) => {
   const getRegularExpressionOfQuery = () => {
     if (comboBox.query !== query || !queryRegExp) {
       query = comboBox.query || '';
+      // Non-word characters are escaped to prevent ReDoS attack.
+      // This serves as a demo only. 
+      // For production, use a proven implementation instead.
       queryRegExp = new RegExp(query.replace(/(\W)/g, '\\$1'), 'i');
     }
     return queryRegExp;
   };
   return (item) => {
     const regex = getRegularExpressionOfQuery();
-    const result = query === item.value || regex.test(item.label);
-    regex.lastIndex = 0; // do not forget to reset last index
+    const result =  regex.test(item.value) || regex.test(item.label);
     return result;
   };
 };
@@ -280,6 +282,9 @@ const customFilter = (comboBox) => {
   const getRegularExpressionOfQuery = () => {
     if (comboBox.query !== query || !queryRegExp) {
       query = comboBox.query || '';
+      // Non-word characters are escaped to prevent ReDoS attack.
+      // This serves as a demo only. 
+      // For production, use a proven implementation instead.
       queryRegExp = new RegExp(query.replace(/(\W)/g, '\\$1'), 'i');
     }
     return queryRegExp;
@@ -288,8 +293,7 @@ const customFilter = (comboBox) => {
   // return scoped custom filter
   return (item) => {
     const regex = getRegularExpressionOfQuery();
-    const result = query === item.value || regex.test(item.label);
-    regex.lastIndex = 0; // do not forget to reset last index
+    const result = regex.test(item.value) || regex.test(item.label);
     return result;
   };
 };
@@ -314,6 +318,9 @@ const customFilter = (comboBox: ComboBox): ComboBoxFilter => {
   const getRegularExpressionOfQuery = () => {
     if (comboBox.query !== query || !queryRegExp) {
       query = comboBox.query || '';
+      // Non-word characters are escaped to prevent ReDoS attack.
+      // This serves as a demo only. 
+      // For production, use a proven implementation instead.
       queryRegExp = new RegExp(query.replace(/(\W)/g, '\\$1'), 'i');
     }
     return queryRegExp;
@@ -322,8 +329,7 @@ const customFilter = (comboBox: ComboBox): ComboBoxFilter => {
   // return scoped custom filter
   return (item: ItemData) => {
     const regex = getRegularExpressionOfQuery();
-    const result = query === item.value || regex.test(item.label as string);
-    regex.lastIndex = 0; // do not forget to reset last index
+    const result = regex.test(item.value) || regex.test(item.label as string);
     return result;
   };
 };
@@ -395,6 +401,9 @@ comboBox.filter = null;
 
 // A function to make request. In real life scenario it may wrap fetch
 const request = (query, value) => {
+  // Non-word characters are escaped to prevent ReDoS attack.
+  // This serves as a demo only. 
+  // For production, use a proven implementation instead.
   const regex = new RegExp(query.replace(/(\W)/g, '\\$1'), 'i');
 
   // Always keep a promise to let Combo Box know that the data is loading
@@ -410,13 +419,11 @@ const request = (query, value) => {
             selected: true,
             hidden: query ? !regex.test(item.label) : false
           }));
-          regex.lastIndex = 0;
           continue;
         }
 
         if (query && regex.test(item.label)) {
           filterData.push(item);
-          regex.lastIndex = 0;
         }
       }
     }

--- a/documents/src/pages/elements/combo-box.md
+++ b/documents/src/pages/elements/combo-box.md
@@ -246,9 +246,11 @@ const customFilter = (comboBox) => {
     }
     return queryRegExp;
   };
-  return (item) => {
+  return (item, composer) => {
+    const label = composer.getItemPropertyValue(item, 'label');
+    const value = composer.getItemPropertyValue(item, 'value');
     const regex = getRegularExpressionOfQuery();
-    const result =  regex.test(item.value) || regex.test(item.label);
+    const result =  regex.test(value) || regex.test(label);
     return result;
   };
 };
@@ -291,9 +293,11 @@ const customFilter = (comboBox) => {
   };
 
   // return scoped custom filter
-  return (item) => {
+  return (item, composer) => {
+    const label = composer.getItemPropertyValue(item, 'label');
+    const value = composer.getItemPropertyValue(item, 'value');
     const regex = getRegularExpressionOfQuery();
-    const result = regex.test(item.value) || regex.test(item.label);
+    const result = regex.test(value) || regex.test(label);
     return result;
   };
 };
@@ -302,8 +306,8 @@ comboBox.filter = customFilter(comboBox);
 ```
 
 ```typescript
-import { ItemData } from '@refinitiv-ui/elements/item';
-import { ComboBox, ComboBoxFilter } from '@refinitiv-ui/elements/combo-box';
+import type { ItemData } from '@refinitiv-ui/elements/item';
+import type { ComboBox, ComboBoxFilter } from '@refinitiv-ui/elements/combo-box';
 
 const comboBox = document.querySelector('ef-combo-box');
 
@@ -327,9 +331,12 @@ const customFilter = (comboBox: ComboBox): ComboBoxFilter => {
   };
 
   // return scoped custom filter
-  return (item: ItemData) => {
+  return (item, context) => {
+    const composer = context as CollectionComposer<ItemData>;
+    const label = composer.getItemPropertyValue(item, 'label') as string;
+    const value = composer.getItemPropertyValue(item, 'value') as string;
     const regex = getRegularExpressionOfQuery();
-    const result = regex.test(item.value) || regex.test(item.label as string);
+    const result = regex.test(value) || regex.test(label);
     return result;
   };
 };

--- a/documents/src/pages/elements/tree-select.md
+++ b/documents/src/pages/elements/tree-select.md
@@ -370,8 +370,7 @@ Tree select has built in text filtering and selection editing.
 
 By clicking the `Selected` button, Tree Select allows the items to be filtered by selected state, and that subset to be operated on in isolation from the main item list.
 
-For custom filtering, Tree Select provides an identical interface as Combo Box. You provide a predicate function that tests an item. Please consult the [Combo Box docs](./elements/combo-box) for details on how to construct a compatible filter.
-
+For custom filtering, Tree Select provides an identical interface as Combo Box. You provide a predicate function testing each item. Please consult the [Combo Box docs](./elements/combo-box#filtering) for details on how to construct a compatible filter.
 
 ## Limiting Selected Items
 Tree Select offers a convenient way to limit the number of selected items using `max` property. If users attempt to select more items than the specified limit, "Done" button will be automatically disabled.

--- a/documents/src/pages/elements/tree-select.md
+++ b/documents/src/pages/elements/tree-select.md
@@ -378,18 +378,24 @@ To customise filtering, provide a predicate function testing each item to `filte
 ::import-elements::
 const treeSelect = document.querySelector('ef-tree-select');
 treeSelect.data = [
-  { label: 'France', value: 'fr' },
-  { label: 'Russian Federation', value: 'ru' },
-  { label: 'Spain', value: 'es' },
-  { label: 'United Kingdom', value: 'gb' },
-  { label: 'China', value: 'ch' },
-  { label: 'Australia', value: 'au' },
-  { label: 'India', value: 'in' },
-  { label: 'Thailand', value: 'th' },
-  { label: 'Canada', value: 'ca' },
-  { label: 'United States', value: 'us' },
-  { label: 'Brazil', value: 'br' },
-  { label: 'Argentina', value: 'ar' }
+  { label: 'EMEA', value: 'emea', expanded: true, items: [
+    { label: 'France', value: 'fr' },
+    { label: 'Russian Federation', value: 'ru' },
+    { label: 'Spain', value: 'es' },
+    { label: 'United Kingdom', value: 'gb' }
+  ]},
+  { label: 'APAC', value: 'apac', expanded: true, items: [
+    { label: 'China', value: 'ch' },
+    { label: 'Australia', value: 'au' },
+    { label: 'India', value: 'in' },
+    { label: 'Thailand', value: 'th' }
+  ]},
+  { label: 'AMERS', value: 'amers', expanded: true, items: [
+    { label: 'Canada', value: 'ca' },
+    { label: 'United States', value: 'us' },
+    { label: 'Brazil', value: 'br' },
+    { label: 'Argentina', value: 'ar' }
+  ]}
 ];
 const createCustomFilter = (treeSelect) => {
   let query = '';

--- a/documents/src/pages/elements/tree.md
+++ b/documents/src/pages/elements/tree.md
@@ -604,7 +604,154 @@ export const createTreeRenderer = <T extends TreeDataItem = TreeDataItem>(
 tree.renderer = createTreeRenderer(tree)
 ```
 
+## Filtering
+
+Filtering happens when `query` property or attribute is not empty. By Default, the filter is applied on the data `label` property. Developers may wish to do their own filtering by implementing the `filter` property. A typical example is to apply filter on multiple data properties e.g. `label` and `value`.
+
+::
+```javascript
+::import-elements::
+const tree = document.querySelector('ef-tree');
+tree.data = [
+  { label: 'France', value: 'fr' },
+  { label: 'Russian Federation', value: 'ru' },
+  { label: 'Spain', value: 'es' },
+  { label: 'United Kingdom', value: 'gb' },
+  { label: 'China', value: 'ch' },
+  { label: 'Australia', value: 'au' },
+  { label: 'India', value: 'in' },
+  { label: 'Thailand', value: 'th' },
+  { label: 'Canada', value: 'ca' },
+  { label: 'United States', value: 'us' },
+  { label: 'Brazil', value: 'br' },
+  { label: 'Argentina', value: 'ar' }
+];
+const createCustomFilter = (tree) => {
+  let query = '';
+  let queryRegExp;
+  const getRegularExpressionOfQuery = () => {
+    if (tree.query !== query || !queryRegExp) {
+      query = tree.query || '';
+      // Non-word characters are escaped to prevent ReDoS attack.
+      // This serves as a demo only. 
+      // For production, use a proven implementation instead.
+      queryRegExp = new RegExp(query.replace(/(\W)/g, '\\$1'), 'i');
+    }
+    return queryRegExp;
+  };
+  return (item, manager) => {
+    const treeNode = manager.getTreeNode(item);
+    const { label, value } = treeNode;
+    const regex = getRegularExpressionOfQuery();
+    const result = regex.test(value) || regex.test(label);
+    return result;
+  };
+};
+tree.filter = createCustomFilter(tree);
+
+const input = document.getElementById('query');
+input.addEventListener('value-changed', e => {
+  tree.query = e.detail.value;
+});
+```
+```css
+.wrapper {
+  padding: 5px;
+  width: 300px;
+}
+
+#query {
+  width: 200px;
+}
+```
+```html
+<div class="wrapper">
+  <label for="query">Filter</label>
+  <ef-text-field id="query" placeholder="keyword to filter Tree's items"></ef-text-field>
+  <br>
+  <ef-tree></ef-tree>
+</div>
+```
+::
+
+```javascript
+const tree = document.querySelector('ef-tree');
+
+// Make a scoped re-usable filter for performance
+const createCustomFilter = (tree) => {
+  let query = ''; // reference query string for validating queryRegExp cache state
+  let queryRegExp; // cache RegExp
+
+  // Get current RegExp, or renew if out of date
+  // this is fetched on demand by filter/renderer
+  // only created once per query
+  const getRegularExpressionOfQuery = () => {
+    if (tree.query !== query || !queryRegExp) {
+      query = tree.query || '';
+      // Non-word characters are escaped to prevent ReDoS attack.
+      // This serves as a demo only. 
+      // For production, use a proven implementation instead.
+      queryRegExp = new RegExp(query.replace(/(\W)/g, '\\$1'), 'i');
+    }
+    return queryRegExp;
+  };
+
+  // return scoped custom filter
+  return (item, manager) => {
+    const treeNode = manager.getTreeNode(item);
+    const { label, value } = treeNode;
+    const regex = getRegularExpressionOfQuery();
+    const result = regex.test(value) || regex.test(label);
+    return result;
+  };
+};
+
+tree.filter = createCustomFilter(tree);
+```
+
+```typescript
+import type { Tree, TreeFilter } from '@refinitiv-ui/elements/tree';
+
+const tree = document.querySelector('ef-tree');
+
+// Make a scoped re-usable filter for performance
+const createCustomFilter = (tree: Tree): TreeFilter => {
+  let query = ''; // reference query string for validating queryRegExp cache state
+  let queryRegExp: RegExp; // cache RegExp
+
+  // Get current RegExp, or renew if out of date
+  // this is fetched on demand by filter/renderer
+  // only created once per query
+  const getRegularExpressionOfQuery = () => {
+    if (tree.query !== query || !queryRegExp) {
+      query = tree.query || '';
+      // Non-word characters are escaped to prevent ReDoS attack.
+      // This serves as a demo only. 
+      // For production, use a proven implementation instead.
+      queryRegExp = new RegExp(query.replace(/(\W)/g, '\\$1'), 'i');
+    }
+    return queryRegExp;
+  };
+
+  // return scoped custom filter
+  return (item, manager) => {
+    const treeNode = manager.getTreeNode(item)!;
+    const { label, value } = treeNode;
+    const regex = getRegularExpressionOfQuery();
+    const result = regex.test(value) || regex.test(label);
+    return result;
+  };
+};
+
+if (tree) {
+  tree.filter = createCustomFilter(tree);
+}
+```
+
+@> Regardless of filter configuration, Tree always show parent items as long as at least one of their child is visible.
+
 ## Accessibility
+
 ::a11y-intro::
 
 `ef-tree` is assigned `role="tree"` and can include properties such as `aria-multiselectable`, `aria-label`, or `aria-labelledby`. It receives focus once at host and it is navigable through items using `Up` and `Down` arrow keys and expandable or collapsable using `Left` and `Right`. Each item is assigned `role="treeitem"` and can include properties such as `aria-selected` or `aria-checked` in `multiple` mode.

--- a/documents/src/pages/elements/tree.md
+++ b/documents/src/pages/elements/tree.md
@@ -613,18 +613,24 @@ Filtering happens when `query` property or attribute is not empty. By Default, t
 ::import-elements::
 const tree = document.querySelector('ef-tree');
 tree.data = [
-  { label: 'France', value: 'fr' },
-  { label: 'Russian Federation', value: 'ru' },
-  { label: 'Spain', value: 'es' },
-  { label: 'United Kingdom', value: 'gb' },
-  { label: 'China', value: 'ch' },
-  { label: 'Australia', value: 'au' },
-  { label: 'India', value: 'in' },
-  { label: 'Thailand', value: 'th' },
-  { label: 'Canada', value: 'ca' },
-  { label: 'United States', value: 'us' },
-  { label: 'Brazil', value: 'br' },
-  { label: 'Argentina', value: 'ar' }
+  { label: 'EMEA', value: 'emea', expanded: true, items: [
+    { label: 'France', value: 'fr' },
+    { label: 'Russian Federation', value: 'ru' },
+    { label: 'Spain', value: 'es' },
+    { label: 'United Kingdom', value: 'gb' }
+  ]},
+  { label: 'APAC', value: 'apac', expanded: true, items: [
+    { label: 'China', value: 'ch' },
+    { label: 'Australia', value: 'au' },
+    { label: 'India', value: 'in' },
+    { label: 'Thailand', value: 'th' }
+  ]},
+  { label: 'AMERS', value: 'amers', expanded: true, items: [
+    { label: 'Canada', value: 'ca' },
+    { label: 'United States', value: 'us' },
+    { label: 'Brazil', value: 'br' },
+    { label: 'Argentina', value: 'ar' }
+  ]}
 ];
 const createCustomFilter = (tree) => {
   let query = '';
@@ -658,7 +664,7 @@ input.addEventListener('value-changed', e => {
 .wrapper {
   padding: 5px;
   width: 300px;
-  height: 360px;
+  height: 430px;
 }
 
 #query {

--- a/documents/src/pages/elements/tree.md
+++ b/documents/src/pages/elements/tree.md
@@ -658,6 +658,7 @@ input.addEventListener('value-changed', e => {
 .wrapper {
   padding: 5px;
   width: 300px;
+  height: 360px;
 }
 
 #query {
@@ -748,7 +749,7 @@ if (tree) {
 }
 ```
 
-@> Regardless of filter configuration, Tree always show parent items as long as at least one of their child is visible.
+@> Regardless of filter configuration, Tree always shows parent items as long as at least one of their child is visible.
 
 ## Accessibility
 

--- a/packages/elements/src/combo-box/__demo__/index.html
+++ b/packages/elements/src/combo-box/__demo__/index.html
@@ -170,10 +170,10 @@
 
           // return scoped custom filter
           return (item) => {
+            const value = item.value;
+            const label = item.label;
             const regex = getRegularExpressionOfQuery();
-            // test on label or value
-            const result = query === item.value || regex.test(item.label);
-            regex.lastIndex = 0; // do not forget to reset last index
+            const result = regex.test(value) || regex.test(label);
             return result;
           };
         };
@@ -314,13 +314,11 @@
                         hidden: query ? !regex.test(item.label) : false
                       })
                     );
-                    regex.lastIndex = 0;
                     continue;
                   }
 
                   if (query && regex.test(item.label)) {
                     filterData.push(item);
-                    regex.lastIndex = 0;
                   }
                 }
               }

--- a/packages/elements/src/combo-box/__test__/__snapshots__/combo-box.filter.test.snap.js
+++ b/packages/elements/src/combo-box/__test__/__snapshots__/combo-box.filter.test.snap.js
@@ -125,3 +125,62 @@ snapshots["combo-box/Filter Can Filter Data Default filter filters data: changed
 `;
 /* end snapshot combo-box/Filter Can Filter Data Default filter filters data: changed */
 
+snapshots["combo-box/Filter Can Filter Data Should be able to use custom filter function"] = 
+`<div part="input-wrapper">
+  <input
+    aria-activedescendant="AX"
+    aria-autocomplete="list"
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    aria-owns="internal-list"
+    autocomplete="off"
+    part="input"
+    role="combobox"
+    type="text"
+  >
+  <div
+    id="toggle-button"
+    part="button button-toggle"
+  >
+    <ef-icon
+      icon="down"
+      part="icon icon-toggle"
+    >
+    </ef-icon>
+  </div>
+</div>
+<ef-overlay-viewport>
+</ef-overlay-viewport>
+<ef-overlay
+  no-autofocus=""
+  no-focus-management=""
+  no-overlap=""
+  opened=""
+  part="list"
+  tabindex="-1"
+  with-shadow=""
+>
+  <ef-list
+    aria-multiselectable="false"
+    id="internal-list"
+    role="listbox"
+    tabindex=""
+  >
+    <ef-list-item
+      aria-selected="false"
+      role="presentation"
+      type="header"
+    >
+    </ef-list-item>
+    <ef-list-item
+      aria-selected="false"
+      highlighted=""
+      id="AX"
+      role="option"
+    >
+    </ef-list-item>
+  </ef-list>
+</ef-overlay>
+`;
+/* end snapshot combo-box/Filter Can Filter Data Should be able to use custom filter function */
+

--- a/packages/elements/src/combo-box/__test__/combo-box.filter.test.js
+++ b/packages/elements/src/combo-box/__test__/combo-box.filter.test.js
@@ -1,3 +1,5 @@
+import escapeStringRegexp from 'escape-string-regexp';
+
 import '@refinitiv-ui/elements/combo-box';
 
 import '@refinitiv-ui/elemental-theme/light/ef-combo-box';
@@ -38,6 +40,41 @@ describe('combo-box/Filter', function () {
       await setInputEl(el, textInput);
       await openedUpdated(el);
       expect(el.query).to.equal(textInput, 'Query should be the same as input text: "Aland Islands"');
+      await expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
+    });
+
+    it('Should be able to use custom filter function', async function () {
+      const el = await fixture('<ef-combo-box opened></ef-combo-box>');
+      el.data = getData();
+      await elementUpdated(el);
+
+      const createCustomFilter = (comboBox) => {
+        let query = '';
+        let queryRegExp;
+        // Items could be filtered with case-insensitive partial match of both labels & values.
+        const getRegularExpressionOfQuery = () => {
+          if (comboBox.query !== query || !queryRegExp) {
+            query = comboBox.query || '';
+            queryRegExp = new RegExp(escapeStringRegexp(query), 'i');
+          }
+          return queryRegExp;
+        };
+        return (item) => {
+          const value = item.value;
+          const label = item.label;
+          const regex = getRegularExpressionOfQuery();
+          const result = regex.test(value) || regex.test(label);
+          return result;
+        };
+      };
+      el.filter = createCustomFilter(el);
+      const textInput = 'ax';
+      await setInputEl(el, textInput);
+
+      // const query = 'ax';
+      // el.query = query;
+      await elementUpdated(el);
+      expect(el.query).to.equal(textInput, `Query should be the same as input text: "${textInput}"`);
       await expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
     });
   });

--- a/packages/elements/src/combo-box/__test__/combo-box.filter.test.js
+++ b/packages/elements/src/combo-box/__test__/combo-box.filter.test.js
@@ -70,9 +70,6 @@ describe('combo-box/Filter', function () {
       el.filter = createCustomFilter(el);
       const textInput = 'ax';
       await setInputEl(el, textInput);
-
-      // const query = 'ax';
-      // el.query = query;
       await elementUpdated(el);
       expect(el.query).to.equal(textInput, `Query should be the same as input text: "${textInput}"`);
       await expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);

--- a/packages/elements/src/combo-box/helpers/filter.ts
+++ b/packages/elements/src/combo-box/helpers/filter.ts
@@ -40,8 +40,6 @@ export const createDefaultFilter = <T extends DataItem = ItemData>(el: ComboBox<
 
     const regex = getRegularExpressionOfQuery();
     const result = regex.test(label);
-    // this example uses global scope, so the index needs resetting
-    regex.lastIndex = 0;
     return result;
   };
 };

--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -114,13 +114,13 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
    * Set this to null when data is filtered externally, eg XHR
    * @type {ComboBoxFilter<T> | null}
    */
-  @property({ type: Function, attribute: false })
+  @property({ attribute: false })
   public filter: ComboBoxFilter<T> | null = createDefaultFilter<T>(this);
 
   /**
    * Renderer used to render list item elements
    */
-  @property({ type: Function, attribute: false })
+  @property({ attribute: false })
   public renderer = createComboBoxRenderer<T>(this);
 
   private _multiple = false;

--- a/packages/elements/src/list/elements/list.ts
+++ b/packages/elements/src/list/elements/list.ts
@@ -86,7 +86,7 @@ export class List<T extends DataItem = ItemData> extends ControlElement {
   /**
    * Renderer used to render list item elements
    */
-  @property({ type: Function, attribute: false })
+  @property({ attribute: false })
   public renderer = createListRenderer<T>(this);
 
   /**

--- a/packages/elements/src/swing-gauge/index.ts
+++ b/packages/elements/src/swing-gauge/index.ts
@@ -196,7 +196,7 @@ export class SwingGauge extends ResponsiveElement {
    * Custom value formatter
    * @type {SwingGaugeValueFormatter}
    */
-  @property({ type: Function, attribute: false })
+  @property({ attribute: false })
   public valueFormatter: SwingGaugeValueFormatter = this.defaultValueFormatter;
 
   /**

--- a/packages/elements/src/tooltip/index.ts
+++ b/packages/elements/src/tooltip/index.ts
@@ -115,7 +115,7 @@ class Tooltip extends BasicElement {
    * Return `true` if the target matches
    * @type {TooltipCondition}
    */
-  @property({ type: Function, attribute: false })
+  @property({ attribute: false })
   public condition: TooltipCondition | undefined;
 
   /**
@@ -124,7 +124,7 @@ class Tooltip extends BasicElement {
    * If the content is not present, tooltip will not be displayed
    * @type {TooltipRenderer}
    */
-  @property({ type: Function, attribute: false })
+  @property({ attribute: false })
   public renderer: TooltipRenderer | undefined;
 
   /**

--- a/packages/elements/src/tree-select/__demo__/countries.js
+++ b/packages/elements/src/tree-select/__demo__/countries.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-const treeCollection = [
+export const countries = [
   {
     value: 'AFR',
     label: 'Africa',

--- a/packages/elements/src/tree-select/__demo__/index.html
+++ b/packages/elements/src/tree-select/__demo__/index.html
@@ -138,8 +138,8 @@
             return queryRegExp;
           };
           return (item, treeManager) => {
-            const label = treeManager.composer.getItemPropertyValue(item, 'label');
-            const value = treeManager.composer.getItemPropertyValue(item, 'value');
+            const treeNode = treeManager.getTreeNode(item);
+            const { label, value } = treeNode;
             const regex = getRegularExpressionOfQuery();
             const result = regex.test(value) || regex.test(label);
             return result;

--- a/packages/elements/src/tree-select/__demo__/index.html
+++ b/packages/elements/src/tree-select/__demo__/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>Tree Select</title>
-    <script src="./countries.js"></script>
   </head>
   <body>
     <script type="module">
@@ -35,6 +34,8 @@
       import '@refinitiv-ui/phrasebook/locale/zh/tree-select.js';
     </script>
     <script type="module">
+      import { countries } from './countries.js';
+
       const makeData = (config = {}) => {
         return Array(config.size || 300)
           .fill(0)
@@ -59,9 +60,9 @@
           case 'selection-tooltip':
             el.data = makeData({ selected: true, disabled: false, hidden: false, size: 1001 });
             break;
-
+          case 'filter':
           default:
-            el.data = treeCollection;
+            el.data = countries;
             break;
         }
       });
@@ -115,5 +116,32 @@
         };
       </script>
     </demo-block>
+
+    <demo-block header="Filter" tags="filter" layout="normal">
+      <p>Items could be filtered with case-insensitive partial match of both labels & values.</p>
+      <ef-tree-select id="filter" aria-label="Choose Country"></ef-tree-select>
+    </demo-block>
+    <script type="module">
+      import escapeStringRegexp from 'escape-string-regexp';
+
+      const treeSelect = document.getElementById('filter');
+      const createCustomFilter = (treeSelect) => {
+        let query = '';
+        let queryRegExp;
+        const getRegularExpressionOfQuery = () => {
+          if (treeSelect.query !== query || !queryRegExp) {
+            query = treeSelect.query || '';
+            queryRegExp = new RegExp(escapeStringRegexp(query), 'i');
+          }
+          return queryRegExp;
+        };
+        return (item) => {
+          const regex = getRegularExpressionOfQuery();
+          const result = regex.test(item.value) || regex.test(item.label);
+          return result;
+        };
+      };
+      treeSelect.filter = createCustomFilter(treeSelect);
+    </script>
   </body>
 </html>

--- a/packages/elements/src/tree-select/__demo__/index.html
+++ b/packages/elements/src/tree-select/__demo__/index.html
@@ -118,8 +118,11 @@
     </demo-block>
 
     <demo-block header="Filter" tags="filter" layout="normal">
-      <p>Items could be filtered with case-insensitive partial match of both labels & values.</p>
-      <ef-tree-select id="filter" aria-label="Choose Country"></ef-tree-select>
+      <p>
+        Items could be filtered with case-insensitive partial match of both labels & values.<br />
+        There is a debounce rate of 500ms applied.
+      </p>
+      <ef-tree-select id="filter" query-debounce-rate="500" aria-label="Choose Country"></ef-tree-select>
       <script type="module">
         import escapeStringRegexp from 'escape-string-regexp';
 

--- a/packages/elements/src/tree-select/__demo__/index.html
+++ b/packages/elements/src/tree-select/__demo__/index.html
@@ -120,28 +120,30 @@
     <demo-block header="Filter" tags="filter" layout="normal">
       <p>Items could be filtered with case-insensitive partial match of both labels & values.</p>
       <ef-tree-select id="filter" aria-label="Choose Country"></ef-tree-select>
-    </demo-block>
-    <script type="module">
-      import escapeStringRegexp from 'escape-string-regexp';
+      <script type="module">
+        import escapeStringRegexp from 'escape-string-regexp';
 
-      const treeSelect = document.getElementById('filter');
-      const createCustomFilter = (treeSelect) => {
-        let query = '';
-        let queryRegExp;
-        const getRegularExpressionOfQuery = () => {
-          if (treeSelect.query !== query || !queryRegExp) {
-            query = treeSelect.query || '';
-            queryRegExp = new RegExp(escapeStringRegexp(query), 'i');
-          }
-          return queryRegExp;
+        const treeSelect = document.getElementById('filter');
+        const createCustomFilter = (treeSelect) => {
+          let query = '';
+          let queryRegExp;
+          const getRegularExpressionOfQuery = () => {
+            if (treeSelect.query !== query || !queryRegExp) {
+              query = treeSelect.query || '';
+              queryRegExp = new RegExp(escapeStringRegexp(query), 'i');
+            }
+            return queryRegExp;
+          };
+          return (item, treeManager) => {
+            const label = treeManager.composer.getItemPropertyValue(item, 'label');
+            const value = treeManager.composer.getItemPropertyValue(item, 'value');
+            const regex = getRegularExpressionOfQuery();
+            const result = regex.test(value) || regex.test(label);
+            return result;
+          };
         };
-        return (item) => {
-          const regex = getRegularExpressionOfQuery();
-          const result = regex.test(item.value) || regex.test(item.label);
-          return result;
-        };
-      };
-      treeSelect.filter = createCustomFilter(treeSelect);
-    </script>
+        treeSelect.filter = createCustomFilter(treeSelect);
+      </script>
+    </demo-block>
   </body>
 </html>

--- a/packages/elements/src/tree-select/__test__/tree-select.filter.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.filter.test.js
@@ -416,9 +416,11 @@ describe('tree-select/Filter', function () {
           }
           return queryRegExp;
         };
-        return (item) => {
+        return (item, treeManager) => {
+          const treeNode = treeManager.getTreeNode(item);
+          const { label, value } = treeNode;
           const regex = getRegularExpressionOfQuery();
-          const result = regex.test(item.value) || regex.test(item.label);
+          const result = regex.test(value) || regex.test(label);
           return result;
         };
       };

--- a/packages/elements/src/tree-select/__test__/tree-select.filter.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.filter.test.js
@@ -1,4 +1,6 @@
 // import element and theme
+import escapeStringRegexp from 'escape-string-regexp';
+
 import '@refinitiv-ui/elements/tree-select';
 
 import '@refinitiv-ui/elemental-theme/light/ef-tree-select';
@@ -396,6 +398,41 @@ describe('tree-select/Filter', function () {
       el.query = 'show me the code';
       await elementUpdated(el);
       expect(treeEl.children.length).to.equal(1, 'there should be 1 child with the provided query');
+    });
+
+    it('Should be able to use custom filter function', async function () {
+      const el = await fixture('<ef-tree-select opened></ef-tree-select>');
+      el.data = flatData;
+      await elementUpdated(el);
+
+      const createCustomFilter = (treeSelect) => {
+        let query = '';
+        let queryRegExp;
+        // Items could be filtered with case-insensitive partial match of both labels & values.
+        const getRegularExpressionOfQuery = () => {
+          if (treeSelect.query !== query || !queryRegExp) {
+            query = treeSelect.query || '';
+            queryRegExp = new RegExp(escapeStringRegexp(query), 'i');
+          }
+          return queryRegExp;
+        };
+        return (item) => {
+          const regex = getRegularExpressionOfQuery();
+          const result = regex.test(item.value) || regex.test(item.label);
+          return result;
+        };
+      };
+      el.filter = createCustomFilter(el);
+      const query = 'is';
+      el.query = query;
+      await elementUpdated(el);
+
+      const expectedLength = 4;
+      const treeEl = getTreeElPart(el);
+      expect(treeEl.children.length).to.equal(
+        expectedLength,
+        `there should be only ${expectedLength} children with a query of ${query}`
+      );
     });
   });
 });

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -49,6 +49,8 @@ const valueFormatWarning = new WarningNotice(
  * Dropdown control that allows selection from the tree list
  *
  * @prop {TreeSelectFilter<T> | null} [filter=createDefaultFilter<T>(this)] - Custom filter for static data. Set this to null when data is filtered externally, eg XHR
+ * @attr {number} [query-debounce-rate] - Control query rate in milliseconds
+ * @prop {number} [queryDebounceRate] - Control query rate in milliseconds
  * @attr {boolean} [opened=false] - Set dropdown to open
  * @prop {boolean} [opened=false] - Set dropdown to open
  * @attr {string} placeholder - Set placeholder text

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -243,7 +243,7 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
   /**
    * Renderer used to render tree item elements
    */
-  @property({ type: Function, attribute: false })
+  @property({ attribute: false })
   public override renderer = createTreeSelectRenderer<TreeSelectDataItem>(this);
 
   private _max: string | null = null;

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -48,6 +48,8 @@ const valueFormatWarning = new WarningNotice(
 /**
  * Dropdown control that allows selection from the tree list
  *
+ * @attr {TreeSelectFilter<T> | null} [filter=createDefaultFilter<T>(this)] - Custom filter for static data. Set this to null when data is filtered externally, eg XHR
+ * @prop {TreeSelectFilter<T> | null} [filter=createDefaultFilter<T>(this)] - Custom filter for static data. Set this to null when data is filtered externally, eg XHR
  * @attr {boolean} [opened=false] - Set dropdown to open
  * @prop {boolean} [opened=false] - Set dropdown to open
  * @attr {string} placeholder - Set placeholder text

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -48,7 +48,6 @@ const valueFormatWarning = new WarningNotice(
 /**
  * Dropdown control that allows selection from the tree list
  *
- * @attr {TreeSelectFilter<T> | null} [filter=createDefaultFilter<T>(this)] - Custom filter for static data. Set this to null when data is filtered externally, eg XHR
  * @prop {TreeSelectFilter<T> | null} [filter=createDefaultFilter<T>(this)] - Custom filter for static data. Set this to null when data is filtered externally, eg XHR
  * @attr {boolean} [opened=false] - Set dropdown to open
  * @prop {boolean} [opened=false] - Set dropdown to open

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -171,8 +171,11 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
   protected override composer: CollectionComposer<TreeSelectDataItem> = new CollectionComposer([]);
 
   protected _treeManager: TreeManager<TreeSelectDataItem> = new TreeManager(this.composer);
+
+  // add a space in front of angle bracket for line break opportunity in EF docs with @type
   /**
    * Tree manager used for item manipulation
+   * @type {TreeManager <TreeSelectDataItem>}
    */
   public get treeManager(): TreeManager<TreeSelectDataItem> {
     return this._treeManager;

--- a/packages/elements/src/tree/__demo__/index.html
+++ b/packages/elements/src/tree/__demo__/index.html
@@ -178,6 +178,14 @@
         };
         return makeData();
       };
+
+      globalThis.debounce = (callback, delay = 500) => {
+        let timeout;
+        return (...args) => {
+          clearTimeout(timeout);
+          timeout = setTimeout(() => callback.apply(this, args), delay);
+        };
+      };
     </script>
 
     <demo-block header="Default" layout="normal" tags="default">
@@ -219,19 +227,139 @@
       <button collapse>Collapse All</button>
       <button check>Check All</button>
       <button uncheck>Uncheck All</button>
-      <script>
-        const debounce = (callback, delay = 500) => {
-          let timeout;
-          return (...args) => {
-            clearTimeout(timeout);
-            timeout = setTimeout(() => callback.apply(this, args), delay);
+      <script type="module">
+        const el = document.getElementById('queryTree');
+
+        document.getElementById('inputQuery').addEventListener(
+          'keyup',
+          debounce((e) => {
+            el.query = e.target.value;
+          })
+        );
+      </script>
+    </demo-block>
+
+    <demo-block header="Filter Query" tags="filter, query" layout="normal">
+      <p>
+        Items could be filtered with case-insensitive partial match of both labels & values through query
+        input
+      </p>
+      <input id="filter-query-input" type="text" placeholder="Input query" />
+      <ef-tree multiple class="custom-data" id="filter-query-tree"></ef-tree>
+      <script type="module">
+        import escapeStringRegexp from 'escape-string-regexp';
+
+        const tree = document.getElementById('filter-query-tree');
+        const data = [
+          {
+            label: 'Group One',
+            value: '1',
+            expanded: true,
+            items: [
+              {
+                label: 'Item One.One',
+                icon: 'clock',
+                value: '1.1',
+                highlighted: true
+              },
+              {
+                label: 'Item One.Two',
+                readonly: true,
+                value: '1.2'
+              },
+              {
+                label: 'Item One.Three',
+                icon: 'info',
+                value: '1.3',
+                selected: true
+              },
+              {
+                label: 'Item One.Four',
+                icon: 'info',
+                value: '1.4',
+                selected: true
+              }
+            ]
+          },
+          {
+            label: 'Group Two',
+            value: '2',
+            expanded: true,
+            disabled: true,
+            items: [
+              {
+                label: 'Item Two.One',
+                value: '2.1',
+                hidden: true
+              },
+              {
+                label: 'Item Two.Two',
+                value: '2.2',
+                items: [
+                  {
+                    label: 'Item Two.Two.One',
+                    value: '2.2.1',
+                    expanded: true
+                  },
+                  {
+                    label: 'Item Two.Two.Two',
+                    value: '2.2.2'
+                  },
+                  {
+                    label: 'Item Two.Two.Three',
+                    value: '2.2.3'
+                  }
+                ]
+              },
+              {
+                label: 'Item Two.Three',
+                value: '2.3'
+              },
+              {
+                label: 'Item Two.Four',
+                value: '2.4',
+                disabled: true
+              }
+            ]
+          },
+          {
+            label: 'Item Three',
+            value: '3'
+          },
+          {
+            label: 'Item Four',
+            value: '4'
+          }
+        ];
+
+        const createCustomFilter = (tree) => {
+          let query = '';
+          let queryRegExp;
+          const getRegularExpressionOfQuery = () => {
+            if (tree.query !== query || !queryRegExp) {
+              query = tree.query || '';
+              queryRegExp = new RegExp(escapeStringRegexp(query), 'i');
+            }
+            return queryRegExp;
+          };
+          return (item, manager) => {
+            const treeNode = manager.getTreeNode(item);
+            const { label, value } = treeNode;
+            const regex = getRegularExpressionOfQuery();
+            const result = regex.test(value) || regex.test(label);
+            return result;
           };
         };
-        const el = document.getElementById('queryTree');
-        const setQuery = function (e) {
-          el.query = e.target.value;
-        };
-        document.getElementById('inputQuery').addEventListener('keyup', debounce(setQuery));
+
+        tree.data = data;
+        tree.filter = createCustomFilter(tree);
+
+        document.getElementById('filter-query-input').addEventListener(
+          'keyup',
+          debounce((e) => {
+            tree.query = e.target.value;
+          })
+        );
       </script>
     </demo-block>
 
@@ -449,7 +577,7 @@
           };
         };
 
-        let composer = new CollectionComposer(globalThis.generateMockData(7));
+        let composer = new CollectionComposer(generateMockData(7));
         let treeManager = new TreeManager(composer);
         let items = treeManager.items;
 

--- a/packages/elements/src/tree/__test__/helpers/data.js
+++ b/packages/elements/src/tree/__test__/helpers/data.js
@@ -180,3 +180,159 @@ export const deepNestedData = [
     ]
   }
 ];
+
+export const firstFilterData = [
+  {
+    label: 'Group One',
+    value: '1',
+    expanded: true,
+    items: [
+      {
+        label: 'Item One.One',
+        icon: 'clock',
+        value: '1.1',
+        highlighted: true
+      },
+      {
+        label: 'Item One.Two',
+        readonly: true,
+        value: '1.2'
+      },
+      {
+        label: 'Item One.Three',
+        icon: 'info',
+        value: '1.3',
+        selected: true
+      },
+      {
+        label: 'Item One.Four',
+        icon: 'info',
+        value: '1.4',
+        selected: true
+      }
+    ]
+  },
+  {
+    label: 'Group Two',
+    value: '2',
+    expanded: true,
+    disabled: true,
+    items: [
+      {
+        label: 'Item Two.One',
+        value: '2.1',
+        hidden: true
+      },
+      {
+        label: 'Item Two.Two',
+        value: '2.2',
+        items: [
+          {
+            label: 'Item Two.Two.One',
+            value: '2.2.1',
+            expanded: true
+          },
+          {
+            label: 'Item Two.Two.Two',
+            value: '2.2.2'
+          },
+          {
+            label: 'Item Two.Two.Three',
+            value: '2.2.3'
+          }
+        ]
+      },
+      {
+        label: 'Item Two.Three',
+        value: '2.3'
+      },
+      {
+        label: 'Item Two.Four',
+        value: '2.4',
+        disabled: true
+      }
+    ]
+  },
+  {
+    label: 'Item Three',
+    value: '3'
+  },
+  {
+    label: 'Item Four',
+    value: '4'
+  }
+];
+
+export const secondFilterData = [
+  {
+    label: 'Group One',
+    value: '1',
+    expanded: true,
+    items: [
+      {
+        label: 'Item One.One',
+        icon: 'clock',
+        value: '1.1',
+        highlighted: true
+      },
+      {
+        label: 'Item One.Two',
+        readonly: true,
+        value: '1.2'
+      },
+      {
+        label: 'Item One.Three',
+        icon: 'info',
+        value: '1.3',
+        selected: true
+      },
+      {
+        label: 'Item One.Four',
+        icon: 'info',
+        value: '1.4',
+        selected: true
+      }
+    ]
+  },
+  {
+    label: 'Group Two',
+    value: '2',
+    expanded: true,
+    disabled: true,
+    items: [
+      {
+        label: 'Item Two.One',
+        value: '2.1',
+        hidden: true
+      },
+      {
+        label: 'Item Two.Two',
+        value: '2.2',
+        items: [
+          {
+            label: 'Item Two.Two.One',
+            value: '2.2.1',
+            expanded: true
+          },
+          {
+            label: 'Item Two.Two.Two',
+            value: '2.2.2'
+          }
+        ]
+      },
+      {
+        label: 'Item Two.Three',
+        value: '2.3'
+      },
+      {
+        label: 'Item Two.Four',
+        value: '2.4',
+        disabled: true
+      }
+    ]
+  },
+  {
+    label: 'Item Four',
+    value: '4'
+  }
+];

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -67,9 +67,9 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
   /**
    * Custom filter for static data
    * @type {TreeFilter<T> | null}
-   * @ignore set to protected for now and need to discuss before set to public API
    */
-  protected filter: TreeFilter<T> | null = createDefaultFilter<T>(this);
+  @property({ attribute: false })
+  public filter: TreeFilter<T> | null = createDefaultFilter<T>(this);
 
   /**
    * Renderer used for generating tree items

--- a/packages/elements/src/tree/helpers/filter.ts
+++ b/packages/elements/src/tree/helpers/filter.ts
@@ -34,8 +34,6 @@ export const createDefaultFilter = <T extends TreeDataItem = TreeDataItem>(el: T
 
     const regex = getRegularExpressionOfQuery();
     const result = regex.test(label);
-    // this regex uses global scope, so the index needs resetting
-    regex.lastIndex = 0;
     return result;
   };
 };

--- a/packages/elements/src/tree/index.ts
+++ b/packages/elements/src/tree/index.ts
@@ -1,9 +1,7 @@
-import type { TreeData, TreeDataItem } from './helpers/types';
-
 export * from './elements/tree.js';
 export * from './elements/tree-item.js';
 export { TreeRenderer, createTreeRenderer } from './helpers/renderer.js';
 export { TreeManager, TreeManagerMode, CheckedState } from './managers/tree-manager.js';
 
 export type { TreeNode } from './managers/tree-node.js';
-export type { TreeData, TreeDataItem };
+export type { TreeData, TreeDataItem, TreeFilter } from './helpers/types';


### PR DESCRIPTION
## Description

Combo Box, Tree & Tree Select support filtering items with their latest prop values. For Tree & Tree Select, EF docs show how to do so with Tree Node. Note that Combo Box is an exception. As Combo Box has no API editing prop values of items directly, custom filter for Combo Box is limited to initial prop values.

* Expose Tree's `filter` property for custom filter of query
* Add missing API reference for custom filter to Tree Select docs
* Improve Combo Box docs on custom filter

https://jira.refinitiv.com/browse/DME-2141

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
