### PR TITLE
fix(ds-theme): missing border when clicking at toggle pill

### DIFF
--- a/packages/ds-theme/src/variants/light/variables.less
+++ b/packages/ds-theme/src/variants/light/variables.less
@@ -209,7 +209,7 @@
 // Pill
 @pill-background-color                            : @comp-toggle-tag-inner-container-color-bg-enabled;
 @pill-border-color                                : @comp-toggle-tag-inner-container-color-border-enabled;
-@pill-toggle-active-border-color                  : @comp-toggle-tag-inner-container-color-border-checked-enabled;
+@pill-toggle-active-border-color                  : @comp-toggle-tag-inner-container-color-border-pressed;
 @pill-default-close-color                         : @comp-toggle-tag-remove-button-icon-color-fg-checked-enabled;
 
 // Slider


### PR DESCRIPTION
Fixes # (issue)

On the toggle pills the border is not visible on pressed state.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
