### PR TITLE
fix(tree, tree-select, combo-box): apply filter when it's updated

### DIFF
--- a/packages/elements/src/combo-box/__demo__/index.html
+++ b/packages/elements/src/combo-box/__demo__/index.html
@@ -131,10 +131,15 @@
     </demo-block>
 
     <demo-block header="Custom Filter" layout="normal" tags="filters, custom">
+      <p>
+        Call the global <code>useLabelOnlyFilter()</code> & <code>useLabelValueFilter()</code> to switch
+        between these filters.<br />
+        <strong>Active Filter</strong>: <span id="active-filter">label only</span>.<br />
+      </p>
       <ef-combo-box id="custom-filter"></ef-combo-box>
       <script>
         const customFilterCombo = document.getElementById('custom-filter');
-        const customFilter = (comboBox) => {
+        const customFilter = (comboBox, labelValue = false) => {
           // reference query string for validating queryRegExp cache state
           let query = '';
           // cache RegExp
@@ -154,13 +159,25 @@
           // return scoped custom filter
           return (item) => {
             const regex = getRegularExpressionOfQuery();
-            // test on label or value
-            const result = query === item.value || regex.test(item.label);
+            const { label, value } = item;
+            let result = regex.test(label);
+            if (labelValue) {
+              result = result || regex.test(value);
+            }
             return result;
           };
         };
 
-        customFilterCombo.filter = customFilter(customFilterCombo);
+        const activeFilter = document.getElementById('active-filter');
+        globalThis.useLabelOnlyFilter = () => {
+          customFilterCombo.filter = customFilter(customFilterCombo);
+          activeFilter.textContent = 'label only';
+        };
+
+        globalThis.useLabelValueFilter = () => {
+          customFilterCombo.filter = customFilter(customFilterCombo, true);
+          activeFilter.textContent = 'label & value';
+        };
       </script>
     </demo-block>
 

--- a/packages/elements/src/combo-box/index.ts
+++ b/packages/elements/src/combo-box/index.ts
@@ -618,6 +618,11 @@ export class ComboBox<T extends DataItem = ItemData> extends FormFieldElement {
       triggerResize();
     }
 
+    // If filter has been updated, filter items again with the updated filter.
+    if (changedProperties.has('filter')) {
+      this.filterItems();
+    }
+
     super.update(changedProperties);
   }
 

--- a/packages/elements/src/tree-select/__demo__/index.html
+++ b/packages/elements/src/tree-select/__demo__/index.html
@@ -107,15 +107,16 @@
 
     <demo-block header="Filter" tags="filter" layout="normal">
       <p>
-        Items could be filtered with case-insensitive partial match of both labels & values.<br />
-        There is a debounce rate of 500ms applied.
+        Call the global <code>useLabelOnlyFilter()</code> & <code>useLabelValueFilter()</code> to switch
+        between these filters.<br />
+        <strong>Active Filter</strong>: <span id="active-filter">label only</span>.<br />
       </p>
       <ef-tree-select id="filter" query-debounce-rate="500" aria-label="Choose Country"></ef-tree-select>
       <script type="module">
         import escapeStringRegexp from 'escape-string-regexp';
 
         const treeSelect = document.getElementById('filter');
-        const createCustomFilter = (treeSelect) => {
+        const createCustomFilter = (treeSelect, labelValue = false) => {
           let query = '';
           let queryRegExp;
           const getRegularExpressionOfQuery = () => {
@@ -126,14 +127,26 @@
             return queryRegExp;
           };
           return (item) => {
-            const label = item.label;
-            const value = item.value;
+            const { label, value } = item;
             const regex = getRegularExpressionOfQuery();
-            const result = regex.test(value) || regex.test(label);
+            let result = regex.test(label);
+            if (labelValue) {
+              result = result || regex.test(value);
+            }
             return result;
           };
         };
-        treeSelect.filter = createCustomFilter(treeSelect);
+
+        const activeFilter = document.getElementById('active-filter');
+        globalThis.useLabelOnlyFilter = () => {
+          treeSelect.filter = createCustomFilter(treeSelect);
+          activeFilter.textContent = 'label only';
+        };
+
+        globalThis.useLabelValueFilter = () => {
+          treeSelect.filter = createCustomFilter(treeSelect, true);
+          activeFilter.textContent = 'label & value';
+        };
       </script>
     </demo-block>
   </body>

--- a/packages/elements/src/tree/__demo__/index.html
+++ b/packages/elements/src/tree/__demo__/index.html
@@ -13,6 +13,8 @@
   </head>
   <body>
     <script type="module">
+      import '@refinitiv-ui/elements/panel';
+      import '@refinitiv-ui/elements/radio-button';
       import { createTreeRenderer } from '@refinitiv-ui/elements/tree';
       import '@refinitiv-ui/elements/tree';
 
@@ -187,11 +189,17 @@
     </demo-block>
 
     <demo-block header="Filter Query" tags="filter, query" layout="normal">
-      <p>
-        Items could be filtered with case-insensitive partial match of both labels & values through query
-        input
-      </p>
-      <input id="filter-query-input" type="text" placeholder="Input query" />
+      <p>Switching between custom filter</p>
+      <ef-panel spacing>
+        Filter item with:
+        <span id="radio-group">
+          <ef-radio-button name="filter" id="label-only" checked>Label Only</ef-radio-button>
+          <ef-radio-button name="filter" id="label-value">Label & Value</ef-radio-button>
+        </span>
+        <br />
+        <label for="filter-query-input">Query</label>
+        <input id="filter-query-input" type="text" placeholder="Input query" />
+      </ef-panel>
       <ef-tree multiple class="custom-data" id="filter-query-tree"></ef-tree>
       <button expand>Expand All</button>
       <button collapse>Collapse All</button>
@@ -283,7 +291,7 @@
           }
         ];
 
-        const createCustomFilter = (tree) => {
+        const createCustomFilter = (tree, labelValue = false) => {
           let query = '';
           let queryRegExp;
           const getRegularExpressionOfQuery = () => {
@@ -297,13 +305,24 @@
             const label = item.label;
             const value = item.value;
             const regex = getRegularExpressionOfQuery();
-            const result = regex.test(value) || regex.test(label);
+            let result = regex.test(label);
+            if (labelValue) {
+              result = result || regex.test(value);
+            }
             return result;
           };
         };
 
         tree.data = data;
-        tree.filter = createCustomFilter(tree);
+        const radioGroup = document.getElementById('radio-group');
+        radioGroup.addEventListener(
+          'checked-changed',
+          (e) => {
+            const labelValue = e.target.id === 'label-value';
+            tree.filter = createCustomFilter(tree, labelValue);
+          },
+          { capture: true }
+        );
 
         document.getElementById('filter-query-input').addEventListener(
           'keyup',

--- a/packages/elements/src/tree/__test__/tree.test.js
+++ b/packages/elements/src/tree/__test__/tree.test.js
@@ -15,6 +15,7 @@ import {
   oneEvent
 } from '@refinitiv-ui/test-helpers';
 
+import { createDefaultFilter } from '../../../lib/tree/helpers/filter.js';
 import {
   deepNestedData,
   firstFilterData,
@@ -666,6 +667,49 @@ describe('tree/Tree', function () {
       expect(el.children.length).to.equal(
         secondChildrenCount,
         `there should be ${secondChildrenCount} child(ren) with the provided custom filter, query & data`
+      );
+    });
+
+    it('should update filter result when filter is update', async function () {
+      const el = await fixture('<ef-tree></ef-tree>');
+      el.data = firstFilterData;
+      await elementUpdated(el);
+
+      const createCustomFilter = (tree) => {
+        let query = '';
+        let queryRegExp;
+        const getRegularExpressionOfQuery = () => {
+          if (tree.query !== query || !queryRegExp) {
+            query = tree.query || '';
+            queryRegExp = new RegExp(escapeStringRegexp(query), 'i');
+          }
+          return queryRegExp;
+        };
+        return (item) => {
+          const label = item.label;
+          const value = item.value;
+          const regex = getRegularExpressionOfQuery();
+          const result = regex.test(value) || regex.test(label);
+          return result;
+        };
+      };
+      el.filter = createCustomFilter(el);
+      el.query = '3';
+      await elementUpdated(el);
+
+      const firstChildrenCount = 7;
+      expect(el.children.length).to.equal(
+        firstChildrenCount,
+        `there should be ${firstChildrenCount} child(ren) with the provided custom filter & query`
+      );
+
+      el.filter = createDefaultFilter(el);
+      await elementUpdated(el);
+
+      const noChildren = 0;
+      expect(el.children.length).to.equal(
+        noChildren,
+        `there should be ${noChildren} child(ren) with the provided custom filter & query`
       );
     });
   });

--- a/packages/elements/src/tree/elements/tree.ts
+++ b/packages/elements/src/tree/elements/tree.ts
@@ -287,7 +287,7 @@ export class Tree<T extends TreeDataItem = TreeDataItem> extends List<T> {
       this.manager.setMode(this.mode);
     }
 
-    if (changeProperties.has('query') || changeProperties.has('data')) {
+    if (changeProperties.has('query') || changeProperties.has('data') || changeProperties.has('filter')) {
       this.filterItems();
     }
   }


### PR DESCRIPTION
## Description

Tree, Tree Select & Combo Box should apply the new `filter` when it's updated. This PR fixes this issue by tapping into `update()` & `willUpdate()` life cycle of respective components.

Fixes # https://jira.refinitiv.com/browse/DME-28738

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
