### PR TITLE
fix(utils): check response header when load svg

### DIFF
--- a/packages/utils/src/loader/svg-loader.ts
+++ b/packages/utils/src/loader/svg-loader.ts
@@ -56,7 +56,8 @@ const stripUnsafeNodes = (...elements: Node[]): void => {
  * @returns Is valid SVG
  */
 const isValidResponse = (response: Response | undefined): response is Response => {
-  const isSVG = Boolean(response?.headers.get('content-type')?.startsWith('image/svg+xml'));
+  //  Header might not be present in case of network error such as CORS issue
+  const isSVG = Boolean(response?.headers?.get('content-type')?.startsWith('image/svg+xml'));
   return Boolean(response) && Boolean(response?.ok) && response?.status === 200 && isSVG;
 };
 


### PR DESCRIPTION
## Description

Header might not be present in case of network error such as CORS issue.

Fixes # (issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
