### PR TITLE
fix(ds-theme): override styles for slotted anchor elements in appstat…

### DIFF
--- a/packages/ds-theme/src/custom-elements/ef-appstate-bar.less
+++ b/packages/ds-theme/src/custom-elements/ef-appstate-bar.less
@@ -23,4 +23,16 @@
   [part='close'] {
     stroke-width: unset;
   }
+
+  /**
+   * This is shallow override a style for a tag, which is limitation of ::slotted selector
+   * to make the style affect to nested elements we must implement in the global scope
+   */
+  ::slotted(a),
+  ::slotted(a:visited),
+  ::slotted(a:hover),
+  ::slotted(a:focus) {
+    color: @cont-color-common-fg-primary-moderate !important;
+    text-decoration: underline !important;
+  }
 }

--- a/packages/ds-theme/src/custom-elements/ef-appstate-bar.less
+++ b/packages/ds-theme/src/custom-elements/ef-appstate-bar.less
@@ -25,7 +25,7 @@
   }
 
   /**
-   * This is shallow override a style for a tag, which is limitation of ::slotted selector
+   * This style affect to children element no nested, which is limitation of ::slotted selector
    * to make the style affect to nested elements we must implement in the global scope
    */
   ::slotted(a),

--- a/packages/ds-theme/src/custom-elements/ef-tree-select.less
+++ b/packages/ds-theme/src/custom-elements/ef-tree-select.less
@@ -1,1 +1,15 @@
 @import '@refinitiv-ui/halo-theme/src/custom-elements/ef-tree-select';
+
+:host {
+  [part~='control'] {
+    color: @cont-color-common-fg-generic-subtle;
+
+    &[part~='active'] {
+      color: @cont-color-common-fg-generic-bold;
+    }
+  }
+
+  [part='list'] {
+    border: none;
+  }
+}

--- a/packages/elements/src/appstate-bar/__demo__/index.html
+++ b/packages/elements/src/appstate-bar/__demo__/index.html
@@ -9,12 +9,8 @@
       }
 
       a ef-icon {
-        font-size: 20px;
-        vertical-align: middle;
-      }
-
-      a span {
-        vertical-align: middle;
+        font-size: 18px;
+        vertical-align: bottom;
       }
     </style>
   </head>


### PR DESCRIPTION
## Description

Override styles for slotted anchor elements in appstate bar

Note: This style affect to children element no nested, which is limitation of ::slotted selector to make the style affect to nested elements we must implement in the global scope

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
