### PR TITLE
fix(overlay): fix to support filtor-dialog of efx-grid

### DIFF
--- a/packages/elements/src/overlay/managers/close-manager.ts
+++ b/packages/elements/src/overlay/managers/close-manager.ts
@@ -10,6 +10,15 @@ type OverlayClose = {
 };
 
 /**
+ * Check if an element is filter-dialog of efx-grid.
+ * @param elements Event target
+ * @returns {boolean} true if the element is filter-dialog
+ */
+const isFilterDialog = (elements: EventTarget) => {
+  return elements instanceof HTMLElement && elements.tagName === 'FILTER-DIALOG';
+};
+
+/**
  * Close manager ensures that the correct (or the most top) overlay
  * is closed on ESC and click events
  * @returns {void}
@@ -82,12 +91,14 @@ export class CloseManager {
     const path = event.composedPath();
     const focusBoundary = overlay.focusBoundary || overlay;
     const isOutsideClick = !path.includes(focusBoundary);
+    const isInPopup = path.find(isFilterDialog); // Ignore clicks inside filter-dialog of efx-grid
+    const shouldClose = isOutsideClick && !isInPopup;
 
-    if (isOutsideClick && !overlay.noInteractionLock) {
+    if (shouldClose && !overlay.noInteractionLock) {
       event.preventDefault();
     }
 
-    if (isOutsideClick && !overlay.noCancelOnOutsideClick) {
+    if (shouldClose && !overlay.noCancelOnOutsideClick) {
       closeCallback();
     }
   };


### PR DESCRIPTION
## Description

Can't click at EFX grid filter dialog when grid is in EF dialog

To reproduce and solution: You can try at test/overlay-filter-dialog branch.

1. Set zIndex property to override zIndex default behaviour of ef-overlay.
2. Set CSS zindex=0 to ef-dialog to prevent auto zindex calculation.
3. Set CSS zindex=0 or above and set pointer-event=auto to filter-dialog.

Fixes # ([issue](https://jira.refinitiv.com/browse/DME-53331))

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
