### PR TITLE
fix(ds-theme): update font weights for header and non-header items

### DIFF
--- a/packages/ds-theme/src/custom-elements/ef-item.less
+++ b/packages/ds-theme/src/custom-elements/ef-item.less
@@ -11,10 +11,11 @@
 
   &[type='header'] {
     text-transform: none;
+    font-weight: @core-typography-font-weight-semi-bold;
   }
 
   &:not([type='header']) {
-    font-weight: @core-typography-font-weight-medium;
+    font-weight: @core-typography-font-weight-regular;
   }
 
   &[selected][highlighted] {


### PR DESCRIPTION
## Description

Update font-weight of the items to be: core.typography.font-weight.regular
Update the font-weight of the header to be: core.typography.font-weight.semi-bold

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
