### PR TITLE
docs(sidebar-layout): fix color contrast in sandbox

### DIFF
--- a/documents/src/pages/elements/sidebar-layout.md
+++ b/documents/src/pages/elements/sidebar-layout.md
@@ -18,12 +18,10 @@ ef-sidebar-layout {
 [slot="sidebar-content"] {
   text-align: center;
   padding: 50px 0;
-  background-color: #dfe2e8;
 }
 [slot="main-content"] {
   text-align: center;
   padding: 90px 0;
-  background-color: #f1f1f1;
 }
 ```
 ```html


### PR DESCRIPTION
## Description

Fix sandbox doesn't follow contrast principle at Dark theme of [Sidebar](https://ui.refinitiv.com/elements/sidebar-layout) page.