### PR TITLE
fix(tree-select): fix item interface doesn't sync with values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6879,12 +6879,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
-      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -247,16 +247,20 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
    * @returns {void}
    */
   protected override updateComposerValues(newValues: string[]): void {
-    const selectedAt = Date.now();
     for (const item of this.treeManager.checkedItems) {
       this.treeManager.uncheckItem(item);
     }
     const selectedItems = this.queryItems((item, composer) => {
-      return newValues.includes(composer.getItemPropertyValue(item, 'value') || '');
+      return newValues.includes(composer.getItemPropertyValue(item, 'value') ?? '');
     });
+    const sortedSelectedItem = [];
     for (const item of selectedItems) {
-      const timestamp = selectedAt + newValues.indexOf(item.value ?? '');
-      this.treeManager.checkItemWithTimestamp(item, timestamp);
+      const value = this.composer.getItemPropertyValue(item, 'value') ?? '';
+      const index = newValues.indexOf(value);
+      sortedSelectedItem[index] = item;
+    }
+    for (const item of sortedSelectedItem) {
+      this.treeManager.checkItem(item);
     }
   }
 

--- a/packages/elements/src/tree-select/index.ts
+++ b/packages/elements/src/tree-select/index.ts
@@ -242,6 +242,25 @@ export class TreeSelect extends ComboBox<TreeSelectDataItem> {
   }
 
   /**
+   * Update composer values.
+   * @param newValues new values
+   * @returns {void}
+   */
+  protected override updateComposerValues(newValues: string[]): void {
+    const selectedAt = Date.now();
+    for (const item of this.treeManager.checkedItems) {
+      this.treeManager.uncheckItem(item);
+    }
+    const selectedItems = this.queryItems((item, composer) => {
+      return newValues.includes(composer.getItemPropertyValue(item, 'value') || '');
+    });
+    for (const item of selectedItems) {
+      const timestamp = selectedAt + newValues.indexOf(item.value ?? '');
+      this.treeManager.checkItemWithTimestamp(item, timestamp);
+    }
+  }
+
+  /**
    * Renderer used to render tree item elements
    */
   @property({ attribute: false })

--- a/packages/elements/src/tree/managers/tree-manager.ts
+++ b/packages/elements/src/tree/managers/tree-manager.ts
@@ -424,6 +424,40 @@ export class TreeManager<T extends TreeDataItem> {
   }
 
   /**
+   * Selects the item by update timestamp manually.
+   * @param item Original data item
+   * @param timestamp timestamp in number value
+   * @returns `True` if the item is modified
+   */
+  public checkItemWithTimestamp(item: T, timestamp: number): boolean {
+    return this._checkItemWithTimestamp(item, this.manageRelationships, timestamp);
+  }
+  private _checkItemWithTimestamp(
+    item: T,
+    manageRelationships = this.manageRelationships,
+    newTimestamp: number
+  ): boolean {
+    if (this.canCheckItem(item)) {
+      // Create unique timestamp base on the latest selection for sequential selection.
+      const timestamp = Date.now();
+      this.lastSelectedAt =
+        this.lastSelectedAt && this.lastSelectedAt >= timestamp ? this.lastSelectedAt + 1 : timestamp;
+
+      // Set item selected with timestamp
+      this.composer.setItemPropertyValue(item, 'selected', true);
+      this.composer.setItemPropertyValue(item, 'selectedAt', newTimestamp);
+      if (manageRelationships) {
+        this.forceUpdateOnPath(item);
+        this.getItemDescendants(item).forEach((descendant) =>
+          this._checkItemWithTimestamp(descendant, false, newTimestamp)
+        );
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * Unchecks the item
    * @param item Original data item
    * @returns `True` if the item is modified

--- a/packages/elements/src/tree/managers/tree-manager.ts
+++ b/packages/elements/src/tree/managers/tree-manager.ts
@@ -424,40 +424,6 @@ export class TreeManager<T extends TreeDataItem> {
   }
 
   /**
-   * Selects the item by update timestamp manually.
-   * @param item Original data item
-   * @param timestamp timestamp in number value
-   * @returns `True` if the item is modified
-   */
-  public checkItemWithTimestamp(item: T, timestamp: number): boolean {
-    return this._checkItemWithTimestamp(item, this.manageRelationships, timestamp);
-  }
-  private _checkItemWithTimestamp(
-    item: T,
-    manageRelationships = this.manageRelationships,
-    newTimestamp: number
-  ): boolean {
-    if (this.canCheckItem(item)) {
-      // Create unique timestamp base on the latest selection for sequential selection.
-      const timestamp = Date.now();
-      this.lastSelectedAt =
-        this.lastSelectedAt && this.lastSelectedAt >= timestamp ? this.lastSelectedAt + 1 : timestamp;
-
-      // Set item selected with timestamp
-      this.composer.setItemPropertyValue(item, 'selected', true);
-      this.composer.setItemPropertyValue(item, 'selectedAt', newTimestamp);
-      if (manageRelationships) {
-        this.forceUpdateOnPath(item);
-        this.getItemDescendants(item).forEach((descendant) =>
-          this._checkItemWithTimestamp(descendant, false, newTimestamp)
-        );
-      }
-      return true;
-    }
-    return false;
-  }
-
-  /**
    * Unchecks the item
    * @param item Original data item
    * @returns `True` if the item is modified


### PR DESCRIPTION
## Description

TreeSelect Item interface of TreeSelect doesn't update when popup is opened, and values are changing.

Reproduce steps:
1. Go to sandbox [codesandbox.io/p/devbox/treeselect-item-doesnt-update-interface-correctly-ang-16-ef-v7-sndnp2](https://codesandbox.io/p/devbox/treeselect-item-doesnt-update-interface-correctly-ang-16-ef-v7-sndnp2)
2. The sandbox has TreeSelect with data. The data has parent item and selected child item.
3. Try change the `values` property to empty array during the popup is still opened.
4. The parent item interface doesn't update.

Fixes # ([DME-23424](https://jira.refinitiv.com/browse/DME-23424))

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
