### PR TITLE
fix(ds-theme): use default background color for track and thumb when hovering slider

### DIFF
--- a/packages/ds-theme/src/custom-elements/ef-slider.less
+++ b/packages/ds-theme/src/custom-elements/ef-slider.less
@@ -5,11 +5,6 @@
     border-radius: @cont-radius-common-2xl;
   }
   &:hover {
-    [part='thumb'],
-    [part='track-wrapper'] {
-      background-color: @cont-color-control-bg-moderate;
-    }
-
     [part='thumb'] {
       border-color: @slider-thumb-hover-border-color;
     }


### PR DESCRIPTION
Description
- Design have changed the colour of the track on hover to be the same as the default.
- Remove :host(:hover) [part=thumb], :host(:hover) [part=track-wrapper]

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
