### PR TITLE
fix(ds-theme): accordion border color

### DIFF
--- a/packages/ds-theme/src/custom-elements/ef-accordion.less
+++ b/packages/ds-theme/src/custom-elements/ef-accordion.less
@@ -5,6 +5,6 @@
   border-radius: @comp-accordion-container-radius-md;
 
   ::slotted(ef-collapse:not(:last-child):not([expanded])) {
-    border-bottom: 1px solid @comp-accordion-item-header-container-color-border-base-enabled;
+    border-bottom: 1px solid @comp-accordion-item-header-container-color-border-divider-enabled;
   }
 }


### PR DESCRIPTION
Fixes

- No border on the items, currently set to transparent
- Use comp.accordion.item.header.container.color.border.divider.enabled as border color

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
