### PR TITLE
fix(flag, icon): resolve empty value returned by getComputedStyle on Chromium 151+

### DIFF
--- a/.github/prompts/local-code-review.prompt.md
+++ b/.github/prompts/local-code-review.prompt.md
@@ -1,0 +1,35 @@
+---
+agent: agent
+description: 'Self-review current vs v7 branch - identify KISS violations, code issues, and PR feedback items'
+---
+
+# Self-Review: Current vs v7 Branch
+
+Please perform a comprehensive self-review of the current compared to v7 branch:
+
+## Analysis Focus Areas:
+
+1. **KISS Principle Violations** - Identify overly complex solutions that could be simplified
+2. **Code Quality Issues** - Spot potential bugs, security issues, performance problems
+3. **Best Practice Deviations** - Find patterns that don't follow project conventions
+4. **Architecture Concerns** - Identify design decisions that may cause future maintenance issues
+5. **Testing Gaps** - Areas that lack proper test coverage
+6. **Documentation Issues** - Missing or unclear documentation
+
+## Review Process:
+
+1. Compare all changed files between current and v7 branch
+2. Analyze the diff for each file focusing on the areas above
+3. Look for patterns across multiple files that suggest systemic issues
+4. Prioritize feedback by impact: Critical > Major > Minor > Nit
+
+## Output Format:
+
+Provide structured feedback with:
+
+- **File:Line** references for specific issues
+- **Category** (KISS/Quality/Practice/Architecture/Testing/Docs)
+- **Impact Level** (Critical/Major/Minor/Nit)
+- **Issue Description** with clear explanation
+- **Suggested Fix** with concrete improvement
+- **Colorful Output** for readability and emphasis

--- a/packages/elements/src/flag/__test__/flag.cdn-prefix.test.js
+++ b/packages/elements/src/flag/__test__/flag.cdn-prefix.test.js
@@ -49,6 +49,6 @@ describe('flag/cdn-prefix', function () {
     const svg = el.shadowRoot.querySelector('svg');
 
     expect(svg).to.not.equal(null, 'SVG element should exist when falling back to the default prefix');
-    expect(isEqualSvg(svg.outerHTML, gbSvg)).to.equal(true, 'Should render SVG, from the server response');
+    expect(isEqualSvg(svg.outerHTML, gbSvg)).to.equal(true, 'Should render SVG, from the mock response');
   });
 });

--- a/packages/elements/src/flag/__test__/flag.cdn-prefix.test.js
+++ b/packages/elements/src/flag/__test__/flag.cdn-prefix.test.js
@@ -1,0 +1,54 @@
+import sinon from 'sinon';
+
+// import element and theme
+import '@refinitiv-ui/elements/flag';
+
+import '@refinitiv-ui/halo-theme/light/ef-flag.js';
+import { expect, fixture } from '@refinitiv-ui/test-helpers';
+
+import {
+  checkRequestedUrl,
+  createFakeResponse,
+  flagName,
+  gbSvg,
+  generateUniqueName,
+  isEqualSvg,
+  responseConfigSuccess
+} from './helpers/helpers.js';
+
+// Must match DefaultStyle.CDN_PREFIX in src/flag/const.ts
+const DEFAULT_CDN_PREFIX = 'https://cdn.refinitiv.net/public/libs/elf/assets/elf-theme-halo/resources/flags/';
+
+// CDN prefix is resolved once per page by the FlagLoader singleton, so this case needs its own test file
+describe('flag/cdn-prefix', function () {
+  let fetch;
+  beforeEach(function () {
+    fetch = sinon.stub(window, 'fetch');
+  });
+  afterEach(function () {
+    window.fetch.restore(); // remove stub
+  });
+
+  it('Should fall back to the hardcoded CDN prefix when --cdn-prefix resolves to an empty value', async function () {
+    createFakeResponse(gbSvg, responseConfigSuccess);
+    const uniqueFlagName = generateUniqueName(flagName); // to avoid caching
+    // `initial` makes the custom property guaranteed-invalid, so getComputedStyle returns an empty value
+    const el = await fixture(`<ef-flag style="--cdn-prefix: initial" flag="${uniqueFlagName}"></ef-flag>`);
+    const expectedSrc = `${DEFAULT_CDN_PREFIX}${uniqueFlagName}.svg`;
+
+    expect(el.getComputedVariable('--cdn-prefix')).to.equal(
+      '',
+      'CSS variable should resolve to an empty value'
+    );
+    expect(fetch.callCount).to.equal(1, 'Should make one request');
+    expect(checkRequestedUrl(fetch.args, expectedSrc)).to.equal(
+      true,
+      `Requested URL should use the fallback prefix: ${expectedSrc}`
+    );
+
+    const svg = el.shadowRoot.querySelector('svg');
+
+    expect(svg).to.not.equal(null, 'SVG element should exist when falling back to the default prefix');
+    expect(isEqualSvg(svg.outerHTML, gbSvg)).to.equal(true, 'Should render SVG, from the server response');
+  });
+});

--- a/packages/elements/src/flag/const.ts
+++ b/packages/elements/src/flag/const.ts
@@ -1,0 +1,4 @@
+// Default to Halo theme as Elemental and Solar theme are deprecated.
+export enum DefaultStyle {
+  CDN_PREFIX = 'https://cdn.refinitiv.net/public/libs/elf/assets/elf-theme-halo/resources/flags/'
+}

--- a/packages/elements/src/flag/index.ts
+++ b/packages/elements/src/flag/index.ts
@@ -158,6 +158,7 @@ export class Flag extends BasicElement {
   private setPrefix(): void {
     if (FlagLoader.isPrefixPending) {
       const CDNPrefix = this.getComputedVariable('--cdn-prefix', DefaultStyle.CDN_PREFIX);
+
       FlagLoader.setCdnPrefix(CDNPrefix);
     }
   }

--- a/packages/elements/src/flag/index.ts
+++ b/packages/elements/src/flag/index.ts
@@ -159,8 +159,7 @@ export class Flag extends BasicElement {
    */
   private setPrefix(): void {
     if (FlagLoader.isPrefixPending) {
-      const CDNPrefix = this.getComputedVariable('--cdn-prefix').replace(/^('|")|('|")$/g, '');
-
+      const CDNPrefix = this.getComputedVariable('--cdn-prefix');
       FlagLoader.setCdnPrefix(CDNPrefix);
     }
   }

--- a/packages/elements/src/flag/index.ts
+++ b/packages/elements/src/flag/index.ts
@@ -104,7 +104,10 @@ export class Flag extends BasicElement {
    */
   protected override firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
-    this.setPrefix();
+    // Chromium only issue: starting from version 151,
+    // In some situations, getComputedStyle() needs a little more time before the value could be retrieved correctly.
+    // Otherwise, it would return empty string. requestAnimationFrame() is used here to provide the time needed.
+    requestAnimationFrame(() => this.setPrefix());
   }
 
   protected override async getUpdateComplete(): Promise<boolean> {

--- a/packages/elements/src/flag/index.ts
+++ b/packages/elements/src/flag/index.ts
@@ -105,7 +105,17 @@ export class Flag extends BasicElement {
    */
   protected override firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
-    this.setPrefix();
+    // Chromium only issue: starting from version 151,
+    // when Flag is slotted into an unregistered custom element,
+    // getComputedStyle() will always return empty string as a style value.
+    // It needs to wait for the registration of the parent custom element first.
+    // In practice, this happens when Flag class and its style are imported before the parent's ones as following:
+    // import '@refinitiv-ui/elements/flag';
+    // import '@refinitiv-ui/elements/panel';
+
+    // import '@refinitiv-ui/elements/flag/themes/halo/dark';
+    // import '@refinitiv-ui/elements/panel/themes/halo/dark';
+    setTimeout(() => this.setPrefix());
   }
 
   protected override async getUpdateComplete(): Promise<boolean> {

--- a/packages/elements/src/flag/index.ts
+++ b/packages/elements/src/flag/index.ts
@@ -6,6 +6,7 @@ import { unsafeHTML } from '@refinitiv-ui/core/directives/unsafe-html.js';
 import { Deferred } from '@refinitiv-ui/utils/loader.js';
 
 import { VERSION } from '../version.js';
+import { DefaultStyle } from './const.js';
 import { FlagLoader } from './utils/FlagLoader.js';
 
 export { preload } from './utils/FlagLoader.js';
@@ -104,10 +105,7 @@ export class Flag extends BasicElement {
    */
   protected override firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
-    // Chromium only issue: starting from version 151,
-    // In some situations, getComputedStyle() needs a little more time before the value could be retrieved correctly.
-    // Otherwise, it would return empty string. requestAnimationFrame() is used here to provide the time needed.
-    requestAnimationFrame(() => this.setPrefix());
+    this.setPrefix();
   }
 
   protected override async getUpdateComplete(): Promise<boolean> {
@@ -159,7 +157,7 @@ export class Flag extends BasicElement {
    */
   private setPrefix(): void {
     if (FlagLoader.isPrefixPending) {
-      const CDNPrefix = this.getComputedVariable('--cdn-prefix');
+      const CDNPrefix = this.getComputedVariable('--cdn-prefix', DefaultStyle.CDN_PREFIX);
       FlagLoader.setCdnPrefix(CDNPrefix);
     }
   }

--- a/packages/elements/src/icon/__test__/icon.cdn-prefix-fallback.test.js
+++ b/packages/elements/src/icon/__test__/icon.cdn-prefix-fallback.test.js
@@ -1,0 +1,62 @@
+import sinon from 'sinon';
+
+// import element and theme
+import '@refinitiv-ui/elements/configuration';
+import '@refinitiv-ui/elements/icon';
+
+import '@refinitiv-ui/halo-theme/light/ef-icon.js';
+import { expect, fixture } from '@refinitiv-ui/test-helpers';
+
+import {
+  checkRequestedUrl,
+  createFakeResponse,
+  iconName,
+  isEqualSvg,
+  responseConfigSuccess,
+  tickSvgSprite
+} from './helpers/helpers.js';
+
+// Must match DefaultStyle.CDN_SPRITE_PREFIX in src/icon/const.ts
+const DEFAULT_CDN_SPRITE_PREFIX =
+  'https://cdn.refinitiv.net/public/libs/elf/assets/elf-theme-halo/resources/sprites/icons.svg';
+
+// CDN prefixes are resolved once per page by the loader singletons, so this case needs its own test file
+describe('icon/cdn-prefix-fallback', function () {
+  let fetch;
+  beforeEach(function () {
+    fetch = sinon.stub(window, 'fetch');
+  });
+  afterEach(function () {
+    window.fetch.restore(); // remove stub
+  });
+
+  it('Should fall back to the sprite when CDN prefixes resolve to empty values', async function () {
+    createFakeResponse(tickSvgSprite, responseConfigSuccess);
+    // `initial` makes the custom properties guaranteed-invalid, so getComputedStyle returns empty values
+    const el = await fixture(
+      `<ef-icon style="--cdn-prefix: initial; --cdn-sprite-prefix: initial" icon="${iconName}"></ef-icon>`
+    );
+
+    expect(el.getComputedVariable('--cdn-prefix')).to.equal(
+      '',
+      'CSS variable should resolve to an empty value'
+    );
+    expect(el.getComputedVariable('--cdn-sprite-prefix')).to.equal(
+      '',
+      'CSS variable should resolve to an empty value'
+    );
+    expect(fetch.callCount).to.equal(1, 'Should make one request');
+    expect(checkRequestedUrl(fetch.args, DEFAULT_CDN_SPRITE_PREFIX)).to.equal(
+      true,
+      `Requested URL should use the fallback sprite prefix: ${DEFAULT_CDN_SPRITE_PREFIX}`
+    );
+
+    const svg = el.shadowRoot.querySelector('svg');
+
+    expect(svg).to.not.equal(null, 'SVG element should exist when falling back to the sprite');
+    expect(isEqualSvg(svg.outerHTML, tickSvgSprite)).to.equal(
+      true,
+      'Should render SVG, from the mock response'
+    );
+  });
+});

--- a/packages/elements/src/icon/const.ts
+++ b/packages/elements/src/icon/const.ts
@@ -1,0 +1,5 @@
+// Default to Halo theme as Elemental and Solar theme are deprecated.
+export enum DefaultStyle {
+  CDN_PREFIX = '',
+  CDN_SPRITE_PREFIX = 'https://cdn.refinitiv.net/public/libs/elf/assets/elf-theme-halo/resources/sprites/icons.svg'
+}

--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -88,7 +88,10 @@ export class Icon extends BasicElement {
     if (oldValue !== value) {
       this.deferIconReady();
       this._icon = value;
-      requestAnimationFrame(() => this.updateRenderer());
+      // Wait for setPrefix() settling both sprite & icon CDN prefix value before updating the renderer
+      void Promise.allSettled([SpriteLoader.getCdnPrefix(), IconLoader.getCdnPrefix()]).then(() => {
+        this.updateRenderer();
+      });
       this.requestUpdate('icon', oldValue);
     }
   }
@@ -140,9 +143,9 @@ export class Icon extends BasicElement {
   protected override firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
     // Chromium only issue: starting from version 151,
-    // In some situations, getComputedStyle() needs a little more time before the value could be retrieved correctly.
-    // Otherwise, it would return empty string. requestAnimationFrame() is used here to provide the time needed.
-    requestAnimationFrame(() => this.setPrefix());
+    // in some situations, getComputedStyle() needs a little more time before the value could be retrieved correctly.
+    // Otherwise, it would return empty string. setTimeout is used here to provide the time needed.
+    setTimeout(() => this.setPrefix());
   }
 
   protected override async getUpdateComplete(): Promise<boolean> {

--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -138,7 +138,10 @@ export class Icon extends BasicElement {
    */
   protected override firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
-    this.setPrefix();
+    // Chromium only issue: starting from version 151,
+    // In some situations, getComputedStyle() needs a little more time before the value could be retrieved correctly.
+    // Otherwise, it would return empty string. requestAnimationFrame() is used here to provide the time needed.
+    requestAnimationFrame(() => this.setPrefix());
   }
 
   protected override async getUpdateComplete(): Promise<boolean> {

--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -143,9 +143,15 @@ export class Icon extends BasicElement {
   protected override firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
     // Chromium only issue: starting from version 151,
-    // when Icon is used by Angular and Presumably other SPA frameworks including Vue and React,
-    // getComputedStyle() needs a little more time before the value could be retrieved correctly.
-    // Otherwise, it would return empty string. setTimeout is used here to provide the time needed.
+    // when Icon is slotted into an unregistered custom element,
+    // getComputedStyle() will always return empty string as a style value.
+    // It needs to wait for the registration of the parent custom element first.
+    // In practice, this happens when Icon class and its style are imported before the parent's ones as following:
+    // import '@refinitiv-ui/elements/icon';
+    // import '@refinitiv-ui/elements/panel';
+
+    // import '@refinitiv-ui/elements/icon/themes/halo/dark';
+    // import '@refinitiv-ui/elements/panel/themes/halo/dark';
     setTimeout(() => this.setPrefix());
   }
 

--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -19,6 +19,7 @@ import { Deferred, isBase64svg, isUrl } from '@refinitiv-ui/utils/loader.js';
 import { efConfig } from '../configuration/index.js';
 import type { Config } from '../configuration/index.js';
 import { VERSION } from '../version.js';
+import { DefaultStyle } from './const.js';
 import { IconLoader } from './utils/IconLoader.js';
 import { SpriteLoader } from './utils/SpriteLoader.js';
 
@@ -240,12 +241,12 @@ export class Icon extends BasicElement {
   private setPrefix(): void {
     // This prefix for individual icons allows supporting custom prefix of self-managed icons.
     if (IconLoader.isPrefixPending) {
-      const CDNPrefix = this.getComputedVariable('--cdn-prefix');
+      const CDNPrefix = this.getComputedVariable('--cdn-prefix', DefaultStyle.CDN_PREFIX);
       IconLoader.setCdnPrefix(CDNPrefix);
     }
 
     if (SpriteLoader.isPrefixPending) {
-      const CDNSpritePrefix = this.getComputedVariable('--cdn-sprite-prefix');
+      const CDNSpritePrefix = this.getComputedVariable('--cdn-sprite-prefix', DefaultStyle.CDN_SPRITE_PREFIX);
       SpriteLoader.setCdnPrefix(CDNSpritePrefix);
     }
   }

--- a/packages/elements/src/icon/index.ts
+++ b/packages/elements/src/icon/index.ts
@@ -88,8 +88,8 @@ export class Icon extends BasicElement {
     if (oldValue !== value) {
       this.deferIconReady();
       this._icon = value;
-      // Wait for setPrefix() settling both sprite & icon CDN prefix value before updating the renderer
-      void Promise.allSettled([SpriteLoader.getCdnPrefix(), IconLoader.getCdnPrefix()]).then(() => {
+      // Wait for setPrefix() resolving both sprite & icon CDN prefix value before updating the renderer
+      void Promise.all([SpriteLoader.getCdnPrefix(), IconLoader.getCdnPrefix()]).then(() => {
         this.updateRenderer();
       });
       this.requestUpdate('icon', oldValue);
@@ -143,7 +143,8 @@ export class Icon extends BasicElement {
   protected override firstUpdated(changedProperties: PropertyValues): void {
     super.firstUpdated(changedProperties);
     // Chromium only issue: starting from version 151,
-    // in some situations, getComputedStyle() needs a little more time before the value could be retrieved correctly.
+    // when Icon is used by Angular and Presumably other SPA frameworks including Vue and React,
+    // getComputedStyle() needs a little more time before the value could be retrieved correctly.
     // Otherwise, it would return empty string. setTimeout is used here to provide the time needed.
     setTimeout(() => this.setPrefix());
   }


### PR DESCRIPTION
## Description

Chromium only issue: starting from version 151, when Icon is slotted into an unregistered custom element, `getComputedStyle()` will always return empty string as a style value. It needs to wait for the registration of the parent custom element first. In practice, this happens when Icon class and its style are imported before the parent's ones as following:

```javascript
import '@refinitiv-ui/elements/icon';
import '@refinitiv-ui/elements/panel';

import '@refinitiv-ui/elements/icon/themes/halo/dark';
import '@refinitiv-ui/elements/panel/themes/halo/dark'; 
```

Additionally, this PR includes the following change:

* [Icon, Flag] Introduce fallback CDN prefix value
* [Flag] Delete duplicate quote removal from CSS custom property retrieval
* Add predefined prompt: `local-code-review.prompt.md`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
