### PR TITLE
fix(slider): resolve missing thumb reference when from and to are initially equal

### DIFF
--- a/packages/elements/src/slider/__test__/slider.event.test.js
+++ b/packages/elements/src/slider/__test__/slider.event.test.js
@@ -1098,7 +1098,7 @@ describe('slider/Events', function () {
 
     await elementUpdated(el);
 
-    // Drag to to the lower side should not do anything
+    // Drag 'to' to the lower side should not do anything
     setTimeout(() =>
       slider.dispatchEvent(new MouseEvent('mousedown', { clientX: dragPosition0, clientY: 0 }))
     );
@@ -1119,7 +1119,7 @@ describe('slider/Events', function () {
     expect(el.from).to.equal('50');
     expect(el.to).to.equal('50');
 
-    // Drag to to the higher side should work
+    // Drag 'to' to the higher side should work
     setTimeout(() =>
       slider.dispatchEvent(new MouseEvent('mousedown', { clientX: dragPosition100, clientY: 0 }))
     );

--- a/packages/elements/src/slider/__test__/slider.event.test.js
+++ b/packages/elements/src/slider/__test__/slider.event.test.js
@@ -1085,6 +1085,63 @@ describe('slider/Events', function () {
     expect(el.to).to.equal(calculateValue(el, dragPosition100).toString());
   });
 
+  it('Drag thumb slider range "to" and "from" with show-input-field and same initial value of "to" and "from"', async function () {
+    el.range = true;
+    el.showInputField = true;
+    el.min = '0';
+    el.from = '50';
+    el.max = '100';
+    el.to = '50';
+
+    const dragPosition0 = tabSliderPosition(el, 0);
+    const dragPosition100 = tabSliderPosition(el, 100);
+
+    await elementUpdated(el);
+
+    // Drag to to the lower side should not do anything
+    setTimeout(() =>
+      slider.dispatchEvent(new MouseEvent('mousedown', { clientX: dragPosition0, clientY: 0 }))
+    );
+    await oneEvent(slider, 'mousedown');
+    expect(isDragging(el)).to.be.true;
+    expect(el.from).to.equal('50');
+    expect(el.to).to.equal('50');
+
+    setTimeout(() =>
+      window.dispatchEvent(new MouseEvent('mousemove', { clientX: dragPosition0, clientY: 0 }))
+    );
+    await oneEvent(window, 'mousemove');
+
+    setTimeout(() => window.dispatchEvent(new MouseEvent('mouseup', { clientX: dragPosition0, clientY: 0 })));
+    await oneEvent(window, 'mouseup');
+    expect(isDragging(el)).to.be.false;
+
+    expect(el.from).to.equal('50');
+    expect(el.to).to.equal('50');
+
+    // Drag to to the higher side should work
+    setTimeout(() =>
+      slider.dispatchEvent(new MouseEvent('mousedown', { clientX: dragPosition100, clientY: 0 }))
+    );
+    await oneEvent(slider, 'mousedown');
+    expect(isDragging(el)).to.be.true;
+    expect(el.from).to.equal('50');
+    expect(el.to).to.equal(calculateValue(el, dragPosition100).toString());
+
+    setTimeout(() =>
+      window.dispatchEvent(new MouseEvent('mousemove', { clientX: dragPosition100, clientY: 0 }))
+    );
+    await oneEvent(window, 'mousemove');
+
+    setTimeout(() =>
+      window.dispatchEvent(new MouseEvent('mouseup', { clientX: dragPosition100, clientY: 0 }))
+    );
+    await oneEvent(window, 'mouseup');
+    expect(isDragging(el)).to.be.false;
+    expect(el.from).to.equal('50');
+    expect(el.to).to.equal(calculateValue(el, dragPosition100).toString());
+  });
+
   it('Event value-changed should not fired when property programmatically set', async function () {
     const slider = await fixture('<ef-slider></ef-slider>');
     let eventCount = 0;

--- a/packages/elements/src/slider/elements/slider.ts
+++ b/packages/elements/src/slider/elements/slider.ts
@@ -1016,11 +1016,14 @@ export class Slider extends FormFieldElement {
       if (distanceFrom < distanceTo) {
         this.changedThumb = this.fromThumbRef.value;
         this.fromPreviousInput = this.from;
-      } else if (distanceFrom > distanceTo) {
+        // When from === to & changedThumb is already set,
+        // use its latest value and z-index will determine thumb on top.
+        // If this's the first drag, changedThumb would be unset.
+        // In that case, set changedThumb to "to" as it appears after "from" in the DOM.
+      } else if (distanceFrom > distanceTo || !this.changedThumb) {
         this.changedThumb = this.toThumbRef.value;
         this.toPreviousInput = this.to;
       }
-      // When from === to, use latest value of changedThumb and z-index will determine thumb on top
     } else {
       this.changedThumb = this.valueThumbRef.value;
       this.valuePreviousInput = this.value;


### PR DESCRIPTION
## Description

Fix `Uncaught TypeError: Cannot read properties of undefined (reading 'reportValidity')` by adding missing thumb reference when `from` and `to` are initially equal. Note that, `show-input-field` must also be `true`.

Fixes # https://jira.refinitiv.com/browse/DME-19922

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
