### PR TITLE
fix(chart): fix ticks color

### DIFF
--- a/packages/elements/src/chart/elements/chart.ts
+++ b/packages/elements/src/chart/elements/chart.ts
@@ -586,6 +586,7 @@ export class Chart extends BasicElement {
    * @returns {void}
    */
   protected createChart(): void {
+    this.setGlobalConfig();
     const canvas = this.canvas.value;
     if (canvas && this.config) {
       this.destroyChart();


### PR DESCRIPTION
## Description

When ef-chart's rendered more than one, most of second and other charts display the wrong the ticks color (label at axis).

Fixes # (issue)

