### PR TITLE
fix(ds-theme): update slider's track and step color based on the feedback

### DIFF
--- a/packages/ds-theme/src/variants/light/variables.less
+++ b/packages/ds-theme/src/variants/light/variables.less
@@ -214,9 +214,9 @@
 @pill-default-close-color                         : @comp-toggle-tag-remove-button-icon-color-fg-checked-enabled;
 
 // Slider
-@slider-track-color                               : @cont-color-common-container-surface-on-layer-1-moderate;
+@slider-track-color                               : @cont-color-common-container-surface-on-layer-1-subtle;
 @slider-track-disabled-color                      : @cont-color-common-container-misc-disabled;
-@slider-step-color                                : @scheme-color-primary;
+@slider-step-color                                : @cont-color-control-bg-base;
 @slider-thumb-color                               : @cont-color-control-bg-base;
 @slider-marker-background-color                   : @slider-thumb-color;
 @slider-marker-text-color                         : @control-text-color;


### PR DESCRIPTION
Fixes 

Update slider's colors

- @slider-track-color: @--cont-color-common-container-surface-on-layer-1-subtle
- @slider-step-color: @-cont-color-control-bg-base

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
