### PR TITLE
feat(datetime-picker): introduce preventCloseOnSelect to prevents the Picker from closing on date selection

### DIFF
--- a/packages/elements/src/datetime-picker/__demo__/index.html
+++ b/packages/elements/src/datetime-picker/__demo__/index.html
@@ -155,6 +155,7 @@
             <ef-checkbox id="inputTriggerDisabled">Input Trigger Disabled</ef-checkbox>
             <ef-checkbox id="inputDisabled">Input Disabled</ef-checkbox>
             <ef-checkbox id="popupDisabled">Popup Disabled</ef-checkbox>
+            <ef-checkbox id="preventCloseOnSelect">Prevent Close On Select</ef-checkbox>
           </p>
         </div>
       </div>
@@ -190,7 +191,8 @@
             weekendsOnly: dateTimePicker.weekendsOnly,
             inputTriggerDisabled: dateTimePicker.inputTriggerDisabled,
             inputDisabled: dateTimePicker.inputDisabled,
-            popupDisabled: dateTimePicker.popupDisabled
+            popupDisabled: dateTimePicker.popupDisabled,
+            preventCloseOnSelect: dateTimePicker.preventCloseOnSelect
           };
 
           consoleEl.value = JSON.stringify(data, undefined, 4);
@@ -378,6 +380,12 @@
           .getElementById('popupDisabled')
           .addEventListener('checked-changed', ({ detail: { value } }) => {
             dateTimePicker.popupDisabled = value || undefined;
+          });
+
+        document
+          .getElementById('preventCloseOnSelect')
+          .addEventListener('checked-changed', ({ detail: { value } }) => {
+            dateTimePicker.preventCloseOnSelect = value || undefined;
           });
 
         const eventLog = [];

--- a/packages/elements/src/datetime-picker/__test__/datetime-picker.navigation.test.js
+++ b/packages/elements/src/datetime-picker/__test__/datetime-picker.navigation.test.js
@@ -2,7 +2,7 @@
 import '@refinitiv-ui/elements/datetime-picker';
 
 import '@refinitiv-ui/halo-theme/light/ef-datetime-picker.js';
-import { elementUpdated, expect, fixture, oneEvent } from '@refinitiv-ui/test-helpers';
+import { elementUpdated, expect, fixture, nextFrame, oneEvent } from '@refinitiv-ui/test-helpers';
 
 import { fireKeydownEvent } from './utils.js';
 
@@ -94,6 +94,76 @@ describe('datetime-picker/Navigation', function () {
       el.disabled = true;
       await elementUpdated(el);
       expect(el.opened).to.be.equal(false, 'Setting disabled should close calendar');
+    });
+    it('Should not close calendar when preventCloseOnSelect is true in single mode', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker lang="en-gb" opened prevent-close-on-select></ef-datetime-picker>'
+      );
+      await elementUpdated(el);
+
+      const calendarEl = el.calendarEl;
+      const cell = calendarEl.shadowRoot.querySelector('div[tabindex]'); // Select a date cell
+      cell.click();
+      await elementUpdated(el);
+
+      expect(el.opened).to.be.equal(true, 'Calendar should remain open when preventCloseOnSelect is true');
+    });
+    it('Should not close calendar when preventCloseOnSelect is true in range mode', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker lang="en-gb" opened range duplex prevent-close-on-select></ef-datetime-picker>'
+      );
+      el.views = ['2020-04', '2020-05'];
+      await elementUpdated(el);
+      await nextFrame();
+      await nextFrame();
+
+      const calendarFromEl = el.calendarFromEl;
+      const fromCell = calendarFromEl.shadowRoot.querySelector('div[tabindex]'); // Select a date in the "from" calendar
+      fromCell.click();
+      await elementUpdated(el);
+      await nextFrame();
+
+      const calendarToEl = el.calendarToEl;
+      const toCell = calendarToEl.shadowRoot.querySelector('div[tabindex]'); // Select a date in the "to" calendar
+      toCell.click();
+      await elementUpdated(el);
+      await nextFrame();
+
+      expect(el.opened).to.be.equal(
+        true,
+        'Calendar should remain open when preventCloseOnSelect is true in range mode'
+      );
+    });
+    it('Should not close calendar when preventCloseOnSelect is true with timepicker', async function () {
+      const el = await fixture(
+        '<ef-datetime-picker lang="en-gb" opened timepicker prevent-close-on-select></ef-datetime-picker>'
+      );
+      await elementUpdated(el);
+
+      const calendarEl = el.calendarEl;
+      const cell = calendarEl.shadowRoot.querySelector('div[tabindex]'); // Select a date cell
+      cell.click();
+      await elementUpdated(el);
+
+      const timepickerEl = el.timepickerEl;
+      timepickerEl.value = '12:30'; // Simulate time selection
+      await elementUpdated(el);
+
+      expect(el.opened).to.be.equal(
+        true,
+        'Calendar should remain open when preventCloseOnSelect is true with timepicker'
+      );
+    });
+    it('Should close calendar when preventCloseOnSelect is false', async function () {
+      const el = await fixture('<ef-datetime-picker lang="en-gb" opened></ef-datetime-picker>');
+      await elementUpdated(el);
+
+      const calendarEl = el.calendarEl;
+      const cell = calendarEl.shadowRoot.querySelector('div[tabindex]'); // Select a date cell
+      cell.click();
+      await elementUpdated(el);
+
+      expect(el.opened).to.be.equal(false, 'Calendar should close when preventCloseOnSelect is false');
     });
   });
 });

--- a/packages/elements/src/datetime-picker/index.ts
+++ b/packages/elements/src/datetime-picker/index.ts
@@ -343,6 +343,13 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
   public inputTriggerDisabled = false;
 
   /**
+   * Prevents the Picker from closing on date selection.
+   * Note that if timepicker is true, the picker will remain open regardless of this flag.
+   */
+  @property({ type: Boolean, attribute: 'prevent-close-on-select' })
+  public preventCloseOnSelect = false;
+
+  /**
    * Disable input part of the picker
    */
   @property({ type: Boolean, attribute: 'input-disabled', reflect: true })
@@ -998,6 +1005,9 @@ export class DatetimePicker extends FormFieldElement implements MultiValue {
     // Close popup if there is no time picker
     const newValues = this.values;
     if (!this.timepicker && newValues[0] && (this.range ? newValues[1] : true)) {
+      if (this.preventCloseOnSelect) {
+        return;
+      }
       this.setOpened(false);
 
       /**


### PR DESCRIPTION
Description
A user of the component has requested a feature to control the popup behavior after selecting a date or date range. They are using a custom time picker placed in the footer slot and would like the calendar popup to remain open after selection—similar to the existing behavior when the built-in timepicker property is enabled.

To support this use case, we propose introducing a new property (e.g. prevent-close-on-select) that allows developers to prevent the popup from closing automatically upon selection.

Fixes # (issue)
https://jira.refinitiv.com/browse/DME-50576

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
