### PR TITLE
fix(ds-theme): incorrect led gauge's bar color

### DIFF
--- a/packages/ds-theme/src/custom-elements/ef-led-gauge.less
+++ b/packages/ds-theme/src/custom-elements/ef-led-gauge.less
@@ -1,6 +1,7 @@
 @import '@refinitiv-ui/halo-theme/src/custom-elements/ef-led-gauge';
 
 :host {
+  --neutral-color: @cont-color-common-container-surface-on-layer-1-subtle;
   --led-spacing: 1px;
   --top-selected-color: @cont-color-common-container-neutral-base;
   --bottom-selected-color: @cont-color-data-viz-categorical-bg-category-1;


### PR DESCRIPTION
## Fixes

The daily range example has the incorrect bg colour applied.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
