### PR TITLE
fix(datetime-picker): incorrect value with 2 digits year format

### DIFF
--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -419,6 +419,24 @@ describe('datetime-picker/Value', function () {
       expect(el.calendarEl.value).to.be.equal('2021-05-11');
       expect(value).to.be.equal('2021-05-11');
     });
+    it('value should be formatted correctly when the user changes the year input while it has a 2 digit of year format', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker format="yy-MM-dd" lang="en-gb" opened></ef-datetime-picker>'
+      );
+
+      el.value = '1450-12-12';
+
+      await elementUpdated(el);
+
+      setTimeout(() => typeText(el.inputEl, '51-12-12'));
+      const {
+        detail: { value }
+      } = await oneEvent(el, 'value-changed');
+      await elementUpdated(el);
+      expect(el.value).to.be.equal('1451-12-12');
+      expect(el.calendarEl.value).to.be.equal('1451-12-12');
+      expect(value).to.be.equal('1451-12-12');
+    });
     // TODO: add input validation test cases when the value update is originated from typing input
   });
 });

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -406,6 +406,19 @@ describe('datetime-picker/Value', function () {
       expect(el.timepickerFromEl.value).to.equal('11:00');
       expect(el.timepickerToEl.value).to.equal('15:00');
     });
+    it('should format value correctly when it have 2 digits year format', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker format="yy-MM-dd" lang="en-gb" opened></ef-datetime-picker>'
+      );
+      setTimeout(() => typeText(el.inputEl, '21-05-11'));
+      const {
+        detail: { value }
+      } = await oneEvent(el, 'value-changed');
+      await elementUpdated(el);
+      expect(el.value).to.be.equal('2021-05-11');
+      expect(el.calendarEl.value).to.be.equal('2021-05-11');
+      expect(value).to.be.equal('2021-05-11');
+    });
     // TODO: add input validation test cases when the value update is originated from typing input
   });
 });

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -1063,7 +1063,7 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
     let dateString = '';
 
     if (inputValue) {
-      const recoveryDate = (this.interimSegments[index] || new DateTimeSegment()).getTime();
+      const recoveryDate = new Date();
       const date = inputParse(inputValue, this.format, recoveryDate, {
         locale: getDateFNSLocale(getLocale(this))
       });

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -1063,7 +1063,7 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
     let dateString = '';
 
     if (inputValue) {
-      const recoveryDate = new Date();
+      const recoveryDate = (this.interimSegments[index] || new DateTimeSegment()).getTime();
       const date = inputParse(inputValue, this.format, recoveryDate, {
         locale: getDateFNSLocale(getLocale(this))
       });

--- a/packages/elements/src/datetime-picker/utils.ts
+++ b/packages/elements/src/datetime-picker/utils.ts
@@ -56,7 +56,7 @@ class DateTimeSegment {
    * @returns {number} time
    */
   public getTime(): number {
-    const date = this.dateSegment ? parse(this.dateSegment) : new Date(0);
+    const date = this.dateSegment ? parse(this.dateSegment) : new Date();
     const timeSegment = toTimeSegment(this.timeSegment);
     date.setHours(timeSegment.hours);
     date.setMinutes(timeSegment.minutes);


### PR DESCRIPTION
## Description
Instead of using Unix time 0 as a reference point for date parsing, use the current date instead.

Fixes # (issue)
https://jira.refinitiv.com/browse/DME-18030
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
