### PR TITLE
feat(form-field): introduce clears api to Form field elements

### DIFF
--- a/documents/src/pages/elements/text-field.md
+++ b/documents/src/pages/elements/text-field.md
@@ -82,7 +82,7 @@ You can also listen for the `value-changed` event. This event triggers when user
 ```html
 <label for="full-name">full Name</label>
 <ef-text-field
-  id="full-name" 
+  id="full-name"
   placeholder="Your name as shown on your passport">
 </ef-text-field>
 ```
@@ -279,20 +279,11 @@ The icon can become actionable by adding the `icon-has-action` attribute to the 
 
 ```javascript
 ::import-elements::
-const feedback = document.getElementById("feedback");
-feedback.addEventListener("icon-click", (e) => {
-  feedback.value = "";
-  feedback.icon = "";
-  feedback.iconHasAction = false;
-});
-feedback.addEventListener("value-changed", (e) => {
-  if (feedback.value) {
-    feedback.icon = "cross";
-    feedback.iconHasAction = true;
-  } else {
-    feedback.icon = "";
-    feedback.iconHasAction = false;
-  }
+const urlInput = document.getElementById("urlInput");
+const label = document.getElementById("actionResult");
+urlInput.addEventListener("icon-click", (e) => {
+  navigator.clipboard.writeText(urlInput.value)
+  label.textContent = 'URL copied'
 });
 ```
 
@@ -303,35 +294,37 @@ ef-text-field {
 ```
 
 ```html
-<label for="feedback">Feedback</label>
+<label for="urlInput">URL</label>
 <ef-text-field
-  id="feedback"
-  value="nice job!"
-  placeholder="Type your feedback and click the icon"
-  icon="cross"
+  id="urlInput"
+  value="https://ui.refinitiv.com/"
+  placeholder="Type URL to be copied"
+  icon="copy"
   icon-has-action>
 </ef-text-field>
+<p id="actionResult"></p>
 ```
 
 ::
 
 ```html
-<label for="feedback">Feedback</label>
+<label for="urlInput">URL</label>
 <ef-text-field
-  id="feedback"
-  value="nice job!"
-  placeholder="Type your feedback and click the icon"
-  icon="cross"
+  id="urlInput"
+  value="https://ui.refinitiv.com/"
+  placeholder="Type URL to be copied"
+  icon="copy"
   icon-has-action>
 </ef-text-field>
+<p id="actionResult"></p>
 ```
 
 ```javascript
-const feedback = document.getElementById("feedback");
-feedback.addEventListener("icon-click", (e) => {
-  feedback.value = "";
-  feedback.icon = "";
-  feedback.iconHasAction = false;
+const urlInput = document.getElementById("urlInput");
+const label = document.getElementById("actionResult");
+urlInput.addEventListener("icon-click", (e) => {
+  navigator.clipboard.writeText(urlInput.value)
+  label.textContent = 'URL copied'
 });
 ```
 
@@ -356,7 +349,7 @@ If there is an element displaying error of `ef-text-field`, `aria-describedby` s
 ```
 
 ```html
-<ef-text-field 
+<ef-text-field
   aria-label="Full name"
   placeholder="Your name as shown on your passport">
 </ef-text-field>
@@ -364,7 +357,7 @@ If there is an element displaying error of `ef-text-field`, `aria-describedby` s
 
 ```html
 <label id="name">Full Name</label>
-<ef-text-field 
+<ef-text-field
   aria-labelledby="name"
   placeholder="Your name as shown on your passport">
 </ef-text-field>
@@ -378,7 +371,7 @@ If there is an element displaying error of `ef-text-field`, `aria-describedby` s
   pattern="[a-zA-Z]{3,}"
   placeholder="Your name as shown on your passport">
 </ef-text-field>
-<p id="error-text">Must be letters at least 3 characters</p> 
+<p id="error-text">Must be letters at least 3 characters</p>
 ```
 
 ::a11y-end::

--- a/packages/core/__test__/elements/FormFieldElement.test.js
+++ b/packages/core/__test__/elements/FormFieldElement.test.js
@@ -41,6 +41,12 @@ describe('elements/FormFieldElement/DefaultsTest', function () {
     const formFieldEl = await fixture('<form-field-element-test></form-field-element-test>');
     expect(formFieldEl).shadowDom.to.equalSnapshot();
   });
+  it('value should include clears', async function () {
+    const formFieldEl = await fixture(
+      '<form-field-element-test value="test" clears></form-field-element-test>'
+    );
+    expect(formFieldEl.hasClear).to.equal(true);
+  });
 });
 
 describe('elements/FormFieldElement/RequiredTest', function () {
@@ -85,6 +91,10 @@ describe('elements/FormFieldElement/ReadonlyTest', function () {
     await elementUpdated(formFieldEl);
     expect(formFieldEl).shadowDom.to.equalSnapshot();
   });
+  it("readonly shouldn't include clears", async function () {
+    const formFieldEl = await fixture('<form-field-element-test readonly clears></form-field-element-test>');
+    expect(formFieldEl.hasClear).to.equal(false);
+  });
 });
 
 describe('elements/FormFieldElement/DisabledTest', function () {
@@ -94,6 +104,10 @@ describe('elements/FormFieldElement/DisabledTest', function () {
     formFieldEl.disabled = false;
     await elementUpdated(formFieldEl);
     expect(formFieldEl).shadowDom.to.equalSnapshot();
+  });
+  it("disabled shouldn't include clears", async function () {
+    const formFieldEl = await fixture('<form-field-element-test disabled clears></form-field-element-test>');
+    expect(formFieldEl.hasClear).to.equal(false);
   });
 });
 

--- a/packages/core/__test__/elements/FormFieldElement.test.js
+++ b/packages/core/__test__/elements/FormFieldElement.test.js
@@ -41,7 +41,7 @@ describe('elements/FormFieldElement/DefaultsTest', function () {
     const formFieldEl = await fixture('<form-field-element-test></form-field-element-test>');
     expect(formFieldEl).shadowDom.to.equalSnapshot();
   });
-  it('With value should include clears button', async function () {
+  it('should include clears button when value is filled', async function () {
     const formFieldEl = await fixture(
       '<form-field-element-test value="test" clears></form-field-element-test>'
     );
@@ -91,8 +91,10 @@ describe('elements/FormFieldElement/ReadonlyTest', function () {
     await elementUpdated(formFieldEl);
     expect(formFieldEl).shadowDom.to.equalSnapshot();
   });
-  it("With readonly shouldn't include clears button", async function () {
-    const formFieldEl = await fixture('<form-field-element-test readonly clears></form-field-element-test>');
+  it('should not include clears button', async function () {
+    const formFieldEl = await fixture(
+      '<form-field-element-test readonly clears value="test"></form-field-element-test>'
+    );
     expect(formFieldEl.hasClear).to.equal(false);
   });
 });
@@ -105,8 +107,10 @@ describe('elements/FormFieldElement/DisabledTest', function () {
     await elementUpdated(formFieldEl);
     expect(formFieldEl).shadowDom.to.equalSnapshot();
   });
-  it("With disabled shouldn't display clears button", async function () {
-    const formFieldEl = await fixture('<form-field-element-test disabled clears></form-field-element-test>');
+  it('should not include clears button', async function () {
+    const formFieldEl = await fixture(
+      '<form-field-element-test disabled clears value="test"></form-field-element-test>'
+    );
     expect(formFieldEl.hasClear).to.equal(false);
   });
 });

--- a/packages/core/__test__/elements/FormFieldElement.test.js
+++ b/packages/core/__test__/elements/FormFieldElement.test.js
@@ -41,7 +41,7 @@ describe('elements/FormFieldElement/DefaultsTest', function () {
     const formFieldEl = await fixture('<form-field-element-test></form-field-element-test>');
     expect(formFieldEl).shadowDom.to.equalSnapshot();
   });
-  it('value should include clears', async function () {
+  it('With value should include clears button', async function () {
     const formFieldEl = await fixture(
       '<form-field-element-test value="test" clears></form-field-element-test>'
     );
@@ -91,7 +91,7 @@ describe('elements/FormFieldElement/ReadonlyTest', function () {
     await elementUpdated(formFieldEl);
     expect(formFieldEl).shadowDom.to.equalSnapshot();
   });
-  it("readonly shouldn't include clears", async function () {
+  it("With readonly shouldn't include clears button", async function () {
     const formFieldEl = await fixture('<form-field-element-test readonly clears></form-field-element-test>');
     expect(formFieldEl.hasClear).to.equal(false);
   });
@@ -105,7 +105,7 @@ describe('elements/FormFieldElement/DisabledTest', function () {
     await elementUpdated(formFieldEl);
     expect(formFieldEl).shadowDom.to.equalSnapshot();
   });
-  it("disabled shouldn't include clears", async function () {
+  it("With disabled shouldn't display clears button", async function () {
     const formFieldEl = await fixture('<form-field-element-test disabled clears></form-field-element-test>');
     expect(formFieldEl.hasClear).to.equal(false);
   });

--- a/packages/core/src/elements/FormFieldElement.ts
+++ b/packages/core/src/elements/FormFieldElement.ts
@@ -392,6 +392,7 @@ export abstract class FormFieldElement extends ControlElement {
     if (this.hasClear) {
       return html`
         <div
+          aria-hidden="true"
           ${ref(this.clearsButtonRef)}
           id="clears-button"
           part="button button-clear"

--- a/packages/elemental-theme/src/custom-elements/ef-datetime-picker.less
+++ b/packages/elemental-theme/src/custom-elements/ef-datetime-picker.less
@@ -68,4 +68,12 @@
     margin: auto 0;
     height: 1px;
   }
+
+  [part~='button'] {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    flex: none;
+  }
 }

--- a/packages/elemental-theme/src/custom-elements/ef-text-field.less
+++ b/packages/elemental-theme/src/custom-elements/ef-text-field.less
@@ -32,4 +32,12 @@
   &[disabled] [part='input'] {
     user-select: none;
   }
+
+  [part~='button'] {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    flex: none;
+  }
 }

--- a/packages/elements/src/combo-box/__demo__/clears.html
+++ b/packages/elements/src/combo-box/__demo__/clears.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="IE=edge" http-equiv="X-UA-Compatible" />
+    <title>Combo Box</title>
+    <link href="/node_modules/@refinitiv-ui/demo-block/demo.css" rel="stylesheet" />
+    <script src="countries.js"></script>
+  </head>
+  <body>
+    <style>
+      label {
+        display: block;
+      }
+    </style>
+    <script type="module">
+      import '@refinitiv-ui/elements/combo-box';
+      import '@refinitiv-ui/elements/datetime-picker';
+      import '@refinitiv-ui/elements/email-field';
+      import '@refinitiv-ui/elements/number-field';
+      import '@refinitiv-ui/elements/password-field';
+      import '@refinitiv-ui/elements/search-field';
+      import '@refinitiv-ui/elements/text-field';
+      import '@refinitiv-ui/elements/tree-select';
+
+      import '@refinitiv-ui/demo-block';
+    </script>
+    <script type="module">
+      const makeData = (config = {}) => {
+        if (config.selectionTooltip) {
+          return Array(1001)
+            .fill(0)
+            .map((_, i) => ({
+              type: 'text',
+              label: `Item number ${i + 1}`,
+              value: (i + 1).toString(),
+              selected: true
+            }));
+        } else {
+          return window.countries.reduce((countries, _, i) => {
+            const lastItem = countries[countries.length - 1];
+            if (!lastItem || lastItem.label[0] !== _.label[0]) {
+              countries.push({
+                type: 'header',
+                label: `${_.label[0]}`
+              });
+            }
+            countries.push({
+              type: 'text',
+              label: _.label,
+              value: _.value,
+              selected:
+                config.selected || config.selected === undefined
+                  ? i === 109 || (config.multiple && i === 1)
+                  : false,
+              disabled: config.disabled === undefined ? i % 10 === 7 : false,
+              hidden: config.hidden === undefined ? i % 50 === 49 : false
+            });
+            return countries;
+          }, []);
+        }
+      };
+      window.makeData = makeData;
+
+      document.querySelector('ef-combo-box').data = makeData({ multiple: true });
+      document.querySelector('ef-tree-select').data = makeData({ multiple: true });
+
+      const pElements = document.querySelectorAll('p');
+      for (const pElement of pElements) {
+        pElement.querySelector('[clears]').addEventListener('value-changed', (event) => {
+          const span = pElement.querySelector('span');
+          if (event.detail.value === '') {
+            span.textContent = 'cleared';
+          } else {
+            span.textContent = '';
+          }
+        });
+      }
+    </script>
+    <demo-block header="Clearable + Placeholder" layout="normal" tags="clears, placeholder">
+      <p>
+        <label for="textField">Text field: <span></span></label>
+        <ef-text-field id="textField" value="Welcome to my world" clears></ef-text-field>
+      </p>
+      <p>
+        <label for="textField">Text field: <span></span></label>
+        <ef-text-field id="textField" icon="home" value="Welcome to my world" clears></ef-text-field>
+      </p>
+      <p>
+        <label for="numberField">Number field: <span></span></label>
+        <ef-number-field id="numberField" value="123456789" clears></ef-number-field>
+      </p>
+      <p>
+        <label for="passwordField">Password field: <span></span></label>
+        <ef-password-field id="passwordField" value="welcome_to_my@world" clears></ef-password-field>
+      </p>
+      <p>
+        <label for="emailField">Email field: <span></span></label>
+        <ef-email-field id="emailField" value="welcome_to_my@world" clears></ef-email-field>
+      </p>
+      <p>
+        <label for="searchField">Search field: <span></span></label>
+        <ef-search-field id="searchField" value="Welcome to my world" clears></ef-search-field>
+      </p>
+      <p>
+        <label for="datetimePicker">Datetime picker: <span></span></label>
+        <ef-datetime-picker id="datetimePicker" clears value="2024-05-22"></ef-datetime-picker>
+      </p>
+      <p>
+        <label for="datetimePicker">Datetime picker Range mode: <span></span></label>
+        <ef-datetime-picker
+          id="datetimePicker"
+          range
+          clears
+          values="2024-06-18,2024-06-19"
+        ></ef-datetime-picker>
+      </p>
+      <p>
+        <label for="comboBox">Combo box: <span></span></label>
+        <ef-combo-box id="comboBox" clears placeholder="Select..." values="[af,dz]" multiple></ef-combo-box>
+      </p>
+      <p>
+        <label for="treeSelect">Tree select: <span></span></label>
+        <ef-tree-select id="treeSelect" clears placeholder="Select..." values="[af,dz]"></ef-tree-select>
+      </p>
+    </demo-block>
+  </body>
+</html>

--- a/packages/elements/src/combo-box/__snapshots__/Filter.md
+++ b/packages/elements/src/combo-box/__snapshots__/Filter.md
@@ -67,6 +67,7 @@
     </ef-list-item>
   </ef-list>
 </ef-overlay>
+
 ```
 
 ```html
@@ -126,6 +127,7 @@
     </ef-list-item>
   </ef-list>
 </ef-overlay>
+
 ```
 
 ####   `Should be able to use custom filter function`

--- a/packages/elements/src/combo-box/__snapshots__/Template.md
+++ b/packages/elements/src/combo-box/__snapshots__/Template.md
@@ -27,6 +27,43 @@
     </ef-icon>
   </div>
 </div>
+```
+
+####   `DOM structure with clears is correct`
+
+```html
+<div part="input-wrapper">
+  <input
+    aria-autocomplete="list"
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-owns="internal-list"
+    autocomplete="off"
+    part="input"
+    role="combobox"
+    type="text"
+  >
+  <div
+    id="clears-button"
+    part="button button-clear"
+  >
+    <ef-icon
+      icon="cross"
+      part="icon icon-clear"
+    >
+    </ef-icon>
+  </div>
+  <div
+    id="toggle-button"
+    part="button button-toggle"
+  >
+    <ef-icon
+      icon="down"
+      part="icon icon-toggle"
+    >
+    </ef-icon>
+  </div>
+</div>
 
 ```
 
@@ -56,7 +93,6 @@
     </ef-icon>
   </div>
 </div>
-
 ```
 
 ```html
@@ -83,7 +119,6 @@
     </ef-icon>
   </div>
 </div>
-
 ```
 
 ```html
@@ -109,7 +144,6 @@
     </ef-icon>
   </div>
 </div>
-
 ```
 
 ####   `Lazy Render: data`
@@ -183,7 +217,6 @@
     </ef-list-item>
   </ef-list>
 </ef-overlay>
-
 ```
 
 ```html
@@ -250,7 +283,6 @@
     </ef-list-item>
   </ef-list>
 </ef-overlay>
-
 ```
 
 ####   `Data is reflected to render`
@@ -324,7 +356,6 @@
     </ef-list-item>
   </ef-list>
 </ef-overlay>
-
 ```
 
 ```html
@@ -396,7 +427,6 @@
     </ef-list-item>
   </ef-list>
 </ef-overlay>
-
 ```
 
 ```html
@@ -443,6 +473,5 @@
     No results found.
   </ef-list-item>
 </ef-overlay>
-
 ```
 

--- a/packages/elements/src/combo-box/__snapshots__/Template.md
+++ b/packages/elements/src/combo-box/__snapshots__/Template.md
@@ -27,6 +27,7 @@
     </ef-icon>
   </div>
 </div>
+
 ```
 
 ####   `DOM structure with clears is correct`
@@ -44,6 +45,7 @@
     type="text"
   >
   <div
+    aria-hidden="true"
     id="clears-button"
     part="button button-clear"
   >
@@ -93,6 +95,7 @@
     </ef-icon>
   </div>
 </div>
+
 ```
 
 ```html
@@ -119,6 +122,7 @@
     </ef-icon>
   </div>
 </div>
+
 ```
 
 ```html
@@ -144,6 +148,7 @@
     </ef-icon>
   </div>
 </div>
+
 ```
 
 ####   `Lazy Render: data`
@@ -217,6 +222,7 @@
     </ef-list-item>
   </ef-list>
 </ef-overlay>
+
 ```
 
 ```html
@@ -283,6 +289,7 @@
     </ef-list-item>
   </ef-list>
 </ef-overlay>
+
 ```
 
 ####   `Data is reflected to render`
@@ -356,6 +363,7 @@
     </ef-list-item>
   </ef-list>
 </ef-overlay>
+
 ```
 
 ```html
@@ -427,6 +435,7 @@
     </ef-list-item>
   </ef-list>
 </ef-overlay>
+
 ```
 
 ```html
@@ -473,5 +482,6 @@
     No results found.
   </ef-list-item>
 </ef-overlay>
+
 ```
 

--- a/packages/elements/src/combo-box/__test__/combo-box.interaction.test.js
+++ b/packages/elements/src/combo-box/__test__/combo-box.interaction.test.js
@@ -52,7 +52,7 @@ describe('combo-box/Interaction', function () {
       const el = await fixture('<ef-combo-box clears value="AF" lang="en"></ef-combo-box>');
       el.data = getData();
       await elementUpdated(el);
-      await dispatchCustomEvent(el.clearsButtonEl, 'tapstart');
+      await dispatchCustomEvent(el.clearsButton, 'tap');
       await onFocusEl(el);
       await elementUpdated(el);
       expect(el.value).to.equal('', 'Tapping on clears did not clear the value');

--- a/packages/elements/src/combo-box/__test__/combo-box.template.test.js
+++ b/packages/elements/src/combo-box/__test__/combo-box.template.test.js
@@ -11,6 +11,30 @@ describe('combo-box/Template', function () {
       const el = await fixture('<ef-combo-box lang="en"></ef-combo-box>');
       expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
     });
+    it('DOM structure with clears is correct', async function () {
+      const el = await fixture('<ef-combo-box clears></ef-combo-box>');
+      el.data = getData([1]);
+      await openedUpdated(el);
+      await expect(el).shadowDom.to.equalSnapshot();
+    });
+    it("Shouldn't have clears button when set readonly", async function () {
+      const el = await fixture('<ef-combo-box readonly clears value="AF" lang="en"></ef-combo-box>');
+      el.data = getData();
+      await elementUpdated(el);
+      expect(el.clearsButton).to.equal(undefined, "Clear button shouldn't display");
+    });
+    it("Shouldn't have clears button when set disabled", async function () {
+      const el = await fixture('<ef-combo-box disabled clears value="AF" lang="en"></ef-combo-box>');
+      el.data = getData();
+      await elementUpdated(el);
+      expect(el.clearsButton).to.equal(undefined, "Clear button shouldn't display");
+    });
+    it("Shouldn't have clears button when no value", async function () {
+      const el = await fixture('<ef-combo-box clears lang="en"></ef-combo-box>');
+      el.data = getData();
+      await elementUpdated(el);
+      expect(el.clearsButton).to.equal(undefined, "Clear button shouldn't display");
+    });
 
     it('Placeholder is rendered', async function () {
       const el = await fixture('<ef-combo-box placeholder="Placeholder" lang="en"></ef-combo-box>');

--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -69,6 +69,9 @@ const freeTextMultipleWarning = new WarningNotice('"free-text" mode is not compa
  * @attr {string} placeholder - Set placeholder text
  * @prop {string} [placeholder=""] - Set placeholder text
  *
+ * @attr {boolean} clears - Show clears button
+ * @prop {boolean} [clears=false] - Show clears button
+ *
  * @fires value-changed - Fired when the user commits a value change. The event is not triggered if `value` property is changed programmatically.
  * @fires query-changed - Fired when the user changes value in the input to change a query word. If `query-debounce-rate` is set, this event will be triggered after debounce completion. The event is not triggered if `query` property is changed programmatically.
  * @fires opened-changed - Fired when the user opens or closes control's popup. The event is not triggered if `opened` property is changed programmatically.
@@ -148,12 +151,6 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
    */
   @property({ type: Boolean, reflect: true })
   public opened = false;
-
-  /**
-   * Show clears button
-   */
-  @property({ type: Boolean })
-  public clears = false;
 
   private _freeText = false;
   /**
@@ -403,12 +400,6 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
    */
   @query('#toggle-button')
   protected toggleButtonEl!: HTMLElement;
-
-  /**
-   * Internal reference to clears button
-   */
-  @query('#clears-button')
-  protected clearsButtonEl?: HTMLElement;
 
   /**
    * Use to call request update when CC changes its value
@@ -1013,8 +1004,8 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
 
     const path = event.composedPath();
 
-    if (this.clearsButtonEl && path.includes(this.clearsButtonEl)) {
-      this.onClearsButtonTap();
+    if (this.clearsButton && path.includes(this.clearsButton)) {
+      // clear button uses tap event from FormField instead so no-op here
       return;
     }
 
@@ -1039,15 +1030,15 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
   }
 
   /**
-   * Run when tap event happens on clears button
+   * Run when tap event happens on clears button and fire value-changed event.
+   * @param event tap event
    * @returns {void}
    */
-  protected onClearsButtonTap(): void {
-    this.freeTextValue = '';
-    this.inputText = '';
+  protected override onClearsButtonTap(event: TapEvent): void {
     this.setQuery('');
-    this.setValueAndNotify('');
-    this.openOnFocus();
+    super.onClearsButtonTap(event);
+    this.inputText = '';
+    this.inputElement?.focus();
   }
 
   /**
@@ -1201,22 +1192,6 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
   }
 
   /**
-   * Template for clear button
-   * Rendered when `clears` attribute is set
-   * @returns Popup template or undefined
-   */
-  protected get clearButtonTemplate(): TemplateResult | undefined {
-    const hasText = this.label || this.query || this.freeTextValue || this.inputText;
-    if (this.clears && hasText) {
-      return html`
-        <div id="clears-button" part="button button-clear">
-          <ef-icon part="icon icon-clear" icon="cross"></ef-icon>
-        </div>
-      `;
-    }
-  }
-
-  /**
    * Template for selection badge in multiple mode
    * @returns Selection badge template or undefined
    */
@@ -1310,6 +1285,15 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
       'aria-owns': 'internal-list',
       'aria-activedescendant': this.highlightedItemValue
     };
+  }
+
+  /**
+   * Returns a condition to show clear button
+   * @returns True if clear button will show
+   */
+  protected override get hasClear(): boolean {
+    const editable = !(this.readonly || this.disabled);
+    return !!(this.clears && editable && (this.value || this.inputText || this.freeTextValue));
   }
 
   /**

--- a/packages/elements/src/datetime-picker/__demo__/index.html
+++ b/packages/elements/src/datetime-picker/__demo__/index.html
@@ -113,7 +113,7 @@
           <p>
             <ef-checkbox id="timepicker" title="Turn on timepicker">Timepicker</ef-checkbox>
             <ef-checkbox id="am-pm" title="Set timepicker to AM-PM mode">AM-PM mode</ef-checkbox>
-            <ef-checkbox id="show-seconds" title="Turn on timepicker">Show Seconds</ef-checkbox>
+            <ef-checkbox id="show-seconds" title="Turn on show-seconds">Show Seconds</ef-checkbox>
           </p>
           <p>
             <ef-select id="lang" placeholder="Set locale">
@@ -151,6 +151,7 @@
             <ef-checkbox id="error">Error</ef-checkbox>
           </p>
           <p>
+            <ef-checkbox id="clears">Clears</ef-checkbox>
             <ef-checkbox id="inputTriggerDisabled">Input Trigger Disabled</ef-checkbox>
             <ef-checkbox id="inputDisabled">Input Disabled</ef-checkbox>
             <ef-checkbox id="popupDisabled">Popup Disabled</ef-checkbox>
@@ -353,6 +354,9 @@
           .addEventListener('checked-changed', ({ detail: { value } }) => {
             dateTimePicker.inputTriggerDisabled = value || undefined;
           });
+        document.getElementById('clears').addEventListener('checked-changed', ({ detail: { value } }) => {
+          dateTimePicker.clears = value || undefined;
+        });
         document.getElementById('disabled').addEventListener('checked-changed', ({ detail: { value } }) => {
           dateTimePicker.disabled = value || undefined;
         });

--- a/packages/elements/src/datetime-picker/__snapshots__/DOMStructure.md
+++ b/packages/elements/src/datetime-picker/__snapshots__/DOMStructure.md
@@ -19,7 +19,6 @@
   part="icon"
 >
 </ef-icon>
-
 ```
 
 ####   `DOM structure is correct when opened`
@@ -81,7 +80,6 @@
     </slot>
   </div>
 </ef-overlay>
-
 ```
 
 ####   `DOM structure is correct when range`
@@ -155,7 +153,6 @@
     </slot>
   </div>
 </ef-overlay>
-
 ```
 
 ####   `DOM structure is correct when duplex`
@@ -225,7 +222,6 @@
     </slot>
   </div>
 </ef-overlay>
-
 ```
 
 ####   `DOM structure is correct when timepicker`
@@ -297,7 +293,6 @@
     </slot>
   </div>
 </ef-overlay>
-
 ```
 
 ####   `DOM structure is correct when timepicker and with-seconds`
@@ -369,7 +364,6 @@
     </slot>
   </div>
 </ef-overlay>
-
 ```
 
 ####   `DOM structure is correct when range timepicker`
@@ -463,7 +457,6 @@
     </slot>
   </div>
 </ef-overlay>
-
 ```
 
 ####   `DOM structure is correct when add custom cell slot of calendar without prefix`
@@ -530,7 +523,6 @@
     </slot>
   </div>
 </ef-overlay>
-
 ```
 
 ####   `DOM structure is correct when add custom cell slot of calendar with prefix`
@@ -610,7 +602,6 @@
     </slot>
   </div>
 </ef-overlay>
-
 ```
 
 ####   `DOM structure is correct when add custom cell slot of calendar while overlay is opened`
@@ -690,7 +681,6 @@
     </slot>
   </div>
 </ef-overlay>
-
 ```
 
 ####   `DOM structure should not contain added custom cell slot when overlay is closed`
@@ -756,6 +746,35 @@
     </slot>
   </div>
 </ef-overlay>
+```
+
+####   `DOM structure with clears is correct`
+
+```html
+<div part="input-wrapper">
+  <ef-text-field
+    id="input"
+    part="input"
+    tabindex="0"
+    transparent=""
+  >
+  </ef-text-field>
+  <div
+    id="clears-button"
+    part="button button-clear"
+  >
+    <ef-icon
+      icon="cross"
+      part="icon icon-clear"
+    >
+    </ef-icon>
+  </div>
+</div>
+<ef-icon
+  icon="calendar"
+  part="icon"
+>
+</ef-icon>
 
 ```
 

--- a/packages/elements/src/datetime-picker/__snapshots__/DOMStructure.md
+++ b/packages/elements/src/datetime-picker/__snapshots__/DOMStructure.md
@@ -19,6 +19,7 @@
   part="icon"
 >
 </ef-icon>
+
 ```
 
 ####   `DOM structure is correct when opened`
@@ -80,6 +81,7 @@
     </slot>
   </div>
 </ef-overlay>
+
 ```
 
 ####   `DOM structure is correct when range`
@@ -153,6 +155,7 @@
     </slot>
   </div>
 </ef-overlay>
+
 ```
 
 ####   `DOM structure is correct when duplex`
@@ -222,6 +225,7 @@
     </slot>
   </div>
 </ef-overlay>
+
 ```
 
 ####   `DOM structure is correct when timepicker`
@@ -293,6 +297,7 @@
     </slot>
   </div>
 </ef-overlay>
+
 ```
 
 ####   `DOM structure is correct when timepicker and with-seconds`
@@ -364,6 +369,7 @@
     </slot>
   </div>
 </ef-overlay>
+
 ```
 
 ####   `DOM structure is correct when range timepicker`
@@ -457,6 +463,7 @@
     </slot>
   </div>
 </ef-overlay>
+
 ```
 
 ####   `DOM structure is correct when add custom cell slot of calendar without prefix`
@@ -523,6 +530,7 @@
     </slot>
   </div>
 </ef-overlay>
+
 ```
 
 ####   `DOM structure is correct when add custom cell slot of calendar with prefix`
@@ -602,6 +610,7 @@
     </slot>
   </div>
 </ef-overlay>
+
 ```
 
 ####   `DOM structure is correct when add custom cell slot of calendar while overlay is opened`
@@ -681,6 +690,7 @@
     </slot>
   </div>
 </ef-overlay>
+
 ```
 
 ####   `DOM structure should not contain added custom cell slot when overlay is closed`
@@ -746,6 +756,7 @@
     </slot>
   </div>
 </ef-overlay>
+
 ```
 
 ####   `DOM structure with clears is correct`
@@ -760,6 +771,7 @@
   >
   </ef-text-field>
   <div
+    aria-hidden="true"
     id="clears-button"
     part="button button-clear"
   >

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.snapshot.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.snapshot.test.js
@@ -108,5 +108,27 @@ describe('datetime-picker/DOMStructure', function () {
       await nextFrame(2);
       await expect(el).shadowDom.to.equalSnapshot(snapshotIgnore);
     });
+    it('DOM structure with clears is correct', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker lang="en-gb" value="2024-05-31" clears></ef-datetime-picker>'
+      );
+      await expect(el).shadowDom.to.equalSnapshot();
+    });
+    it("Shouldn't have clears button when set readonly", async function () {
+      const el = await fixture(
+        '<ef-datetime-picker readonly clears value="2020-04-21" lang="en-gb"></ef-datetime-picker>'
+      );
+      expect(el.clearsButton).to.equal(undefined, "Clear button shouldn't display");
+    });
+    it("Shouldn't have clears button when set disabled", async function () {
+      const el = await fixture(
+        '<ef-datetime-picker disabled clears value="2020-04-21" lang="en-gb"></ef-datetime-picker>'
+      );
+      expect(el.clearsButton).to.equal(undefined, "Clear button shouldn't display");
+    });
+    it("Shouldn't have clears button when no value", async function () {
+      const el = await fixture('<ef-datetime-picker clears lang="en-gb"></ef-datetime-picker>');
+      expect(el.clearsButton).to.equal(undefined, "Clear button shouldn't display");
+    });
   });
 });

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.value.test.js
@@ -443,4 +443,13 @@ describe('datetime-picker/Value', function () {
     });
     // TODO: add input validation test cases when the value update is originated from typing input
   });
+
+  it('Tapping on clears button should clear the value', async function () {
+    const el = await fixture(
+      '<ef-datetime-picker clears value="2020-04-21" lang="en-gb"></ef-datetime-picker>'
+    );
+    el.clearsButton.dispatchEvent(new CustomEvent('tap'));
+    await elementUpdated(el);
+    expect(el.value).to.equal('', 'Tapping on clears did not clear the value');
+  });
 });

--- a/packages/elements/src/email-field/__demo__/index.html
+++ b/packages/elements/src/email-field/__demo__/index.html
@@ -178,5 +178,8 @@
         fieldWith.addEventListener('icon-click', loggerFunc);
       </script>
     </demo-block>
+    <demo-block header="Clearable" layout="normal" tags="clears">
+      <ef-email-field clears id="clears" value="test@email.com"></ef-email-field>
+    </demo-block>
   </body>
 </html>

--- a/packages/elements/src/email-field/index.ts
+++ b/packages/elements/src/email-field/index.ts
@@ -47,6 +47,9 @@ import { TextField } from '../text-field/index.js';
  *
  * @attr {string} value - Input's value
  * @prop {string} [value=""] - Input's value
+ *
+ * @attr {boolean} clears - Show clears button
+ * @prop {boolean} [clears=false] - Show clears button
  */
 @customElement('ef-email-field')
 export class EmailField extends TextField {

--- a/packages/elements/src/number-field/__demo__/index.html
+++ b/packages/elements/src/number-field/__demo__/index.html
@@ -237,5 +237,8 @@
         );
       </script>
     </demo-block>
+    <demo-block header="Clearable" layout="normal" tags="clears">
+      <ef-number-field clears id="clears" value="123"></ef-number-field>
+    </demo-block>
   </body>
 </html>

--- a/packages/elements/src/number-field/__snapshots__/NumberField.md
+++ b/packages/elements/src/number-field/__snapshots__/NumberField.md
@@ -26,7 +26,6 @@
   >
   </ef-icon>
 </div>
-
 ```
 
 ####   `DOM structure without spinner is correct`
@@ -41,6 +40,32 @@
   role="spinbutton"
   type="text"
 >
+```
+
+####   `DOM structure with clears is correct`
+
+```html
+<input
+  aria-valuenow="0"
+  aria-valuetext="0"
+  autocomplete="off"
+  inputmode="decimal"
+  part="input"
+  role="spinbutton"
+  type="text"
+>
+<div part="spinner">
+  <ef-icon
+    icon="up"
+    part="spinner-up"
+  >
+  </ef-icon>
+  <ef-icon
+    icon="down"
+    part="spinner-down"
+  >
+  </ef-icon>
+</div>
 
 ```
 

--- a/packages/elements/src/number-field/__snapshots__/NumberField.md
+++ b/packages/elements/src/number-field/__snapshots__/NumberField.md
@@ -26,6 +26,7 @@
   >
   </ef-icon>
 </div>
+
 ```
 
 ####   `DOM structure without spinner is correct`
@@ -40,20 +41,32 @@
   role="spinbutton"
   type="text"
 >
+
 ```
 
 ####   `DOM structure with clears is correct`
 
 ```html
 <input
-  aria-valuenow="0"
-  aria-valuetext="0"
+  aria-valuenow="1"
+  aria-valuetext="1"
   autocomplete="off"
   inputmode="decimal"
   part="input"
   role="spinbutton"
   type="text"
 >
+<div
+  aria-hidden="true"
+  id="clears-button"
+  part="button button-clear"
+>
+  <ef-icon
+    icon="cross"
+    part="icon icon-clear"
+  >
+  </ef-icon>
+</div>
 <div part="spinner">
   <ef-icon
     icon="up"

--- a/packages/elements/src/number-field/__test__/number-field.test.js
+++ b/packages/elements/src/number-field/__test__/number-field.test.js
@@ -23,6 +23,10 @@ describe('number-field/NumberField', function () {
       await elementUpdated();
       expect(el).shadowDom.to.equalSnapshot();
     });
+    it('DOM structure with clears is correct', async function () {
+      const el = await fixture('<ef-number-field value="abbr" clears></ef-number-field>');
+      await expect(el).shadowDom.to.equalSnapshot();
+    });
   });
 
   describe('Appearances', function () {
@@ -181,6 +185,24 @@ describe('number-field/NumberField', function () {
 
       expect(eventFired).to.equal(false);
       expect(el.value).to.equal('4');
+    });
+    it('Tapping on clears button should clear the value', async function () {
+      const el = await fixture('<ef-number-field clears value="1"></ef-number-field>');
+      el.clearsButton.dispatchEvent(new CustomEvent('tap'));
+      await elementUpdated(el);
+      expect(el.value).to.equal('', 'Tapping on clears did not clear the value');
+    });
+    it("Shouldn't have clears button when set readonly", async function () {
+      const el = await fixture('<ef-text-field readonly clears value="abbr"></ef-text-field>');
+      expect(el.clearsButton).to.equal(undefined, "Clear button shouldn't display");
+    });
+    it("Shouldn't have clears button when set disabled", async function () {
+      const el = await fixture('<ef-text-field disabled clears value="abbr"></ef-text-field>');
+      expect(el.clearsButton).to.equal(undefined, "Clear button shouldn't display");
+    });
+    it("Shouldn't have clears button when no value", async function () {
+      const el = await fixture('<ef-text-field disabled clears ></ef-text-field>');
+      expect(el.clearsButton).to.equal(undefined, "Clear button shouldn't display");
     });
   });
 

--- a/packages/elements/src/number-field/__test__/number-field.test.js
+++ b/packages/elements/src/number-field/__test__/number-field.test.js
@@ -24,7 +24,7 @@ describe('number-field/NumberField', function () {
       expect(el).shadowDom.to.equalSnapshot();
     });
     it('DOM structure with clears is correct', async function () {
-      const el = await fixture('<ef-number-field value="abbr" clears></ef-number-field>');
+      const el = await fixture('<ef-number-field value="1" clears></ef-number-field>');
       await expect(el).shadowDom.to.equalSnapshot();
     });
   });

--- a/packages/elements/src/number-field/index.ts
+++ b/packages/elements/src/number-field/index.ts
@@ -54,6 +54,9 @@ enum Direction {
  *
  * @attr {string} value - Input's value
  * @prop {string} [value=""] - Input's value
+ *
+ * @attr {boolean} clears - Show clears button
+ * @prop {boolean} [clears=false] - Show clears button
  */
 @customElement('ef-number-field')
 export class NumberField extends FormFieldElement {
@@ -954,7 +957,7 @@ export class NumberField extends FormFieldElement {
    * @return {TemplateResult}  Render template
    */
   protected override render(): TemplateResult {
-    return html` ${super.render()} ${this.noSpinner ? null : this.renderSpinner()}`;
+    return html` ${super.render()} ${this.clearButtonTemplate} ${this.noSpinner ? null : this.renderSpinner()}`;
   }
 }
 

--- a/packages/elements/src/password-field/index.ts
+++ b/packages/elements/src/password-field/index.ts
@@ -48,6 +48,9 @@ let isEyeOffPreloadRequested = false;
  *
  * @attr {string} value - Input's value
  * @prop {string} [value=""] - Input's value
+ *
+ * @attr {boolean} clears - Show clears button
+ * @prop {boolean} [clears=false] - Show clears button
  */
 @customElement('ef-password-field')
 export class PasswordField extends TextField {

--- a/packages/elements/src/search-field/__demo__/index.html
+++ b/packages/elements/src/search-field/__demo__/index.html
@@ -144,5 +144,8 @@
         fieldWith.addEventListener('icon-click', loggerFunc);
       </script>
     </demo-block>
+    <demo-block header="Clearable" layout="normal" tags="clears">
+      <ef-search-field clears id="clears" value="Select..."></ef-search-field>
+    </demo-block>
   </body>
 </html>

--- a/packages/elements/src/search-field/index.ts
+++ b/packages/elements/src/search-field/index.ts
@@ -46,6 +46,9 @@ import { TextField } from '../text-field/index.js';
  *
  * @attr {string} value - Input's value
  * @prop {string} [value=""] - Input's value
+ *
+ * @attr {boolean} clears - Show clears button
+ * @prop {boolean} [clears=false] - Show clears button
  */
 @customElement('ef-search-field')
 export class SearchField extends TextField {

--- a/packages/elements/src/text-field/__demo__/index.html
+++ b/packages/elements/src/text-field/__demo__/index.html
@@ -282,5 +282,8 @@
         </script>
       </p>
     </demo-block>
+    <demo-block header="Clearable" layout="normal" tags="clears">
+      <ef-text-field clears id="clears" value="Select..."></ef-text-field>
+    </demo-block>
   </body>
 </html>

--- a/packages/elements/src/text-field/__snapshots__/TextField.md
+++ b/packages/elements/src/text-field/__snapshots__/TextField.md
@@ -8,6 +8,7 @@
   part="input"
   type="text"
 >
+
 ```
 
 #### `DOM structure and properties are correct`
@@ -28,6 +29,7 @@
   part="icon"
 >
 </ef-icon>
+
 ```
 
 #### `DOM structure with clears is correct`
@@ -39,6 +41,7 @@
   type="text"
 >
 <div
+  aria-hidden="true"
   id="clears-button"
   part="button button-clear"
 >

--- a/packages/elements/src/text-field/__snapshots__/TextField.md
+++ b/packages/elements/src/text-field/__snapshots__/TextField.md
@@ -8,7 +8,6 @@
   part="input"
   type="text"
 >
-
 ```
 
 #### `DOM structure and properties are correct`
@@ -29,6 +28,26 @@
   part="icon"
 >
 </ef-icon>
+```
+
+#### `DOM structure with clears is correct`
+
+```html
+<input
+  autocomplete="off"
+  part="input"
+  type="text"
+>
+<div
+  id="clears-button"
+  part="button button-clear"
+>
+  <ef-icon
+    icon="cross"
+    part="icon icon-clear"
+  >
+  </ef-icon>
+</div>
 
 ```
 

--- a/packages/elements/src/text-field/__test__/text-field.test.js
+++ b/packages/elements/src/text-field/__test__/text-field.test.js
@@ -48,6 +48,11 @@ describe('text-field/TextField', function () {
     expect(el).shadowDom.to.equalSnapshot();
   });
 
+  it('DOM structure with clears is correct', async function () {
+    const el = await fixture('<ef-text-field value="abbr" clears></ef-text-field>');
+    await expect(el).shadowDom.to.equalSnapshot();
+  });
+
   describe('Functional Tests', function () {
     it('Error-changed from true to false for pattern', async function () {
       const el = await fixture('<ef-text-field pattern="[a-z]" value="1"></ef-text-field>');
@@ -192,6 +197,24 @@ describe('text-field/TextField', function () {
 
       const { detail } = await oneEvent(el, 'value-changed');
       expect(detail.value).to.equal('test');
+    });
+    it('Tapping on clears button should clear the value', async function () {
+      const el = await fixture('<ef-text-field clears value="abbr"></ef-text-field>');
+      el.clearsButton.dispatchEvent(new CustomEvent('tap'));
+      await elementUpdated(el);
+      expect(el.value).to.equal('', 'Tapping on clears did not clear the value');
+    });
+    it("Shouldn't have clears button when set readonly", async function () {
+      const el = await fixture('<ef-text-field readonly clears value="abbr"></ef-text-field>');
+      expect(el.clearsButton).to.equal(undefined, "Clear button shouldn't display");
+    });
+    it("Shouldn't have clears button when set disabled", async function () {
+      const el = await fixture('<ef-text-field disabled clears value="abbr"></ef-text-field>');
+      expect(el.clearsButton).to.equal(undefined, "Clear button shouldn't display");
+    });
+    it("Shouldn't have clears button when no value", async function () {
+      const el = await fixture('<ef-text-field disabled clears ></ef-text-field>');
+      expect(el.clearsButton).to.equal(undefined, "Clear button shouldn't display");
     });
   });
   describe('Accessiblity', function () {

--- a/packages/elements/src/text-field/index.ts
+++ b/packages/elements/src/text-field/index.ts
@@ -48,6 +48,9 @@ const hasChanged = (newVal: unknown, oldVal: unknown): boolean =>
  *
  * @attr {string} value - Input's value
  * @prop {string} [value=""] - Input's value
+ *
+ * @attr {boolean} clears - Show clears button
+ * @prop {boolean} [clears=false] - Show clears button
  */
 @customElement('ef-text-field')
 export class TextField extends FormFieldElement {
@@ -304,7 +307,7 @@ export class TextField extends FormFieldElement {
    * @return Render template
    */
   protected override render(): TemplateResult {
-    return html` ${super.render()} ${this.renderIcon()} `;
+    return html` ${super.render()} ${this.clearButtonTemplate} ${this.renderIcon()} `;
   }
 }
 

--- a/packages/elements/src/tree-select/__demo__/index.html
+++ b/packages/elements/src/tree-select/__demo__/index.html
@@ -101,6 +101,10 @@
       </script>
     </demo-block>
 
+    <demo-block header="Clearable" layout="normal" tags="clears">
+      <ef-tree-select clears id="clears"></ef-tree-select>
+    </demo-block>
+
     <demo-block header="Filter" tags="filter" layout="normal">
       <p>
         Items could be filtered with case-insensitive partial match of both labels & values.<br />

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -55,6 +55,8 @@ const valueFormatWarning = new WarningNotice(
  * @prop {boolean} [opened=false] - Set dropdown to open
  * @attr {string} placeholder - Set placeholder text
  * @prop {string} [placeholder=""] - Set placeholder text
+ * @attr {boolean} clears - Show clears button
+ * @prop {boolean} [clears=false] - Show clears button
  * @prop {TreeSelectData[]} [data=[]] - Data object to be used for creating tree
  * @fires confirm - Fired when the user closes a popup by confirming the new selection.
  * @fires cancel - Fired when the user closes a popup by cancelling the new selection.

--- a/packages/halo-theme/src/custom-elements/ef-combo-box.less
+++ b/packages/halo-theme/src/custom-elements/ef-combo-box.less
@@ -38,10 +38,6 @@
   }
 
   &:not([readonly]) {
-    [part~='button-clear']:hover {
-      color: @input-focused-border-color;
-    }
-
     &:hover {
       [part~='button-toggle'] {
         color: @input-focused-border-color;
@@ -86,6 +82,10 @@
 
     [part~='icon'] {
       color: inherit !important;
+    }
+    [part~='button-clear']:hover,
+    [part~='button-clear']:active {
+      color: @input-focused-border-color;
     }
   }
 

--- a/packages/halo-theme/src/custom-elements/ef-datetime-picker.less
+++ b/packages/halo-theme/src/custom-elements/ef-datetime-picker.less
@@ -76,4 +76,9 @@
     border-color: @input-hover-border-color;
     color: @input-hover-text-color;
   }
+
+  [part~='button-clear']:hover,
+  [part~='button-clear']:active {
+    color: @input-focused-border-color;
+  }
 }

--- a/packages/halo-theme/src/custom-elements/ef-text-field.less
+++ b/packages/halo-theme/src/custom-elements/ef-text-field.less
@@ -29,6 +29,11 @@
     }
   }
 
+  [part~='button-clear']:hover,
+  [part~='button-clear']:active {
+    color: @input-focused-border-color;
+  }
+
   &[warning] {
     border-color: @control-warning-color;
   }

--- a/packages/halo-theme/src/custom-elements/ef-tree-select.less
+++ b/packages/halo-theme/src/custom-elements/ef-tree-select.less
@@ -58,10 +58,6 @@
       background: none;
     }
 
-    [part~='button']:active {
-      color: @button-hover-text-color;
-    }
-
     [part~='button-toggle']:active {
       color: @input-focused-border-color;
       background: none;

--- a/packages/halo-theme/src/custom-elements/ef-tree-select.less
+++ b/packages/halo-theme/src/custom-elements/ef-tree-select.less
@@ -40,10 +40,6 @@
   }
 
   &:not([readonly]) {
-    [part~='button-clear']:hover {
-      color: @input-focused-border-color;
-    }
-
     &:hover {
       [part~='button-toggle'] {
         color: @input-focused-border-color;
@@ -69,6 +65,11 @@
     [part~='button-toggle']:active {
       color: @input-focused-border-color;
       background: none;
+    }
+
+    [part~='button-clear']:hover,
+    [part~='button-clear']:active {
+      color: @input-focused-border-color;
     }
   }
 


### PR DESCRIPTION
## Description

Introduce Clears to form field.

Fixes # ([DME-2142](https://jira.refinitiv.com/browse/DME-2142))

### Effected elements:
 - Text field
 - Number field
 - Password field
 - Email field
 - Search field
 - Combo box
 - Tree Select
 - Datetime picker

### Effected Change:
- Add a new demo
- Add style for clears
- Code implementation
- Add Tests
- Change content in Text field doc.

### Prefer to not change:
- Doesn't support a11y because Vaadin and native doesn't support it.
- Don't implement in Slider and Select because it looks weird to have clears button and native doesn't support it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
