### PR TITLE
chore: bump test platform to Safari/iOS 16 - 18

### DIFF
--- a/browsers.config.js
+++ b/browsers.config.js
@@ -11,7 +11,6 @@ const BrowserStack = {
     ...DefaultMobileBrowsers,
     'chrome_minus1',
     'chrome_minus2',
-    'safari_minus2',
     'firefox_minus1',
     'firefox_minus2',
     'android_minus1',
@@ -38,7 +37,7 @@ BrowserStack.availableBrowsers = [...BrowserStack.supportedBrowsers, ...BrowserS
 // base platform config
 const deviceConfig = { real_mobile: 'true' };
 const windowsConfig = { os: 'Windows', os_version: '11' };
-const macOSConfig = { os: 'OS X', os_version: 'Sonoma' };
+const macOSConfig = { os: 'OS X', os_version: 'Sequoia' };
 
 // BrowserStack Browsers Config
 BrowserStack.config = {
@@ -52,13 +51,13 @@ BrowserStack.config = {
   chrome_minus1: { ...windowsConfig, browser: 'chrome', browser_version: 'latest-1' },
   firefox_minus1: { ...windowsConfig, browser: 'firefox', browser_version: 'latest-1' },
   edge_minus1: { ...windowsConfig, browser: 'edge', browser_version: 'latest-1' },
-  safari_minus1: { ...macOSConfig, browser: 'safari', os_version: 'Ventura' },
+  safari_minus1: { ...macOSConfig, browser: 'safari', os_version: 'Sonoma' },
 
   // minus2 versions
   chrome_minus2: { ...windowsConfig, browser: 'chrome', browser_version: 'latest-2' },
   firefox_minus2: { ...windowsConfig, browser: 'firefox', browser_version: 'latest-2' },
   edge_minus2: { ...windowsConfig, browser: 'edge', browser_version: 'latest-2' },
-  safari_minus2: { ...macOSConfig, browser: 'safari', os_version: 'Monterey' },
+  safari_minus2: { ...macOSConfig, browser: 'safari', os_version: 'Ventura' },
 
   // Mobile Devices
   ios: { ...deviceConfig, browser: 'iphone', device: 'iPhone 16 Pro', os: 'ios', os_version: '18' },

--- a/browsers.config.js
+++ b/browsers.config.js
@@ -61,7 +61,7 @@ BrowserStack.config = {
   safari_minus2: { ...macOSConfig, browser: 'safari', os_version: 'Monterey' },
 
   // Mobile Devices
-  ios: { ...deviceConfig, browser: 'iphone', device: 'iPhone 15 Pro', os: 'ios', os_version: '17' },
+  ios: { ...deviceConfig, browser: 'iphone', device: 'iPhone 16 Pro', os: 'ios', os_version: '18' },
   android: {
     ...deviceConfig,
     browser: 'android',
@@ -71,7 +71,7 @@ BrowserStack.config = {
   },
 
   // Mobile Devices minus1 versions
-  ios_minus1: { ...deviceConfig, browser: 'iphone', device: 'iPhone 14 Pro', os: 'ios', os_version: '16' },
+  ios_minus1: { ...deviceConfig, browser: 'iphone', device: 'iPhone 15 Pro', os: 'ios', os_version: '17' },
   android_minus1: {
     ...deviceConfig,
     browser: 'android',
@@ -81,7 +81,7 @@ BrowserStack.config = {
   },
 
   // Mobile Devices minus2 versions
-  ios_minus2: { ...deviceConfig, browser: 'iphone', device: 'iPhone 13 Pro', os: 'ios', os_version: '15' },
+  ios_minus2: { ...deviceConfig, browser: 'iphone', device: 'iPhone 14 Pro', os: 'ios', os_version: '16' },
   android_minus2: {
     ...deviceConfig,
     browser: 'android',

--- a/packages/elements/src/tree-select/__test__/tree-select.filter.test.js
+++ b/packages/elements/src/tree-select/__test__/tree-select.filter.test.js
@@ -478,7 +478,7 @@ describe('tree-select/Filter', function () {
       await elementUpdated(el);
 
       const noChildren = 0;
-      expect(el.children.length).to.equal(
+      expect(treeEl.children.length).to.equal(
         noChildren,
         `there should be ${noChildren} child(ren) with the provided custom filter & query of ${query}`
       );


### PR DESCRIPTION
## Description

* Fix Tree Select unit test
* Bump test platform to Safari 16 - 18 on both iOS & macOS

Note that, the test platform version is bumped eagerly due to a [unit test issue impacting iOS 15](https://github.com/Refinitiv/refinitiv-ui/actions/runs/10987694943/job/30503591536). Instead of fixing the issue for the soon-to-be-deprecated platform, we should move forward instead.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
