### PR TITLE
fix(combo-box, list, tree): make implicit type of renderer explicit

### DIFF
--- a/packages/elements/src/combo-box/helpers/renderer.ts
+++ b/packages/elements/src/combo-box/helpers/renderer.ts
@@ -6,7 +6,9 @@ import type { ItemData } from '../../item';
 import { createListRenderer } from '../../list/index.js';
 import { Renderer } from '../../list/renderer.js';
 
-export const createComboBoxRenderer = <T extends DataItem = ItemData>(context?: unknown) => {
+export const createComboBoxRenderer = <T extends DataItem = ItemData>(
+  context?: unknown
+): ((item: T, composer: CollectionComposer<T>, element?: HTMLElement) => HTMLElement) => {
   const listRenderer = createListRenderer<T>(context);
 
   return (item: T, composer: CollectionComposer<T>, element?: HTMLElement): HTMLElement => {

--- a/packages/elements/src/list/helpers/renderer.ts
+++ b/packages/elements/src/list/helpers/renderer.ts
@@ -14,7 +14,9 @@ type Context = {
   multiple?: boolean;
 };
 
-export const createListRenderer = <T extends DataItem = ItemData>(context?: unknown) => {
+export const createListRenderer = <T extends DataItem = ItemData>(
+  context?: unknown
+): ((item: T, composer: CollectionComposer<T>, element?: HTMLElement) => HTMLElement) => {
   /**
    * Renderer key prefix, used in combination with item value to give unique id to each item
    */

--- a/packages/elements/src/tree/helpers/renderer.ts
+++ b/packages/elements/src/tree/helpers/renderer.ts
@@ -14,7 +14,9 @@ type RendererScope = {
   noRelation?: boolean;
 };
 
-export const createTreeRenderer = <T extends TreeDataItem = TreeDataItem>(context?: unknown) => {
+export const createTreeRenderer = <T extends TreeDataItem = TreeDataItem>(
+  context?: unknown
+): ((item: T, composer: CollectionComposer<T>, element?: HTMLElement) => HTMLElement) => {
   /**
    * Renderer key prefix, used in combination with item value to give unique id to each item
    */


### PR DESCRIPTION
## Description

Fix TypeScript failing to compile the project due to implicit type issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
