### PR TITLE
docs: remove "design system" term usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,9 @@ Element Framework is using monorepo. This repository has elements, supporting mo
 - `packages/core` - Core module of element e.g. base classes, element registration
 - `packages/create-efx` - Initializer for creating a new EFX elements
 - `packages/demo-block` - Use in demo page of each element to demonstrate element's features
-- `packages/elemental-theme` - Base theme to extend to design system theme e.g. Halo Theme
+- `packages/elemental-theme` - Base theme to extend to LSEG Workspace theme e.g. Halo Theme
 - `packages/elements` - All elements in Element Framework
-- `packages/halo-theme` - LSEG Workspace design system theme
+- `packages/halo-theme` - LSEG Workspace theme
 - `packages/i18n` - Wrappers and APIs of formatjs
 - `packages/phrasebook` - All messages (english and non-english) that use within elements
 - `packages/solar-theme` - Legacy theme

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=refinitiv_refinitiv-ui&metric=coverage&branch=v7)](https://sonarcloud.io/summary/new_code?id=refinitiv_refinitiv-ui&branch=v7)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=refinitiv_refinitiv-ui&metric=vulnerabilities&branch=v7)](https://sonarcloud.io/summary/new_code?id=refinitiv_refinitiv-ui&branch=v7)
 
-Element Framework is LSEG Workspace's design system components that provides components and tooling to help product teams work faster and more efficiently.
+Element Framework is LSEG Workspace standardised components that provides components and tooling to help product teams work faster and more efficiently.
 
 # Documentation
 

--- a/documents/src/index.md
+++ b/documents/src/index.md
@@ -19,11 +19,11 @@ o> ![translate version](https://img.shields.io/npm/v/@refinitiv-ui/translate/%np
 o> ![utils version](https://img.shields.io/npm/v/@refinitiv-ui/utils/%npm_dist_tag%?color=%2339c46e&label=utils)
 o>
 
-Element Framework (EF) provides components and tooling, aligned with LSEG Workspace's design system, to help developers build applications faster and more efficiently.
+Element Framework (EF) provides components and tooling, aligned with LSEG Workspace standardised components, to help developers build applications faster and more efficiently.
 
 Components are built using technology native to the browser, allowing them to be lightweight and work with any web framework.
 
-## Design System
+## Standardised Components
 
 Built on a solid foundation, Element Framework is able to adapt to the needs of your design. Components bring in visual, functional and developmental consistency to your products and development practices.
 

--- a/documents/src/pages/accessibility.md
+++ b/documents/src/pages/accessibility.md
@@ -104,7 +104,7 @@ While some Element Framework components may not be fully compatible with screen 
 
 ## Other assistive technologies
 
-Be aware that there are myriad assistive technologies that users may employ to help them access a computing device. For example, Dragon Naturally Speaking for processing voice commands or Dolphin SuperNova and ZoomText for magnification. Touch-screen devices also pose unique challenges. As we advance the accessibility features of the Halo Design System, technologies like these will increasingly be supported.
+Be aware that there are myriad assistive technologies that users may employ to help them access a computing device. For example, Dragon Naturally Speaking for processing voice commands or Dolphin SuperNova and ZoomText for magnification. Touch-screen devices also pose unique challenges. As we advance the accessibility features of LSEG Workspace standardised components, technologies like these will increasingly be supported.
 
 ## Useful resources
 

--- a/documents/src/pages/elements/efx-grid.md
+++ b/documents/src/pages/elements/efx-grid.md
@@ -23,7 +23,7 @@ EFX Grid element and extensions are published under single package.
 npm install @refinitiv-ui/efx-grid
 ```
 
-The element is required theme to instantiate itself in the app. LSEG Workspace's design system is called Halo theme and you can install it from npm command.
+The element is required theme to instantiate itself in the app. LSEG Workspace theme is called Halo theme and you can install it from npm command.
 
 ```bash
 npm install @refinitiv-ui/halo-theme
@@ -35,7 +35,7 @@ See list of APIs, demo and more usage guide by visiting [EFX Grid document](http
 
 ## Usage
 
-Import EFX Grid and its themes into your application. To follow LSEG Workspace design system, it is required styles of some native elements e.g. typography.
+Import EFX Grid and its themes into your application. To follow LSEG Workspace standardised components, it is required styles of some native elements e.g. typography.
 
 ```javascript
 // import element and its Halo dark theme

--- a/documents/src/pages/start/styling.md
+++ b/documents/src/pages/start/styling.md
@@ -7,10 +7,11 @@ layout: default
 
 # Applying Styles
 
-Applications in LSEG Workspace should use the Halo Design System theme to be fully compliant with branding guidelines. EF elements require their themes to be loaded in order to initialise successfully.
+Applications in LSEG Workspace should use the Halo theme to be fully compliant with branding guidelines. EF elements require their themes to be loaded in order to initialise successfully.
 
 ## Halo Theme
-The Halo Design System theme is provided with two variants; light and dark. An application can use only one variant while the app is running. See [Theme Switching](/guides/theme-switching) to learn how to toggle between light and dark themes in your application.
+
+Halo theme provides two variants; light and dark. An application can use only one variant while the app is running. See [Theme Switching](/guides/theme-switching) to learn how to toggle between light and dark themes in your application.
 
 ### Native styles
 

--- a/documents/src/pages/styles/typography.md
+++ b/documents/src/pages/styles/typography.md
@@ -7,7 +7,7 @@ layout: default
 
 # Typography
 
-In accordance with LSEG Workspace's Halo Design System, the default font in your application should be Proxima Nova Fin. The font is a custom font created for Workspace that has been exhaustively researched and tested with users to support a superior reading experience. It will be applied automatically when you import native styles from EF themes.
+In accordance with LSEG Workspace standardised components, the default font in your application should be Proxima Nova Fin. The font is a custom font created for Workspace that has been exhaustively researched and tested with users to support a superior reading experience. It will be applied automatically when you import native styles from EF themes.
 
 For Japanese, Traditional Chinese, and Simplified Chinese, Halo theme has defined a standard font to be used for those languages. However, if the font is not available on users machine, default font that managed by operation system on user's machine will be used.
 

--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -1,6 +1,6 @@
 # Element Framework
 
-Element Framework (EF) is a collection of elements that includes theming capability within the LSEG Workspace's design system. The elements are a set of web components which is a standard web technology and can be utilized across all browsers.
+Element Framework (EF) is a collection of elements that includes theming capability within the LSEG Workspace standardised components. The elements are a set of web components which is a standard web technology and can be utilized across all browsers.
 
 ## Usage
 
@@ -10,13 +10,13 @@ EF elements are published under single package.
 npm install @refinitiv-ui/elements
 ```
 
-The elements are required theme to instantiate itself in the app. LSEG Workspace's design system is called Halo theme and you can install it from npm command.
+The elements require a theme to instantiate itself in the app. LSEG Workspace theme is called Halo theme and you can install it from npm command.
 
 ```sh
 npm install @refinitiv-ui/halo-theme
 ```
 
-Finally, import both elements that you want to use and its themes into your application and it is ready to go. To follow LSEG Workspace's design system, it is required styles of some native elements e.g. typography.
+Finally, import both elements that you want to use and its themes into your application and it is ready to go. To follow LSEG Workspace standardised components, it is required styles of some native elements e.g. typography.
 
 <br>
 


### PR DESCRIPTION
## Description

Remove "design system" term usage eliminating the ambiguity of the new Design System & the current one based on Halo theme.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
