### PR TITLE
chore: use double quote with chokidar for cross-platform compatibility

### DIFF
--- a/packages/elemental-theme/package.json
+++ b/packages/elemental-theme/package.json
@@ -20,7 +20,7 @@
     "build:dark": "theme-compiler dark --variant=dark --registration=event",
     "build": "npm run build:light && npm run build:dark",
     "build:prod": "npm run build",
-    "watch": "chokidar '**/*.less' --command \"npm run build\" --debounce=5000",
+    "watch": "chokidar \"**/*.less\" --command \"npm run build\" --debounce=5000",
     "prepack": "npm run version",
     "version": "node ../../scripts/version/index.js"
   },

--- a/packages/halo-theme/package.json
+++ b/packages/halo-theme/package.json
@@ -20,7 +20,7 @@
     "build:light": "theme-compiler light --variant=light --registration=event",
     "build": "npm run build:dark && npm run build:light && node ../../scripts/release/theme-extractor.js ../elements",
     "build:prod": "npm run build:dark && npm run build:light",
-    "watch": "chokidar '**/*.less' --command \"npm run build\" --debounce=5000",
+    "watch": "chokidar \"**/*.less\" \"../../packages/elemental-theme/**/*.less\" --command \"npm run build\" --debounce=5000",
     "prepack": "npm run version",
     "version": "node ../../scripts/version/index.js"
   },

--- a/packages/solar-theme/package.json
+++ b/packages/solar-theme/package.json
@@ -20,7 +20,7 @@
     "build:pearl": "theme-compiler pearl --variant=pearl --registration=event",
     "build": "npm run build:charcoal && npm run build:pearl && node ../../scripts/release/theme-extractor.js ../elements",
     "build:prod": "npm run build:charcoal && npm run build:pearl",
-    "watch": "chokidar '**/*.less' --command \"npm run build\" --debounce=5000",
+    "watch": "chokidar \"**/*.less\" \"../../packages/elemental-theme/**/*.less\" --command \"npm run build\" --debounce=5000",
     "prepack": "npm run version",
     "version": "node ../../scripts/version/index.js"
   },


### PR DESCRIPTION
## Description

Fix watch issue on Windows: double quote should be used instead of single quote for [cross-platform compatibility.](https://github.com/open-cli-tools/chokidar-cli?tab=readme-ov-file#usage) 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
