### PR TITLE
fix(halo-theme): change dataviz-color2 to enhance visible for print

### DIFF
--- a/packages/halo-theme/src/variants/dark/overrides.less
+++ b/packages/halo-theme/src/variants/dark/overrides.less
@@ -177,7 +177,7 @@ Rules:
 
 // DataViz - Charting
 @dataviz-color-1                          : @dataviz-color-primary;
-@dataviz-color-2                          : @color-white;
+@dataviz-color-2                          : @color-mercury;
 @dataviz-color-3                          : @color-supernova;
 @dataviz-color-4                          : @color-amethyst;
 @dataviz-color-5                          : @color-robins-egg;


### PR DESCRIPTION
## Description
@dataviz-color-2 of dark Halo theme is currently white (#FFFFFF) which is invisible in the print result of ef-chart.

To mitigate the issue, @dataviz-color-2 shall be changed to @color-mercury. Although the color contrast is quite low, it's much better than no contrast effectively invisible.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
