### PR TITLE
fix(tooltip): fix tooltip reopen when mouse leaves

### DIFF
--- a/packages/elements/src/tooltip/__test__/tooltip.test.js
+++ b/packages/elements/src/tooltip/__test__/tooltip.test.js
@@ -265,6 +265,7 @@ describe('tooltip/Tooltip', function () {
     });
 
     await elementUpdated(el);
+    await nextFrame();
 
     expect(tooltip.opened, 'Tooltip is not opened').to.be.true;
 
@@ -275,6 +276,7 @@ describe('tooltip/Tooltip', function () {
     });
 
     await elementUpdated(el);
+    await nextFrame();
 
     expect(tooltip.opened, 'Tooltip is not hidden').to.be.false;
   }).timeout(MouseMoveDelay * 2);

--- a/packages/elements/src/tooltip/index.ts
+++ b/packages/elements/src/tooltip/index.ts
@@ -55,6 +55,8 @@ class Tooltip extends BasicElement {
   private timerTimeout?: number;
   private contentNodes?: Node[];
 
+  private shouldTeardown = true;
+
   protected override readonly defaultRole: string | null = 'tooltip';
 
   /**
@@ -228,14 +230,15 @@ class Tooltip extends BasicElement {
   public override connectedCallback(): void {
     super.connectedCallback();
     register(this, {
-      mousemove: this.reset,
+      mousemove: () => this.reset(false),
       mousemoveThrottled: this.onMouseMove,
       click: this.onClick,
       mouseout: this.onMouseOut,
-      mouseleave: this.resetTooltip,
-      wheel: this.resetTooltip,
-      keydown: this.resetTooltip,
-      blur: this.resetTooltip
+      mouseleave: () => this.resetTooltip(),
+      wheel: () => this.resetTooltip(),
+      keydown: () => this.resetTooltip(),
+      blur: () => this.resetTooltip(),
+      mouseoutThrottled: () => this.resetTooltip()
     });
   }
 
@@ -254,15 +257,20 @@ class Tooltip extends BasicElement {
   protected override firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
 
-    this.showDelay = parseInt(this.getComputedVariable('--show-delay', '300'), 10);
-    this.hideDelay = parseInt(this.getComputedVariable('--hide-delay', '150'), 10);
+    // this.showDelay = parseInt(this.getComputedVariable('--show-delay', '300'), 10);
+    // this.hideDelay = parseInt(this.getComputedVariable('--hide-delay', '150'), 10);
+    this.showDelay = 1000;
+    this.hideDelay = 1000;
   }
 
   /**
    * Clear all timers
+   * @param shouldTeardown Indicates whether the tooltip should be reset due to a mouse leave event
    * @returns {void}
    */
-  private reset = (): void => {
+  private reset = (shouldTeardown = true): void => {
+    // private reset = (): void => {
+    this.shouldTeardown = shouldTeardown;
     window.clearTimeout(this.timerTimeout);
   };
 
@@ -388,23 +396,16 @@ class Tooltip extends BasicElement {
 
   /**
    * Hide tooltip
+   * @param shouldTeardown Indicates whether the tooltip should be reset due to any events
    * @returns {void}
    */
-  private hideTooltip(): void {
+  private resetTooltip(): void {
     this.reset();
     this.matchTarget = null;
     this.matchTargetRect = null;
     this.positionTarget = null;
     this.setOpened(false);
   }
-
-  /**
-   * Reset tooltip
-   * @returns {void}
-   */
-  private resetTooltip = (): void => {
-    this.hideTooltip();
-  };
 
   /**
    * Run when mouse is moving over the document
@@ -426,6 +427,10 @@ class Tooltip extends BasicElement {
   private showTooltip(paths: EventTarget[], x: number, y: number): void {
     // composedPath is only available on the direct event
     this.timerTimeout = window.setTimeout(() => {
+      if (this.shouldTeardown) {
+        this.setOpened(false);
+        return;
+      }
       const lastMatchTarget = this.matchTarget;
       const matchTarget = this.getMatchedElement(paths);
       this.matchTarget = matchTarget;
@@ -507,7 +512,7 @@ class Tooltip extends BasicElement {
    */
   private onClick = (): void => {
     this.clicked = true;
-    this.hideTooltip();
+    this.resetTooltip();
   };
 
   /**

--- a/packages/elements/src/tooltip/index.ts
+++ b/packages/elements/src/tooltip/index.ts
@@ -55,8 +55,6 @@ class Tooltip extends BasicElement {
   private timerTimeout?: number;
   private contentNodes?: Node[];
 
-  private shouldTeardown = true;
-
   protected override readonly defaultRole: string | null = 'tooltip';
 
   /**
@@ -230,15 +228,14 @@ class Tooltip extends BasicElement {
   public override connectedCallback(): void {
     super.connectedCallback();
     register(this, {
-      mousemove: () => this.reset(false),
+      mousemove: this.reset,
       mousemoveThrottled: this.onMouseMove,
       click: this.onClick,
       mouseout: this.onMouseOut,
-      mouseleave: () => this.resetTooltip(),
-      wheel: () => this.resetTooltip(),
-      keydown: () => this.resetTooltip(),
-      blur: () => this.resetTooltip(),
-      mouseoutThrottled: () => this.resetTooltip()
+      mouseleave: this.resetTooltip,
+      wheel: this.resetTooltip,
+      keydown: this.resetTooltip,
+      blur: this.resetTooltip
     });
   }
 
@@ -257,20 +254,15 @@ class Tooltip extends BasicElement {
   protected override firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
 
-    // this.showDelay = parseInt(this.getComputedVariable('--show-delay', '300'), 10);
-    // this.hideDelay = parseInt(this.getComputedVariable('--hide-delay', '150'), 10);
-    this.showDelay = 1000;
-    this.hideDelay = 1000;
+    this.showDelay = parseInt(this.getComputedVariable('--show-delay', '300'), 10);
+    this.hideDelay = parseInt(this.getComputedVariable('--hide-delay', '150'), 10);
   }
 
   /**
    * Clear all timers
-   * @param shouldTeardown Indicates whether the tooltip should be reset due to a mouse leave event
    * @returns {void}
    */
-  private reset = (shouldTeardown = true): void => {
-    // private reset = (): void => {
-    this.shouldTeardown = shouldTeardown;
+  private reset = (): void => {
     window.clearTimeout(this.timerTimeout);
   };
 
@@ -396,7 +388,6 @@ class Tooltip extends BasicElement {
 
   /**
    * Hide tooltip
-   * @param shouldTeardown Indicates whether the tooltip should be reset due to any events
    * @returns {void}
    */
   private resetTooltip(): void {
@@ -427,10 +418,6 @@ class Tooltip extends BasicElement {
   private showTooltip(paths: EventTarget[], x: number, y: number): void {
     // composedPath is only available on the direct event
     this.timerTimeout = window.setTimeout(() => {
-      if (this.shouldTeardown) {
-        this.setOpened(false);
-        return;
-      }
       const lastMatchTarget = this.matchTarget;
       const matchTarget = this.getMatchedElement(paths);
       this.matchTarget = matchTarget;

--- a/packages/elements/src/tooltip/index.ts
+++ b/packages/elements/src/tooltip/index.ts
@@ -390,13 +390,13 @@ class Tooltip extends BasicElement {
    * Hide tooltip
    * @returns {void}
    */
-  private resetTooltip(): void {
+  private resetTooltip = (): void => {
     this.reset();
     this.matchTarget = null;
     this.matchTargetRect = null;
     this.positionTarget = null;
     this.setOpened(false);
-  }
+  };
 
   /**
    * Run when mouse is moving over the document

--- a/packages/elements/src/tooltip/managers/tooltip-manager.ts
+++ b/packages/elements/src/tooltip/managers/tooltip-manager.ts
@@ -41,6 +41,17 @@ class TooltipManager {
   }
 
   /**
+   * Cancel the pending task of throttled mousemove event listener.
+   * This prevents the task from running out of order compared to the event dispatching sequence
+   * due to its setTimeout usage.
+   * Any event listener hiding the tooltip should call this method.
+   * @returns {void}
+   */
+  private cancelThrottler() {
+    this.titleThrottler.task?.cancel();
+  }
+
+  /**
    * @param event Mouse move event
    * @returns {void}
    */
@@ -59,6 +70,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onClick = (event: MouseEvent): void => {
+    this.cancelThrottler();
     this.registry.forEach(({ click }) => click(event));
   };
 
@@ -67,6 +79,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onMouseOut = (event: MouseEvent): void => {
+    this.cancelThrottler();
     this.registry.forEach(({ mouseout }) => mouseout(event));
   };
 
@@ -75,6 +88,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onMouseLeave = (event: MouseEvent): void => {
+    this.cancelThrottler();
     this.registry.forEach(({ mouseleave }) => mouseleave(event));
   };
 
@@ -83,6 +97,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onWheel = (event: WheelEvent): void => {
+    this.cancelThrottler();
     this.registry.forEach(({ wheel }) => wheel(event));
   };
 
@@ -91,6 +106,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onKeyDown = (event: KeyboardEvent): void => {
+    this.cancelThrottler();
     this.registry.forEach(({ keydown }) => keydown(event));
   };
 
@@ -99,6 +115,7 @@ class TooltipManager {
    * @returns {void}
    */
   private onBlur = (event: FocusEvent): void => {
+    this.cancelThrottler();
     this.registry.forEach(({ blur }) => blur(event));
   };
 


### PR DESCRIPTION
## Description

tooltips sometimes reappear when mouse pointer leaves the frame.

Fixes # ([DME-48231](https://jira.refinitiv.com/browse/DME-48231))

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
