### PR TITLE
fix(tooltip): fix tooltip reopen when mouse leaves

### DIFF
--- a/packages/elements/src/tooltip/__test__/tooltip.test.js
+++ b/packages/elements/src/tooltip/__test__/tooltip.test.js
@@ -258,6 +258,7 @@ describe('tooltip/Tooltip', function () {
     });
 
     await elementUpdated(el);
+    await nextFrame();
 
     expect(tooltip.opened, 'Tooltip is not opened').to.be.true;
 
@@ -268,6 +269,7 @@ describe('tooltip/Tooltip', function () {
     });
 
     await elementUpdated(el);
+    await nextFrame();
 
     expect(tooltip.opened, 'Tooltip is not hidden').to.be.false;
   }).timeout(MouseMoveDelay * 5);

--- a/packages/elements/src/tooltip/index.ts
+++ b/packages/elements/src/tooltip/index.ts
@@ -46,6 +46,10 @@ class Tooltip extends BasicElement {
   private clicked = false;
   private timerTimeout?: number;
   private contentNodes?: Node[];
+  /**
+   * Boolean to check if the timeout is pending
+   */
+  private timeoutPending = false;
 
   protected override readonly defaultRole: string | null = 'tooltip';
 
@@ -220,14 +224,14 @@ class Tooltip extends BasicElement {
   public override connectedCallback(): void {
     super.connectedCallback();
     register(this, {
-      mousemove: this.reset,
+      mousemove: this.reset.bind(null, true),
       mousemoveThrottled: this.onMouseMove,
       click: this.onClick,
       mouseout: this.onMouseOut,
-      mouseleave: this.resetTooltip,
-      wheel: this.resetTooltip,
-      keydown: this.resetTooltip,
-      blur: this.resetTooltip
+      mouseleave: this.resetTooltip.bind(null, false),
+      wheel: this.resetTooltip.bind(null, false),
+      keydown: this.resetTooltip.bind(null, false),
+      blur: this.resetTooltip.bind(null, false)
     });
   }
 
@@ -235,7 +239,7 @@ class Tooltip extends BasicElement {
     deregister(this);
     this.setOpened(false);
 
-    this.reset();
+    this.reset(false);
     this.matchTarget = null;
     this.matchTargetRect = null;
     this.positionTarget = null;
@@ -252,9 +256,11 @@ class Tooltip extends BasicElement {
 
   /**
    * Clear all timers
+   * @param enter Indicates whether the tooltip should be reset due to a mouse leave event
    * @returns {void}
    */
-  private reset = (): void => {
+  private reset = (enter?: boolean): void => {
+    this.timeoutPending = !!enter;
     window.clearTimeout(this.timerTimeout);
   };
 
@@ -380,10 +386,11 @@ class Tooltip extends BasicElement {
 
   /**
    * Hide tooltip
+   * @param leave Indicates whether the tooltip should be reset due to any events
    * @returns {void}
    */
-  private hideTooltip(): void {
-    this.reset();
+  private hideTooltip(leave?: boolean): void {
+    this.reset(leave);
     this.matchTarget = null;
     this.matchTargetRect = null;
     this.positionTarget = null;
@@ -392,10 +399,11 @@ class Tooltip extends BasicElement {
 
   /**
    * Reset tooltip
+   * @param timeoutPending Indicates whether the tooltip should be reset due to any events
    * @returns {void}
    */
-  private resetTooltip = (): void => {
-    this.hideTooltip();
+  private resetTooltip = (timeoutPending?: boolean): void => {
+    this.hideTooltip(timeoutPending);
   };
 
   /**
@@ -418,6 +426,10 @@ class Tooltip extends BasicElement {
   private showTooltip(paths: EventTarget[], x: number, y: number): void {
     // composedPath is only available on the direct event
     this.timerTimeout = window.setTimeout(() => {
+      if (!this.timeoutPending) {
+        this.setOpened(false);
+        return;
+      }
       const lastMatchTarget = this.matchTarget;
       const matchTarget = this.getMatchedElement(paths);
       this.matchTarget = matchTarget;

--- a/packages/elements/src/tooltip/index.ts
+++ b/packages/elements/src/tooltip/index.ts
@@ -47,13 +47,6 @@ class Tooltip extends BasicElement {
   private timerTimeout?: number;
   private contentNodes?: Node[];
 
-  /**
-   * When mouse moves, mousemove and mouseleave run. However, current timout logic causes unsequence.
-   * That take mouseleave may not run at last. The boolean used to ensure closing behavior.
-   * Set to false allows the tooltip to display, while true ensures the tooltip is closed.
-   */
-  private shouldTeardown = true;
-
   protected override readonly defaultRole: string | null = 'tooltip';
 
   /**
@@ -227,14 +220,14 @@ class Tooltip extends BasicElement {
   public override connectedCallback(): void {
     super.connectedCallback();
     register(this, {
-      mousemove: () => this.reset(false),
+      mousemove: this.reset,
       mousemoveThrottled: this.onMouseMove,
       click: this.onClick,
       mouseout: this.onMouseOut,
-      mouseleave: () => this.resetTooltip(),
-      wheel: () => this.resetTooltip(),
-      keydown: () => this.resetTooltip(),
-      blur: () => this.resetTooltip()
+      mouseleave: this.resetTooltip,
+      wheel: this.resetTooltip,
+      keydown: this.resetTooltip,
+      blur: this.resetTooltip
     });
   }
 
@@ -259,11 +252,9 @@ class Tooltip extends BasicElement {
 
   /**
    * Clear all timers
-   * @param shouldTeardown Indicates whether the tooltip should be reset due to a mouse leave event
    * @returns {void}
    */
-  private reset = (shouldTeardown = true): void => {
-    this.shouldTeardown = shouldTeardown;
+  private reset = (): void => {
     window.clearTimeout(this.timerTimeout);
   };
 
@@ -389,16 +380,15 @@ class Tooltip extends BasicElement {
 
   /**
    * Hide tooltip
-   * @param shouldTeardown Indicates whether the tooltip should be reset due to any events
    * @returns {void}
    */
-  private resetTooltip(shouldTeardown = true): void {
-    this.reset(shouldTeardown);
+  private resetTooltip = (): void => {
+    this.reset();
     this.matchTarget = null;
     this.matchTargetRect = null;
     this.positionTarget = null;
     this.setOpened(false);
-  }
+  };
 
   /**
    * Run when mouse is moving over the document
@@ -420,10 +410,6 @@ class Tooltip extends BasicElement {
   private showTooltip(paths: EventTarget[], x: number, y: number): void {
     // composedPath is only available on the direct event
     this.timerTimeout = window.setTimeout(() => {
-      if (this.shouldTeardown) {
-        this.setOpened(false);
-        return;
-      }
       const lastMatchTarget = this.matchTarget;
       const matchTarget = this.getMatchedElement(paths);
       this.matchTarget = matchTarget;

--- a/packages/elements/src/tooltip/index.ts
+++ b/packages/elements/src/tooltip/index.ts
@@ -46,10 +46,13 @@ class Tooltip extends BasicElement {
   private clicked = false;
   private timerTimeout?: number;
   private contentNodes?: Node[];
+
   /**
-   * Boolean to check if the timeout is pending
+   * When mouse moves, mousemove and mouseleave run. However, current timout logic causes unsequence.
+   * That take mouseleave may not run at last. The boolean used to ensure closing behavior.
+   * Set to false allows the tooltip to display, while true ensures the tooltip is closed.
    */
-  private timeoutPending = false;
+  private shouldTeardown = true;
 
   protected override readonly defaultRole: string | null = 'tooltip';
 
@@ -224,14 +227,14 @@ class Tooltip extends BasicElement {
   public override connectedCallback(): void {
     super.connectedCallback();
     register(this, {
-      mousemove: this.reset.bind(null, true),
+      mousemove: () => this.reset(false),
       mousemoveThrottled: this.onMouseMove,
       click: this.onClick,
       mouseout: this.onMouseOut,
-      mouseleave: this.resetTooltip.bind(null, false),
-      wheel: this.resetTooltip.bind(null, false),
-      keydown: this.resetTooltip.bind(null, false),
-      blur: this.resetTooltip.bind(null, false)
+      mouseleave: () => this.resetTooltip(),
+      wheel: () => this.resetTooltip(),
+      keydown: () => this.resetTooltip(),
+      blur: () => this.resetTooltip()
     });
   }
 
@@ -239,7 +242,7 @@ class Tooltip extends BasicElement {
     deregister(this);
     this.setOpened(false);
 
-    this.reset(false);
+    this.reset();
     this.matchTarget = null;
     this.matchTargetRect = null;
     this.positionTarget = null;
@@ -256,11 +259,11 @@ class Tooltip extends BasicElement {
 
   /**
    * Clear all timers
-   * @param enter Indicates whether the tooltip should be reset due to a mouse leave event
+   * @param shouldTeardown Indicates whether the tooltip should be reset due to a mouse leave event
    * @returns {void}
    */
-  private reset = (enter?: boolean): void => {
-    this.timeoutPending = !!enter;
+  private reset = (shouldTeardown = true): void => {
+    this.shouldTeardown = shouldTeardown;
     window.clearTimeout(this.timerTimeout);
   };
 
@@ -386,25 +389,16 @@ class Tooltip extends BasicElement {
 
   /**
    * Hide tooltip
-   * @param leave Indicates whether the tooltip should be reset due to any events
+   * @param shouldTeardown Indicates whether the tooltip should be reset due to any events
    * @returns {void}
    */
-  private hideTooltip(leave?: boolean): void {
-    this.reset(leave);
+  private resetTooltip(shouldTeardown = true): void {
+    this.reset(shouldTeardown);
     this.matchTarget = null;
     this.matchTargetRect = null;
     this.positionTarget = null;
     this.setOpened(false);
   }
-
-  /**
-   * Reset tooltip
-   * @param timeoutPending Indicates whether the tooltip should be reset due to any events
-   * @returns {void}
-   */
-  private resetTooltip = (timeoutPending?: boolean): void => {
-    this.hideTooltip(timeoutPending);
-  };
 
   /**
    * Run when mouse is moving over the document
@@ -426,7 +420,7 @@ class Tooltip extends BasicElement {
   private showTooltip(paths: EventTarget[], x: number, y: number): void {
     // composedPath is only available on the direct event
     this.timerTimeout = window.setTimeout(() => {
-      if (!this.timeoutPending) {
+      if (this.shouldTeardown) {
         this.setOpened(false);
         return;
       }
@@ -511,7 +505,7 @@ class Tooltip extends BasicElement {
    */
   private onClick = (): void => {
     this.clicked = true;
-    this.hideTooltip();
+    this.resetTooltip();
   };
 
   /**

--- a/packages/elements/src/tooltip/managers/tooltip-manager.ts
+++ b/packages/elements/src/tooltip/managers/tooltip-manager.ts
@@ -66,6 +66,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onMouseOut = (event: MouseEvent): void => {
+    this.titleThrottler.task?.cancel();
     this.registry.forEach(({ mouseout }) => mouseout(event));
   };
 
@@ -74,6 +75,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onMouseLeave = (event: MouseEvent): void => {
+    this.titleThrottler.task?.cancel();
     this.registry.forEach(({ mouseleave }) => mouseleave(event));
   };
 
@@ -82,6 +84,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onWheel = (event: WheelEvent): void => {
+    this.titleThrottler.task?.cancel();
     this.registry.forEach(({ wheel }) => wheel(event));
   };
 
@@ -90,6 +93,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onKeyDown = (event: KeyboardEvent): void => {
+    this.titleThrottler.task?.cancel();
     this.registry.forEach(({ keydown }) => keydown(event));
   };
 
@@ -98,6 +102,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onBlur = (event: FocusEvent): void => {
+    this.titleThrottler.task?.cancel();
     this.registry.forEach(({ blur }) => blur(event));
   };
 

--- a/packages/elements/src/tooltip/managers/tooltip-manager.ts
+++ b/packages/elements/src/tooltip/managers/tooltip-manager.ts
@@ -46,7 +46,7 @@ class TooltipManager {
    * Any event listener hiding the tooltip should call this method.
    * @returns {void}
    */
-  private cancleThrottler() {
+  private cancelThrottler() {
     this.titleThrottler.task?.cancel();
   }
 
@@ -69,6 +69,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onClick = (event: MouseEvent): void => {
+    this.cancelThrottler();
     this.registry.forEach(({ click }) => click(event));
   };
 
@@ -77,7 +78,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onMouseOut = (event: MouseEvent): void => {
-    this.cancleThrottler();
+    this.cancelThrottler();
     this.registry.forEach(({ mouseout }) => mouseout(event));
   };
 
@@ -86,7 +87,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onMouseLeave = (event: MouseEvent): void => {
-    this.cancleThrottler();
+    this.cancelThrottler();
     this.registry.forEach(({ mouseleave }) => mouseleave(event));
   };
 
@@ -95,7 +96,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onWheel = (event: WheelEvent): void => {
-    this.cancleThrottler();
+    this.cancelThrottler();
     this.registry.forEach(({ wheel }) => wheel(event));
   };
 
@@ -104,7 +105,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onKeyDown = (event: KeyboardEvent): void => {
-    this.cancleThrottler();
+    this.cancelThrottler();
     this.registry.forEach(({ keydown }) => keydown(event));
   };
 
@@ -113,7 +114,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onBlur = (event: FocusEvent): void => {
-    this.cancleThrottler();
+    this.cancelThrottler();
     this.registry.forEach(({ blur }) => blur(event));
   };
 

--- a/packages/elements/src/tooltip/managers/tooltip-manager.ts
+++ b/packages/elements/src/tooltip/managers/tooltip-manager.ts
@@ -40,6 +40,17 @@ class TooltipManager {
   }
 
   /**
+   * Cancel the pending task of throttled mousemove event listener.
+   * This prevents the task from running out of order compared to the event dispatching sequence
+   * due to its setTimeout usage.
+   * Any event listener hiding the tooltip should call this method.
+   * @returns {void}
+   */
+  private cancleThrottler() {
+    this.titleThrottler.task?.cancel();
+  }
+
+  /**
    * @param event Mouse move event
    * @returns {void}
    */
@@ -66,7 +77,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onMouseOut = (event: MouseEvent): void => {
-    this.titleThrottler.task?.cancel();
+    this.cancleThrottler();
     this.registry.forEach(({ mouseout }) => mouseout(event));
   };
 
@@ -75,7 +86,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onMouseLeave = (event: MouseEvent): void => {
-    this.titleThrottler.task?.cancel();
+    this.cancleThrottler();
     this.registry.forEach(({ mouseleave }) => mouseleave(event));
   };
 
@@ -84,7 +95,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onWheel = (event: WheelEvent): void => {
-    this.titleThrottler.task?.cancel();
+    this.cancleThrottler();
     this.registry.forEach(({ wheel }) => wheel(event));
   };
 
@@ -93,7 +104,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onKeyDown = (event: KeyboardEvent): void => {
-    this.titleThrottler.task?.cancel();
+    this.cancleThrottler();
     this.registry.forEach(({ keydown }) => keydown(event));
   };
 
@@ -102,7 +113,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onBlur = (event: FocusEvent): void => {
-    this.titleThrottler.task?.cancel();
+    this.cancleThrottler();
     this.registry.forEach(({ blur }) => blur(event));
   };
 


### PR DESCRIPTION
## Description

tooltips sometimes reappear when mouse pointer leaves the frame.

Fixes # ([DME-48231](https://jira.refinitiv.com/browse/DME-48231))

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
