### PR TITLE
fix(interactive-chart): hide tradingview default attribution logo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,5 +150,3 @@ certs
 
 # nx
 .nx
-
-.codegpt

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ certs
 
 # nx
 .nx
+
+.codegpt

--- a/package-lock.json
+++ b/package-lock.json
@@ -13950,9 +13950,10 @@
       "dev": true
     },
     "node_modules/lightweight-charts": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-4.1.1.tgz",
-      "integrity": "sha512-HYjm66NAIOhoLDNaaQsiwOVWiFHL1yrygZeKd4PgdZESnWyp5dPoTe3pH3t2h4ix+Ix5TwLZaNbWroZqQuj6OA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-4.2.2.tgz",
+      "integrity": "sha512-H5u9BfUeWzOA90QaqAlGjz1tePa7kUihKSOMiE4538/xMuM3k3n6bWYxuZSj9zwIj1PhgY/J5HTA/4lMk/lYYQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "fancy-canvas": "2.1.0"
       }
@@ -23181,7 +23182,7 @@
         "d3-interpolate": "^3.0.1",
         "date-fns": "^2.29.3",
         "escape-string-regexp": "^5.0.0",
-        "lightweight-charts": "^4.1.0",
+        "lightweight-charts": "^4.2.0",
         "tslib": "^2.3.1"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13681,9 +13681,10 @@
       }
     },
     "node_modules/less": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.2.0.tgz",
-      "integrity": "sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.2.1.tgz",
+      "integrity": "sha512-CasaJidTIhWmjcqv0Uj5vccMI7pJgfD9lMkKtlnTHAdJdYK/7l8pM9tumLyJ0zhbD4KJLo/YvTj+xznQd5NBhg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -23314,7 +23315,7 @@
         "fs-extra": "^8.1.0",
         "glob": "^10.3.9",
         "htmlparser2": "^4.0.0",
-        "less": "^4.2.0",
+        "less": "^4.2.1",
         "less-plugin-npm-import": "^2.1.0",
         "postcss": "^8.4.30",
         "svgo": "^3.2.0",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -466,7 +466,7 @@
     "d3-interpolate": "^3.0.1",
     "date-fns": "^2.29.3",
     "escape-string-regexp": "^5.0.0",
-    "lightweight-charts": "^4.1.0",
+    "lightweight-charts": "^4.2.0",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/packages/elements/src/interactive-chart/__test__/__snapshots__/interactive-chart.test.snap.js
+++ b/packages/elements/src/interactive-chart/__test__/__snapshots__/interactive-chart.test.snap.js
@@ -10,12 +10,14 @@ snapshots["interactive-chart/InteractiveChart Default DOM structure is correct"]
   <div part="jump-button">
   </div>
 </div>
-<div
+<a
+  href="https://www.tradingview.com"
   part="branding-container"
+  target="_blank"
   title=""
-  tooltip="Powered by Trading View"
+  tooltip="Charting by Trading View"
 >
-</div>
+</a>
 <div part="chart">
 </div>
 `;

--- a/packages/elements/src/interactive-chart/__test__/__snapshots__/interactive-chart.test.snap.js
+++ b/packages/elements/src/interactive-chart/__test__/__snapshots__/interactive-chart.test.snap.js
@@ -14,8 +14,7 @@ snapshots["interactive-chart/InteractiveChart Default DOM structure is correct"]
   href="https://www.tradingview.com"
   part="branding-container"
   target="_blank"
-  title=""
-  tooltip="Charting by Trading View"
+  title="Charting by Trading View"
 >
 </a>
 <div part="chart">

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -1187,8 +1187,7 @@ export class InteractiveChart extends ResponsiveElement {
       <a
         href="https://www.tradingview.com"
         part="branding-container"
-        title=""
-        tooltip="Charting by Trading View"
+        title="Charting by Trading View"
         target="_blank"
       >
         <svg width="33" height="19" viewBox="0 0 611 314" part="branding">

--- a/packages/elements/src/interactive-chart/index.ts
+++ b/packages/elements/src/interactive-chart/index.ts
@@ -588,7 +588,8 @@ export class InteractiveChart extends ResponsiveElement {
             color: this.theme.backgroundColor
           },
           textColor: this.theme.textColor,
-          fontFamily: defaultFontFamily
+          fontFamily: defaultFontFamily,
+          attributionLogo: false
         },
         leftPriceScale: {
           borderColor: this.theme.scalePriceBorderColor
@@ -1183,7 +1184,13 @@ export class InteractiveChart extends ResponsiveElement {
       <div part="jump-button-container">
         <div part="jump-button"></div>
       </div>
-      <div part="branding-container" title="" tooltip="Powered by Trading View">
+      <a
+        href="https://www.tradingview.com"
+        part="branding-container"
+        title=""
+        tooltip="Charting by Trading View"
+        target="_blank"
+      >
         <svg width="33" height="19" viewBox="0 0 611 314" part="branding">
           <path
             fill-rule="evenodd"
@@ -1191,7 +1198,7 @@ export class InteractiveChart extends ResponsiveElement {
             d="M341 124C375.242 124 403 96.2417 403 62C403 27.7583 375.242 0 341 0C306.758 0 279 27.7583 279 62C279 96.2417 306.758 124 341 124ZM481 314H337L467 4H611L481 314ZM124 4H248V128V314H124V128H0V4H124Z"
           />
         </svg>
-      </div>
+      </a>
       <div part="chart"></div>
     `;
   }

--- a/packages/theme-compiler/package.json
+++ b/packages/theme-compiler/package.json
@@ -30,7 +30,7 @@
     "fs-extra": "^8.1.0",
     "glob": "^10.3.9",
     "htmlparser2": "^4.0.0",
-    "less": "^4.2.0",
+    "less": "^4.2.1",
     "less-plugin-npm-import": "^2.1.0",
     "postcss": "^8.4.30",
     "svgo": "^3.2.0",


### PR DESCRIPTION
## Description

From version 4.2, tradingview lightweight chart show attribution logo by default. This MR to hide that default logo to keep our same charting design.

Ref: https://tradingview.github.io/lightweight-charts/docs/release-notes#420

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
