### PR TITLE
fix(ds-theme): correct background color of swing gauge

### DIFF
--- a/packages/ds-theme/src/custom-elements/ef-swing-gauge.less
+++ b/packages/ds-theme/src/custom-elements/ef-swing-gauge.less
@@ -2,7 +2,7 @@
 
 :host {
   --primary-color: @dataviz-color-primary;
-  --secondary-color: @dataviz-color-complementary;
+  --secondary-color: @cont-color-common-container-surface-on-layer-1-minimal;
   --center-line-color: @separator-color;
   --border-color: @separator-color;
 }


### PR DESCRIPTION
## Description

The bg of the swing gauge should be `cont/color/common/container/surface/on-layer-1/minimal`.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
