### PR TITLE
docs: fix element closing tag in live example of email field docs

### DIFF
--- a/documents/src/pages/elements/email-field.md
+++ b/documents/src/pages/elements/email-field.md
@@ -24,7 +24,7 @@ p {
 ```
 ```html
 <ef-panel spacing>
-  <label for="email">Email</p>
+  <label for="email">Email</label>
   <ef-email-field 
     id="email"
     placeholder="Business email address"


### PR DESCRIPTION
## Description

Update typo tag from live-example of documentation email-field.md file

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
