### PR TITLE
fix(card): expand body instead of header and footer

### DIFF
--- a/packages/elemental-theme/src/custom-elements/ef-card.less
+++ b/packages/elemental-theme/src/custom-elements/ef-card.less
@@ -17,15 +17,6 @@
     position: relative;
   }
 
-  [part~='body'] {
-    overflow: auto;
-  }
-
-  [part~='header'],
-  [part~='footer'] {
-    flex: 1 0 auto;
-  }
-
   [part~='header'] {
     padding-bottom: inherit;
     min-height: @button-height;

--- a/packages/elements/src/card/index.ts
+++ b/packages/elements/src/card/index.ts
@@ -52,7 +52,6 @@ export class Card extends BasicElement {
 
       [part~='header'] {
         display: flex;
-        flex: 0 0 auto;
       }
 
       [part~='header-body'] {

--- a/packages/elements/src/card/index.ts
+++ b/packages/elements/src/card/index.ts
@@ -49,13 +49,26 @@ export class Card extends BasicElement {
         display: flex;
         flex-flow: column nowrap;
       }
+
       [part~='header'] {
         display: flex;
+        flex: 0 0 auto;
       }
+
       [part~='header-body'] {
         flex: 1;
         min-width: 0px;
       }
+
+      [part~='body'] {
+        overflow: auto;
+        flex: 1;
+      }
+
+      [part~='footer'] {
+        flex: 0 0 auto;
+      }
+
       [part~='footer']:not([part~='has-content']),
       [part~='header']:not([part~='has-content']) {
         display: none;

--- a/packages/elements/src/card/index.ts
+++ b/packages/elements/src/card/index.ts
@@ -64,6 +64,7 @@ export class Card extends BasicElement {
         flex: 1;
       }
 
+      [part~='header'],
       [part~='footer'] {
         flex: 0 0 auto;
       }


### PR DESCRIPTION
## Description

Change card styling in body part to expand size instead of expanding header and footer.

Fixes # (issue)
[DME-18155](https://jira.refinitiv.com/browse/DME-18155)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
