### PR TITLE
fix(ds-theme): incorrect overlay box-shadow

### DIFF
--- a/packages/ds-theme/src/custom-elements/ef-overlay.less
+++ b/packages/ds-theme/src/custom-elements/ef-overlay.less
@@ -2,4 +2,8 @@
 
 :host {
   border-radius: @comp-popover-container-radius-md;
+
+  &[with-shadow] {
+    box-shadow: @cont-elevation-common-level-3;
+  }
 }


### PR DESCRIPTION
Fixes
- incorrect box-shadow value
- cannot utilize the @panel-box-shadow variable because the box-shadow of overlay and card are not similar

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
